### PR TITLE
Added GorillaReport.json that includes all items processed

### DIFF
--- a/cmd/gorilla/main.go
+++ b/cmd/gorilla/main.go
@@ -6,12 +6,16 @@ import (
 	"github.com/1dustindavis/gorilla/pkg/gorillalog"
 	"github.com/1dustindavis/gorilla/pkg/manifest"
 	"github.com/1dustindavis/gorilla/pkg/process"
+	"github.com/1dustindavis/gorilla/pkg/report"
 )
 
 func main() {
 
 	// Create a new logger object
 	gorillalog.NewLog()
+
+	// Start creating GorillaReport
+	report.Start()
 
 	// Get our configuration
 	config.Get()
@@ -39,6 +43,9 @@ func main() {
 	// Prepare and update
 	gorillalog.Info("Processing managed updates...")
 	process.Updates(updates, catalog)
+
+	// Save GorillaReport to disk
+	report.End()
 
 	gorillalog.Info("Done!")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/1dustindavis/gorilla/pkg/report"
 	"gopkg.in/yaml.v2"
 )
 
@@ -91,12 +92,17 @@ func Get() {
 		configuration.Verbose = true
 	}
 
+	// Set global variables
 	URL = configuration.URL
 	Manifest = configuration.Manifest
 	Catalog = configuration.Catalog
 	CachePath = configuration.CachePath
 	Verbose = configuration.Verbose
 	Debug = configuration.Debug
+
+	// Add to GorillaReport
+	report.Items["Manifest"] = Manifest
+	report.Items["Catalog"] = Catalog
 
 	return
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/1dustindavis/gorilla/pkg/config"
 	"github.com/1dustindavis/gorilla/pkg/download"
 	"github.com/1dustindavis/gorilla/pkg/gorillalog"
+	"github.com/1dustindavis/gorilla/pkg/report"
 	"github.com/1dustindavis/gorilla/pkg/status"
 )
 
@@ -127,6 +128,10 @@ func Install(item catalog.Item) {
 		return
 	}
 
+	// Add the item to InstalledItems in GorillaReport
+	report.InstalledItems = append(report.InstalledItems, item)
+
+	// Run the command and arguments
 	runCommand(installCmd, installArgs)
 
 	return
@@ -203,6 +208,10 @@ func Uninstall(item catalog.Item) {
 		return
 	}
 
+	// Add the item to UninstalledItems in GorillaReport
+	report.UninstalledItems = append(report.UninstalledItems, item)
+
+	// Run the command and arguments
 	runCommand(uninstallCmd, uninstallArgs)
 
 	return
@@ -287,6 +296,10 @@ func Update(item catalog.Item) {
 		return
 	}
 
+	// Add the item to UpdatedItems in GorillaReport
+	report.UpdatedItems = append(report.UpdatedItems, item)
+
+	// Run the command and arguments
 	runCommand(installCmd, installArgs)
 
 	return


### PR DESCRIPTION
In addition to all items processed (installed, uninstalled, or updated), this also logs start time, current user, hostname, and end time to `%ProgramData%/gorilla/GorillaReport.json`.

Resolves #20