### PR TITLE
Before comparing the hash, covert it to lowercase

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -137,7 +137,7 @@ func Verify(file string, sha string) bool {
 		return false
 	}
 	shaHash := hex.EncodeToString(h.Sum(nil))
-	if shaHash != sha {
+	if shaHash != strings.ToLower(sha) {
 		gorillalog.Warn("Downloaded file hash does not match catalog hash")
 		return false
 	}


### PR DESCRIPTION
This resolves #35 by converting the admin provided hash to lowercase before comparing it to the computed file hash.