### PR TITLE
Adding recover to func getUninstallKeys

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -40,8 +41,14 @@ func stringInSlice(a string, list []string) bool {
 	return false
 }
 
-func getUninstallKeys() map[string]Application {
+func recoverRegKey() {
+	if r := recover(); r != nil {
+		fmt.Println("Recovered from ", r)
+	}
+}
 
+func getUninstallKeys() map[string]Application {
+	defer recoverRegKey()
 	// Get the Uninstall key from HKLM
 	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `Software\Microsoft\Windows\CurrentVersion\Uninstall`, registry.READ)
 	if err != nil {


### PR DESCRIPTION
Should still output error to gorilla.log, but continue (ignoring the fact that some programs do not have uninstall keys in the registry).