### PR TITLE
Catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The configuration file is in yaml format and defaults to `%ProgramData%/gorilla/
 ---
 url: https://YourWebServer/gorilla/
 manifest: example
-catalog: production
+catalogs: 
+  - alpha
+  - beta
 cachepath: C:/gorilla/cache
 auth_user: GorillaRepoUser
 auth_pass: pizzaisyummy
@@ -42,9 +44,9 @@ tls_server_cert: c:/certs/server.pem
 ### Required Keys
 * `url` is the path on your server that contains the directories for manifests, catalogs, and packages.
 * `manifest` is the primary manifest that is assigned to this machine.
-* `catalog` is the catalog that is assigned to this machine.
 
 ### Optional Keys
+* `catalogs` is an array of catalogs that are assigned to this machine. If you do not provide a catalog in the config, you must have one in a manifest.
 * `app_data_path` is Gorilla's working directory, and may store copies of manifests, catalogs, or packages. If `app_data_path` is not provided, it will default to `%ProgramData%/gorilla/`.
 * `url_packages` is an optional base url to be used instead of `url` when downloading packages.
 
@@ -59,7 +61,7 @@ TLS Auth
 * `tls_server_cert` is the absolute path to your server's CA cert in PEM format.
 
 ## Manifests
-A manifest can include managed_installs, managed_uninstalls, managed_updates, or additional manifests. Manifests are in yaml format and must include the name of the manifest:
+A manifest can include managed_installs, managed_uninstalls, managed_updates, or additional manifests. Catalogs can also be assigned via manifests. Manifests are in yaml format and must include the name of the manifest:
 
 ```yaml
 ---
@@ -74,6 +76,8 @@ managed_updates:
 included_manifests:
   - printers
   - internal
+catalogs:
+  - production
 ```
 ## Catalogs
 A catalog contains details on all available packages. Catalogs are in yaml format with each package reperesented by the package name with a nested object containing the package details:

--- a/cmd/gorilla/main.go
+++ b/cmd/gorilla/main.go
@@ -20,13 +20,13 @@ func main() {
 	// Start creating GorillaReport
 	report.Start()
 
-	// Get the catalog
-	gorillalog.Info("Retrieving catalog:", config.Current.Catalog)
-	catalog := catalog.Get()
-
 	// Get the manifests
 	gorillalog.Info("Retrieving manifest:", config.Current.Manifest)
 	manifests := manifest.Get()
+
+	// Get the catalog
+	gorillalog.Info("Retrieving catalog:", config.Current.Catalogs)
+	catalog := catalog.Get()
 
 	// Process the manifests into install type groups
 	gorillalog.Info("Processing manifest...")

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -41,12 +41,12 @@ If ($upToDate) {
 	}
 
 	config.Current.URL = "http://example.com/"
-	config.Current.Catalog = "test_catalog"
+	config.Current.Catalogs = []string{"test_catalog"}
 	config.CachePath = "testdata/"
 	downloadFile = fakeDownload
 	testCatalog := Get()
 
-	mapsMatch := reflect.DeepEqual(expected, testCatalog)
+	mapsMatch := reflect.DeepEqual(expected, testCatalog[1])
 
 	if !mapsMatch {
 		t.Errorf("\n\nExpected:\n\n%#v\n\nReceived:\n\n %#v", expected, testCatalog)

--- a/pkg/catalog/testdata/example_config.yaml
+++ b/pkg/catalog/testdata/example_config.yaml
@@ -1,7 +1,8 @@
 ---
 url: https://example.com/gorilla/
 manifest: example_manifest
-catalog: example_catalog
+catalogs:
+  - example_catalog
 app_data_path: c:/cpe/gorilla/
 # auth_user: johnny
 # auth_pass: pizza

--- a/pkg/catalog/testdata/example_manifest.yaml
+++ b/pkg/catalog/testdata/example_manifest.yaml
@@ -1,5 +1,7 @@
 ---
 name: example_manifest
+catalogs:
+  - test_catalog2
 managed_installs:
   - Chocolatey
   - GoogleChrome

--- a/pkg/catalog/testdata/test_catalog2.yaml
+++ b/pkg/catalog/testdata/test_catalog2.yaml
@@ -1,0 +1,24 @@
+---
+
+ChefClient2:
+  dependencies:
+    - ruby
+  display_name: Chef Client 2
+  install_check_path: C:\opscode\chef\bin\chef-client2.bat
+  install_check_script: |
+    $latest = "2.3.37"
+    $current = C:\opscode\chef\bin\chef-client2.bat --version
+    $current = $current.Split(" ")[1]
+    $upToDate = [System.Version]$current -ge [System.Version]$latest
+    If ($upToDate) {
+      exit 1
+    } Else {
+      exit 0
+    }
+  installer_item_location: packages/chef-client/chef-client-2.3.37-1-x64.exe
+  installer_item_hash: 25ef8c31898592824751ec2252fe317c0f667db25ac40452710c8ccf35a1b28d
+  installer_item_arguments: 
+     - /L=2033
+     - /S
+  version: 2.0.3440.106
+  uninstaller_type: exe

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,19 +20,19 @@ var (
 
 // Object to store our configuration
 type Object struct {
-	URL           string `yaml:"url"`
-	URLPackages   string `yaml:"url_packages"`
-	Manifest      string `yaml:"manifest"`
-	Catalog       string `yaml:"catalog"`
-	AppDataPath   string `yaml:"app_data_path"`
-	Verbose       bool   `yaml:"verbose,omitempty"`
-	Debug         bool   `yaml:"debug,omitempty"`
-	AuthUser      string `yaml:"auth_user,omitempty"`
-	AuthPass      string `yaml:"auth_pass,omitempty"`
-	TLSAuth       bool   `yaml:"tls_auth,omitempty"`
-	TLSClientCert string `yaml:"tls_client_cert,omitempty"`
-	TLSClientKey  string `yaml:"tls_client_key,omitempty"`
-	TLSServerCert string `yaml:"tls_server_cert,omitempty"`
+	URL           string   `yaml:"url"`
+	URLPackages   string   `yaml:"url_packages"`
+	Manifest      string   `yaml:"manifest"`
+	Catalogs      []string `yaml:"catalogs"`
+	AppDataPath   string   `yaml:"app_data_path"`
+	Verbose       bool     `yaml:"verbose,omitempty"`
+	Debug         bool     `yaml:"debug,omitempty"`
+	AuthUser      string   `yaml:"auth_user,omitempty"`
+	AuthPass      string   `yaml:"auth_pass,omitempty"`
+	TLSAuth       bool     `yaml:"tls_auth,omitempty"`
+	TLSClientCert string   `yaml:"tls_client_cert,omitempty"`
+	TLSClientKey  string   `yaml:"tls_client_key,omitempty"`
+	TLSServerCert string   `yaml:"tls_server_cert,omitempty"`
 }
 
 // Define flag defaults
@@ -161,7 +161,7 @@ func Get() {
 
 	// Add to GorillaReport
 	report.Items["Manifest"] = Current.Manifest
-	report.Items["Catalog"] = Current.Catalog
+	report.Items["Catalog"] = Current.Catalogs
 
 	return
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -12,7 +12,7 @@ func TestGet(t *testing.T) {
 	expected := Object{
 		URL:         "https://example.com/gorilla/",
 		Manifest:    "example_manifest",
-		Catalog:     "example_catalog",
+		Catalogs:    []string{"example_catalog"},
 		AppDataPath: "c:/cpe/gorilla/",
 		Verbose:     true,
 		Debug:       true,

--- a/pkg/config/testdata/test_config.yaml
+++ b/pkg/config/testdata/test_config.yaml
@@ -1,7 +1,8 @@
 ---
 url: https://example.com/gorilla/
 manifest: example_manifest
-catalog: example_catalog
+catalogs:
+  - example_catalog
 app_data_path: c:/cpe/gorilla/
 auth_user: johnny
 auth_pass: pizza

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -17,10 +17,11 @@ type Item struct {
 	Installs   []string `yaml:"managed_installs"`
 	Uninstalls []string `yaml:"managed_uninstalls"`
 	Updates    []string `yaml:"managed_updates"`
+	Catalogs   []string `yaml:"catalogs"`
 }
 
 func getManifest(manifestName string) Item {
-	// Get the yaml file and look for included_manifests
+	// Unmarshal the yaml file
 	yamlPath := filepath.Join(config.CachePath, manifestName) + ".yaml"
 	yamlFile, err := ioutil.ReadFile(yamlPath)
 	var manifest Item
@@ -42,7 +43,7 @@ func Get() []Item {
 	// This is so we can track them before we get the data
 	var manifestsList []string
 
-	// Setup interation tracking for manifests
+	// Setup iteration tracking for manifests
 	var manifestsTotal = len(manifestsList)
 	var manifestsProcessed = 0
 	var manifestsRemaining = 1
@@ -99,6 +100,21 @@ func Get() []Item {
 		if uniqueInManifests {
 			// manifests = append([]Item{newManifest}, manifests...)
 			manifests = append(manifests, newManifest)
+		}
+
+		// If any catalogs are in the manifest, append them to the end of the list
+		for _, newCatalog := range newManifest.Catalogs {
+			// Before adding it, check if it is already on the list
+			var match bool
+			for _, oldCatalog := range config.Current.Catalogs {
+				if oldCatalog == newCatalog {
+					match = true
+				}
+			}
+			// If "match" is still false, it is not already on the list
+			if match == false {
+				config.Current.Catalogs = append(config.Current.Catalogs, newCatalog)
+			}
 		}
 
 		// Increment counters

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -14,6 +14,7 @@ var (
 	origManifest     = config.Current.Manifest
 	origURL          = config.Current.URL
 	origDownloadFile = downloadFile
+	origCatalogs     = config.Current.Catalogs
 )
 
 // TestGetManifest verifies a single manifest is processed correctly
@@ -83,6 +84,36 @@ func TestGet(t *testing.T) {
 
 	if !structsMatch {
 		t.Errorf("\nExpected: %#v\nActual: %#v", expectedManifests, actualManifests)
+	}
+}
+
+// TestGetCatalogs verifies that catalogs included in a manifest get added to the config
+func TestGetCatalogs(t *testing.T) {
+	// Override the cachepath, manifest, and catalogs
+	config.Current.Catalogs = []string{"alpha", "beta"}
+	config.CachePath = "testdata/"
+	config.Current.Manifest = "example_manifest_catalogs"
+	config.Current.URL = "http://example.com/"
+	downloadFile = fakeDownload
+	defer func() {
+		config.Current.Catalogs = origCatalogs
+		config.CachePath = origCachePath
+		config.Current.Manifest = origManifest
+		config.Current.URL = origURL
+		downloadFile = origDownloadFile
+	}()
+
+	// Run Get() to process the manifests and (hopefully) append the catalogs
+	Get()
+
+	// Define our expected catalogs
+	expectedCatalogs := []string{"alpha", "beta", "production1", "production2"}
+
+	// Compare our expectations to the actual catalogs
+	slicesMatch := reflect.DeepEqual(expectedCatalogs, config.Current.Catalogs)
+
+	if !slicesMatch {
+		t.Errorf("\nExpected: %#v\nActual: %#v", expectedCatalogs, config.Current.Catalogs)
 	}
 }
 

--- a/pkg/manifest/testdata/example_manifest_catalogs.yaml
+++ b/pkg/manifest/testdata/example_manifest_catalogs.yaml
@@ -1,0 +1,15 @@
+---
+name: example_manifest
+managed_installs:
+  - Chocolatey
+  - GoogleChrome
+managed_updates:
+  - ChefClient
+  - CanonDrivers
+managed_uninstalls:
+  - AdobeFlash
+included_manifests:
+  - included_manifest
+catalogs:
+  - production1
+  - production2

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -18,19 +18,19 @@ var (
 	origOsRemove    = osRemove
 
 	// Setup a test catalog
-	testCatalog = map[string]catalog.Item{
-		"Chocolatey":     catalog.Item{DisplayName: "Chocolatey", InstallerItemLocation: "Chocolatey.msi", Dependencies: []string{`TestUpdate1`}},
-		"GoogleChrome":   catalog.Item{DisplayName: "GoogleChrome", InstallerItemLocation: "GoogleChrome.msi"},
-		"TestInstall1":   catalog.Item{DisplayName: "TestInstall1", InstallerItemLocation: "TestInstall1.msi"},
-		"TestInstall2":   catalog.Item{DisplayName: "TestInstall2", InstallerItemLocation: "TestInstall2.msi"},
-		"AdobeFlash":     catalog.Item{DisplayName: "AdobeFlash", UninstallerItemLocation: "AdobeUninst.msi"},
-		"Chef Client":    catalog.Item{DisplayName: "Chef Client", InstallerItemLocation: "chef.msi"},
-		"CanonDrivers":   catalog.Item{DisplayName: "CanonDrivers", InstallerItemLocation: "TestInstall1.msi"},
-		"TestUninstall1": catalog.Item{DisplayName: "TestUninstall1", UninstallerItemLocation: "TestUninst2.ps1"},
-		"TestUninstall2": catalog.Item{DisplayName: "TestUninstall2", UninstallerItemLocation: "TestUninst2.exe"},
-		"TestUpdate1":    catalog.Item{DisplayName: "TestUpdate1", InstallerItemLocation: "TestUpdate1.nupkg"},
-		"TestUpdate2":    catalog.Item{DisplayName: "TestUpdate2", InstallerItemLocation: "TestUpdate2.ps1"},
-	}
+	testCatalogs = map[int]map[string]catalog.Item{1: {
+		"Chocolatey":     catalog.Item{DisplayName: "Chocolatey", InstallerType: "msi", InstallerItemLocation: "Chocolatey.msi", Dependencies: []string{`TestUpdate1`}},
+		"GoogleChrome":   catalog.Item{DisplayName: "GoogleChrome", InstallerType: "msi", InstallerItemLocation: "GoogleChrome.msi"},
+		"TestInstall1":   catalog.Item{DisplayName: "TestInstall1", InstallerType: "msi", InstallerItemLocation: "TestInstall1.msi"},
+		"TestInstall2":   catalog.Item{DisplayName: "TestInstall2", InstallerType: "msi", InstallerItemLocation: "TestInstall2.msi"},
+		"AdobeFlash":     catalog.Item{DisplayName: "AdobeFlash", UninstallerType: "msi", UninstallerItemLocation: "AdobeUninst.msi"},
+		"Chef Client":    catalog.Item{DisplayName: "Chef Client", InstallerType: "msi", InstallerItemLocation: "chef.msi"},
+		"CanonDrivers":   catalog.Item{DisplayName: "CanonDrivers", InstallerType: "msi", InstallerItemLocation: "TestInstall1.msi"},
+		"TestUninstall1": catalog.Item{DisplayName: "TestUninstall1", UninstallerType: "ps1", UninstallerItemLocation: "TestUninst2.ps1"},
+		"TestUninstall2": catalog.Item{DisplayName: "TestUninstall2", UninstallerType: "exe", UninstallerItemLocation: "TestUninst2.exe"},
+		"TestUpdate1":    catalog.Item{DisplayName: "TestUpdate1", InstallerType: "nupkg", InstallerItemLocation: "TestUpdate1.nupkg"},
+		"TestUpdate2":    catalog.Item{DisplayName: "TestUpdate2", InstallerType: "ps1", InstallerItemLocation: "TestUpdate2.ps1"},
+	}}
 
 	// Arrays of the test items
 	testInstalls   = []string{"Chocolatey", "GoogleChrome", "TestInstall1", "TestInstall2"}
@@ -66,7 +66,7 @@ func TestManifests(t *testing.T) {
 	}
 
 	// Store the actual results of running `Manifests`
-	actualInstalls, actualUninstalls, actualUpdates := Manifests(testManifests, testCatalog)
+	actualInstalls, actualUninstalls, actualUpdates := Manifests(testManifests, testCatalogs)
 
 	// Define what we expect it to return
 	expectedInstalls := testInstalls
@@ -98,7 +98,7 @@ func TestInstalls(t *testing.T) {
 	defer func() { installerInstall = origInstall }()
 
 	// Run `Installs` with test data
-	Installs(testInstalls, testCatalog)
+	Installs(testInstalls, testCatalogs)
 
 	// Define what we expect to be in the list of installed items
 	// This ends up being the testInstalls slice *PLUS any dependencies*
@@ -121,7 +121,7 @@ func TestUninstalls(t *testing.T) {
 	defer func() { installerInstall = origInstall }()
 
 	// Run `Uninstalls` with test data
-	Uninstalls(testUninstalls, testCatalog)
+	Uninstalls(testUninstalls, testCatalogs)
 
 	// Define what we expect to be in the list of uninstalled items
 	expectedItems := testUninstalls
@@ -143,7 +143,7 @@ func TestUpdates(t *testing.T) {
 	defer func() { installerInstall = origInstall }()
 
 	// Run `Updates` with test data
-	Updates(testUpdates, testCatalog)
+	Updates(testUpdates, testCatalogs)
 
 	// Define what we expect to be in the list of updated items
 	expectedItems := testUpdates


### PR DESCRIPTION
This PR adds support for multiple catalogs and also add support for defining catalogs in a manifest. You can still (optionally) define a catalog in the config file, but it now requires an array instead of a string.

This enables support for beta or alpha catalogs similar to Munki.