### PR TITLE
Improve error handling

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -67,6 +68,14 @@ func Get(cfg config.Configuration) map[int]map[string]Item {
 		os.Exit(1)
 	}
 
+	// Setup to catch a potential failure
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println(r)
+			os.Exit(1)
+		}
+	}()
+
 	// Loop through the catalogs and get each one in order
 	for _, catalog := range cfg.Catalogs {
 
@@ -77,7 +86,7 @@ func Get(cfg config.Configuration) map[int]map[string]Item {
 		gorillalog.Info("Catalog Url:", catalogURL)
 		err := downloadFile(cfg.CachePath, catalogURL)
 		if err != nil {
-			gorillalog.Error("Unable to retrieve catalog:", catalog, err)
+			gorillalog.Error("Unable to retrieve catalog: ", err)
 		}
 
 		// Open the catalog file
@@ -85,14 +94,14 @@ func Get(cfg config.Configuration) map[int]map[string]Item {
 		gorillalog.Debug("Catalog file path:", yamlPath)
 		yamlFile, err := ioutil.ReadFile(yamlPath)
 		if err != nil {
-			gorillalog.Error("Unable to open the catalog file:", yamlPath, err)
+			gorillalog.Error("Unable to open the catalog file: ", err)
 		}
 
 		// Parse the catalog
 		var catalogItems map[string]Item
 		err = yaml.Unmarshal(yamlFile, &catalogItems)
 		if err != nil {
-			gorillalog.Error("Unable to parse yaml catalog:", yamlPath, err)
+			gorillalog.Error("Unable to parse yaml catalog: ", err)
 		}
 
 		// Add the new parsed catalog items to the catalogMap

--- a/pkg/gorillalog/gorillalog.go
+++ b/pkg/gorillalog/gorillalog.go
@@ -25,7 +25,7 @@ func NewLog(cfg config.Configuration) {
 	// Setup a defer function to recover from a panic
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Println("Recovered from panic while creating the log file:", r)
+			fmt.Println(r)
 			os.Exit(1)
 		}
 	}()

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -85,7 +85,7 @@ func installItem(item catalog.Item, itemURL, cachePath string) string {
 	if item.Installer.Type == "nupkg" {
 		gorillalog.Info("Installing nupkg for", item.DisplayName)
 		installCmd = commandNupkg
-		installArgs = []string{"install", absFile, "-f", "-y", "-r"}
+		installArgs = []string{"install", absFile, "-f", "-y"}
 	} else if item.Installer.Type == "msi" {
 		gorillalog.Info("Installing msi for", item.DisplayName)
 		installCmd = commandMsi
@@ -135,7 +135,7 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 	if item.Uninstaller.Type == "nupkg" {
 		gorillalog.Info("Installing nupkg for", item.DisplayName)
 		uninstallCmd = commandNupkg
-		uninstallArgs = []string{"uninstall", absFile, "-f", "-y", "-r"}
+		uninstallArgs = []string{"uninstall", absFile, "-f", "-y"}
 	} else if item.Uninstaller.Type == "msi" {
 		gorillalog.Info("Installing msi for", item.DisplayName)
 		uninstallCmd = commandMsi

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -180,13 +180,16 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string) st
 		return "Item not needed"
 	}
 
-	// Compile the item's URL
-	itemURL := urlPackages + item.Uninstaller.Location
-
 	// Install or uninstall the item
 	if installerType == "install" || installerType == "update" {
+		// Compile the item's URL
+		itemURL := urlPackages + item.Installer.Location
+		// Run the installer
 		installItem(item, itemURL, cachePath)
 	} else if installerType == "uninstall" {
+		// Compile the item's URL
+		itemURL := urlPackages + item.Uninstaller.Location
+		// Run the installer
 		uninstallItem(item, itemURL, cachePath)
 	} else {
 		gorillalog.Warn("Unsupported item type", item.DisplayName, installerType)

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -164,6 +164,12 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 	return uninstallerOut
 }
 
+var (
+	// By putting the functions in a variable, we can override later in tests
+	installItemFunc   = installItem
+	uninstallItemFunc = uninstallItem
+)
+
 // Install determines if action needs to be taken on a item and then
 // calls the appropriate function to install or uninstall
 func Install(item catalog.Item, installerType, urlPackages, cachePath string) string {
@@ -185,12 +191,12 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string) st
 		// Compile the item's URL
 		itemURL := urlPackages + item.Installer.Location
 		// Run the installer
-		installItem(item, itemURL, cachePath)
+		installItemFunc(item, itemURL, cachePath)
 	} else if installerType == "uninstall" {
 		// Compile the item's URL
 		itemURL := urlPackages + item.Uninstaller.Location
 		// Run the installer
-		uninstallItem(item, itemURL, cachePath)
+		uninstallItemFunc(item, itemURL, cachePath)
 	} else {
 		gorillalog.Warn("Unsupported item type", item.DisplayName, installerType)
 		return "Unsupported item type"

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -190,7 +190,7 @@ func TestInstallItem(t *testing.T) {
 	// Check the result
 	nupkgCmd := filepath.Join(os.Getenv("ProgramData"), "chocolatey/bin/choco.exe")
 	nupkgFile := filepath.Join(pkgCache, nupkgPath)
-	expectedNupkg := "[" + nupkgCmd + " install " + nupkgFile + " -f -y -r]"
+	expectedNupkg := "[" + nupkgCmd + " install " + nupkgFile + " -f -y]"
 	if have, want := actualNupkg, expectedNupkg; have != want {
 		t.Errorf("\n-----\nhave\n%s\nwant\n%s\n-----", have, want)
 	}
@@ -311,7 +311,7 @@ func TestUninstallItem(t *testing.T) {
 	// Check the result
 	nupkgCmd := filepath.Join(os.Getenv("ProgramData"), "chocolatey/bin/choco.exe")
 	nupkgPath := filepath.Clean("testdata/packages/chef-client/chef-client-14.3.37-1-x64uninst.nupkg")
-	expectedNupkg := "[" + nupkgCmd + " uninstall " + nupkgPath + " -f -y -r]"
+	expectedNupkg := "[" + nupkgCmd + " uninstall " + nupkgPath + " -f -y]"
 	if have, want := actualNupkg, expectedNupkg; have != want {
 		t.Errorf("\n-----\nhave\n%s\nwant\n%s\n-----", have, want)
 	}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -1,7 +1,9 @@
 package manifest
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/1dustindavis/gorilla/pkg/config"
@@ -54,6 +56,14 @@ func Get(cfg config.Configuration) (manifests []Item, newCatalogs []string) {
 	// Add the top level manifest to the list
 	manifestsList = append(manifestsList, cfg.Manifest)
 
+	// Setup to catch a potential failure
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println(r)
+			os.Exit(1)
+		}
+	}()
+
 	for manifestsRemaining > 0 {
 		currentManifest := manifestsList[manifestsProcessed]
 
@@ -65,7 +75,7 @@ func Get(cfg config.Configuration) (manifests []Item, newCatalogs []string) {
 		gorillalog.Info("Manifest Url:", manifestURL)
 		err := downloadFile(cfg.CachePath, manifestURL)
 		if err != nil {
-			gorillalog.Error("Unable to retrieve manifest:", currentManifest, err)
+			gorillalog.Error("Unable to retrieve manifest: ", err)
 		}
 
 		// Get new manifest


### PR DESCRIPTION
This PR improves error handling of panics by recovering from any expected panics, printing the error, and then calling os.Exit(1).

Current situations where we expect a panic:
- Unable to write log file
- Unable to download a catalog
- Unable to parse a catalog
- Unable to download a manifest
- Unable to parse a manifest

My current thinking is that these are all situations that, if we continued past the error, may cause undesired or unknown effects, so our best option is to exit.

This would resolve #65 and #57. It would also contribute towards #15.

This PR also adjusts the arguments passed to `choco` so that it will output more details and we will catch those in our logs, which should address #58.