### PR TITLE
Modifies how we process stdout so we can stream the output of the installer

### DIFF
--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -532,4 +533,38 @@ func TestUninstallURL(t *testing.T) {
 	if have, want := installItemURL, expectedURL; have != want {
 		t.Errorf("\n-----\nhave\n%s\nwant\n%s\n-----", have, want)
 	}
+}
+
+// ExampleRunCommandDebug tests the output when running a command in debug
+func ExampleRunCommandDebug() {
+	// Temp directory for logging
+	logTmp, _ := ioutil.TempDir("", "gorilla-installer_test")
+
+	// Setup a testing Configuration struct with debug more
+	cfgVerbose := config.Configuration{
+		Debug:       true,
+		Verbose:     true,
+		AppDataPath: logTmp,
+	}
+
+	// Start gorillalog in debug mode
+	gorillalog.NewLog(cfgVerbose)
+
+	// Override execCommand with our fake version
+	execCommand = fakeExecCommand
+	defer func() { execCommand = origExec }()
+
+	// Set up what we expect
+	testCmd := "Command Test!"
+	testArgs := []string{"arg1", "arg2"}
+
+	// Run the function
+	runCommand(testCmd, testArgs)
+
+	// Output:
+	// command: Command Test! [arg1 arg2]
+	// Command Output:
+	// --------------------
+	// [Command Test! arg1 arg2]
+	// --------------------
 }

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -195,7 +195,7 @@ func TestInstallItem(t *testing.T) {
 	// Check the result
 	nupkgCmd := filepath.Join(os.Getenv("ProgramData"), "chocolatey/bin/choco.exe")
 	nupkgFile := filepath.Join(pkgCache, nupkgPath)
-	expectedNupkg := "[" + nupkgCmd + " install " + nupkgFile + " -f -y]"
+	expectedNupkg := "[" + nupkgCmd + " install " + nupkgFile + " -f -y -r]"
 	if have, want := actualNupkg, expectedNupkg; have != want {
 		t.Errorf("\n-----\nhave\n%s\nwant\n%s\n-----", have, want)
 	}
@@ -316,7 +316,7 @@ func TestUninstallItem(t *testing.T) {
 	// Check the result
 	nupkgCmd := filepath.Join(os.Getenv("ProgramData"), "chocolatey/bin/choco.exe")
 	nupkgPath := filepath.Clean("testdata/packages/chef-client/chef-client-14.3.37-1-x64uninst.nupkg")
-	expectedNupkg := "[" + nupkgCmd + " uninstall " + nupkgPath + " -f -y]"
+	expectedNupkg := "[" + nupkgCmd + " uninstall " + nupkgPath + " -f -y -r]"
 	if have, want := actualNupkg, expectedNupkg; have != want {
 		t.Errorf("\n-----\nhave\n%s\nwant\n%s\n-----", have, want)
 	}

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -540,7 +540,7 @@ func ExampleRunCommandDebug() {
 	// Temp directory for logging
 	logTmp, _ := ioutil.TempDir("", "gorilla-installer_test")
 
-	// Setup a testing Configuration struct with debug more
+	// Setup a testing Configuration struct with debug mode
 	cfgVerbose := config.Configuration{
 		Debug:       true,
 		Verbose:     true,


### PR DESCRIPTION
This resolves #58 by fixing a bug caused when the `runCommand` function [started returning the commands stdout](https://github.com/1dustindavis/gorilla/commit/5a2985b8bd84f9cb92fd7310d377f0390aa51e20#diff-4b35ff35fbd91ac2061f732a0a7c801dR28).

We now write the output to a separate variable, instead of redirecting stdout.