### PR TITLE
Check if gorilla is running as an admin

### DIFF
--- a/cmd/gorilla/main.go
+++ b/cmd/gorilla/main.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/1dustindavis/gorilla/pkg/catalog"
 	"github.com/1dustindavis/gorilla/pkg/config"
 	"github.com/1dustindavis/gorilla/pkg/download"
@@ -14,6 +20,9 @@ func main() {
 
 	// Get our configuration
 	cfg := config.Get()
+
+	// Confirm we are running as an administrator before continuing
+	adminCheck()
 
 	// Create a new logger object
 	gorillalog.NewLog(cfg)
@@ -62,4 +71,37 @@ func main() {
 	process.CleanUp(cfg.CachePath)
 
 	gorillalog.Info("Done!")
+}
+
+func adminCheck() {
+
+	// Skip the check if this is test
+	if flag.Lookup("test.v") != nil {
+		return
+	}
+
+	// Compile the PowerShell command used to determine if the current user is an administrator
+	currentUser := "(New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent()))"
+	adminRole := "([Security.Principal.WindowsBuiltInRole]::Administrator)"
+	checkCmd := currentUser + ".IsInRole" + adminRole
+
+	// Execute the command with Powershell and capture the output
+	cmdOutput, err := exec.Command("powershell.exe", "-Command", checkCmd).CombinedOutput()
+	if err != nil {
+		fmt.Println("Unable to determine current permissions via Powershell: ", err)
+		fmt.Println("Gorilla requires admnisistrative access. Please run as an administrator.")
+		os.Exit(1)
+	}
+
+	// Convert the output to a lowercase string
+	strOutput := strings.ToLower(string(cmdOutput))
+
+	// If the output contains the word "true", we are running as an administrator
+	if strings.Contains(strOutput, "true") {
+		return
+	}
+
+	// The user does not have the `Administrator` role
+	fmt.Println("Gorilla requires admnisistrative access. Please run as an administrator.")
+	os.Exit(1)
 }

--- a/cmd/gorilla/main.go
+++ b/cmd/gorilla/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/1dustindavis/gorilla/pkg/catalog"
@@ -23,6 +24,13 @@ func main() {
 
 	// Confirm we are running as an administrator before continuing
 	adminCheck()
+
+	// If needed, create the cache directory
+	err := os.MkdirAll(filepath.Clean(cfg.CachePath), 0755)
+	if err != nil {
+		fmt.Println("Unable to create cache directory: ", err)
+		os.Exit(1)
+	}
 
 	// Create a new logger object
 	gorillalog.NewLog(cfg)


### PR DESCRIPTION
This PR adds a Powershell command at the beginning of a run to determine if the current user has administrative rights.
```Powershell
(New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
```

Also fixed a bug where the cache directory wouldn't always get created.