### PR TITLE
fix: Fix checkPath for uninstall items

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -196,7 +196,6 @@ func checkPath(catalogItem catalog.Item, installType string) (actionNeeded bool,
 		}
 	}
 
-	gorillalog.Info("ActionStore :", actionStore)
 	for _, item := range actionStore {
 		if item == true {
 			actionNeeded = true

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -270,7 +270,7 @@ func TestCheckPath(t *testing.T) {
 
 	// Run checkPath for pathInstalled
 	// We expect action is not needed; Only error if action needed is true
-	actionNeeded, err := checkPath(pathInstalled)
+	actionNeeded, err := checkPath(pathInstalled, "install")
 	if err != nil {
 		t.Errorf("checkPath failed: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestCheckPath(t *testing.T) {
 
 	// Run checkPath for pathNotInstalled
 	// We expect action is needed; Only error if actionNeeded is false
-	actionNeeded, err = checkPath(pathNotInstalled)
+	actionNeeded, err = checkPath(pathNotInstalled, "install")
 	if err != nil {
 		t.Error(err)
 	}
@@ -290,7 +290,7 @@ func TestCheckPath(t *testing.T) {
 
 	// Run checkPath for pathMetadataInstalled
 	// We expect action is not needed; Only error if actionNeeded is true
-	actionNeeded, err = checkPath(pathMetadataInstalled)
+	actionNeeded, err = checkPath(pathMetadataInstalled, "install")
 	if err != nil {
 		t.Error(err)
 	}
@@ -300,7 +300,7 @@ func TestCheckPath(t *testing.T) {
 
 	// Run checkPath for pathMetadataOutdated
 	// We expect action is needed; Only error if actionNeeded is false
-	actionNeeded, err = checkPath(pathMetadataOutdated)
+	actionNeeded, err = checkPath(pathMetadataOutdated, "install")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
When doing an uninstallType we need to make sure the checkPath function
returns the correct action. Prior to this change, the logic was focused
on checking to see if software needed to be installed.

This fixes a bug in which an uninstall item with a Check -> File would
not get properly processed.