### PR TITLE
Script checks now can install/uninstall packages

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -120,7 +120,7 @@ func checkScript(catalogItem catalog.Item, cachePath string, installType string)
 	gorillalog.Debug("stderr:", errStr)
 
 	actionNeeded = false
-	// Application not installed if exit 0 
+	// Application not installed if exit 0
 	if installType == "uninstall" {
 		actionNeeded = !cmdSuccess
 	} else if installType == "install" {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -92,7 +92,7 @@ func checkRegistry(catalogItem catalog.Item, installType string) (actionNeeded b
 	return actionNeeded, checkErr
 }
 
-func checkScript(catalogItem catalog.Item, cachePath string) (actionNeeded bool, checkErr error) {
+func checkScript(catalogItem catalog.Item, cachePath string, installType string) (actionNeeded bool, checkErr error) {
 
 	// Write InstallCheckScript to disk as a Powershell file
 	tmpScript := filepath.Join(cachePath, "tmpCheckScript.ps1")
@@ -119,8 +119,13 @@ func checkScript(catalogItem catalog.Item, cachePath string) (actionNeeded bool,
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
 
-	// Install if exit 0
-	actionNeeded = cmdSuccess
+	actionNeeded = false
+	// Application not installed if exit 0 
+	if installType == "uninstall" {
+		actionNeeded = !cmdSuccess
+	} else if installType == "install" {
+		actionNeeded = cmdSuccess
+	}
 
 	return actionNeeded, checkErr
 }
@@ -224,7 +229,7 @@ func CheckStatus(catalogItem catalog.Item, installType, cachePath string) (actio
 
 	if catalogItem.Check.Script != "" {
 		gorillalog.Info("Checking status via Script:", catalogItem.DisplayName)
-		return checkScript(catalogItem, cachePath)
+		return checkScript(catalogItem, cachePath, installType)
 
 	} else if catalogItem.Check.File != nil {
 		gorillalog.Info("Checking status via File:", catalogItem.DisplayName)

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -249,20 +249,35 @@ func TestCheckScript(t *testing.T) {
 
 	// Set cachepath and run checkScript for scriptActionNoError
 	cachepath := fmt.Sprintf("testdata/%s/", statusActionNoError)
-	actionNeeded, err := checkScript(scriptActionNoError, cachepath)
+	actionNeeded, err := checkScript(scriptActionNoError, cachepath, "install")
 	if !actionNeeded || err != nil {
 		fmt.Printf("action: %v; error: %v\n", actionNeeded, err)
 		t.Errorf("Expected checkScript to action and no error")
 	}
 
 	// Set cachepath and run checkScript for scriptNoActionNoError
+	cachepath = fmt.Sprintf("testdata/%s/", statusActionNoError)
+	actionNeeded, err = checkScript(scriptActionNoError, cachepath, "uninstall")
+	if actionNeeded || err != nil {
+		fmt.Printf("action: %v; error: %v\n", actionNeeded, err)
+		t.Errorf("Expected checkScript to no action and no error")
+	}
+
+	// Set cachepath and run checkScript for scriptNoActionNoError
 	cachepath = fmt.Sprintf("testdata/%s/", statusNoActionNoError)
-	actionNeeded, err = checkScript(scriptNoActionNoError, cachepath)
+	actionNeeded, err = checkScript(scriptNoActionNoError, cachepath, "install")
 	if actionNeeded || err != nil {
 		fmt.Printf("action: %v; error: %v\n", actionNeeded, err)
 		t.Errorf("Expected checkScript to return no action and no error")
 	}
 
+	// Set cachepath and run checkScript for scriptActionNoError
+	cachepath = fmt.Sprintf("testdata/%s/", statusNoActionNoError)
+	actionNeeded, err = checkScript(scriptNoActionNoError, cachepath, "uninstall")
+	if !actionNeeded || err != nil {
+		fmt.Printf("action: %v; error: %v\n", actionNeeded, err)
+		t.Errorf("Expected checkScript to action and no error")
+	}
 }
 
 // TestCheckPath validates that the status of a path is checked correctly


### PR DESCRIPTION
ATM, script checks are able to perform installations if necessary but uninstalls don't work (Gorilla is doing the oposite of what it have to do, it tries to uninstall a package when is not installed...), with this change Gorilla client will be able to uninstall packages when have to.

I've compiled and tested this code on my Windows vagrant box, but IDK how to run the unit tests on my Mac, I'm a Golang newbie, sorry.

Regards