### PR TITLE
Add 32bit apps registry check

### DIFF
--- a/pkg/status/registry_windows.go
+++ b/pkg/status/registry_windows.go
@@ -32,64 +32,70 @@ func getUninstallKeys() (installedItems map[string]RegistryApplication, checkErr
 	// Initialize the map we will add any values to
 	installedItems = make(map[string]RegistryApplication)
 
-	// Get the Uninstall key from HKLM
-	key, checkErr := registry.OpenKey(registry.LOCAL_MACHINE, `Software\Microsoft\Windows\CurrentVersion\Uninstall`, registry.READ)
-	if checkErr != nil {
-		gorillalog.Warn("Unable to read registry key:", checkErr)
-		return installedItems, checkErr
-	}
-	defer key.Close()
+	// Both Uninstall paths (64 & 32 bits apps)
+	regPaths := []string{`Software\Microsoft\Windows\CurrentVersion\Uninstall`,
+	`Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall`}
 
-	// Get all the subkeys under Uninstall
-	subKeys, checkErr := key.ReadSubKeyNames(0)
-	if checkErr != nil {
-		gorillalog.Warn("Unable to read registry sub keys:", checkErr)
-		return installedItems, checkErr
-	}
-
-	// Get the details of each subkey and add them to a map of `RegistryApplication`
-	for _, item := range subKeys {
-
-		//  installedItem is the struct we will store each application in
-		var installedItem RegistryApplication
-		itemKeyName := `Software\Microsoft\Windows\CurrentVersion\Uninstall\` + item
-		itemKey, checkErr := registry.OpenKey(registry.LOCAL_MACHINE, itemKeyName, registry.READ)
+	for _, regPath := range regPaths {
+		
+		// Get the Uninstall key from HKLM
+		key, checkErr := registry.OpenKey(registry.LOCAL_MACHINE, regPath, registry.READ)
 		if checkErr != nil {
 			gorillalog.Warn("Unable to read registry key:", checkErr)
 			return installedItems, checkErr
 		}
-		defer itemKey.Close()
+		defer key.Close()
 
-		// Put the names of all the values in a slice
-		itemValues, checkErr := itemKey.ReadValueNames(0)
+		// Get all the subkeys under Uninstall
+		subKeys, checkErr := key.ReadSubKeyNames(0)
 		if checkErr != nil {
-			gorillalog.Warn("Unable to read registry value names:", checkErr)
+			gorillalog.Warn("Unable to read registry sub keys:", checkErr)
 			return installedItems, checkErr
 		}
 
-		// If checkValues() returns true, add the values to our struct
-		if checkValues(itemValues) {
-			installedItem.Key = itemKeyName
-			installedItem.Name, _, checkErr = itemKey.GetStringValue("DisplayName")
+		// Get the details of each subkey and add them to a map of `RegistryApplication`
+		for _, item := range subKeys {
+
+			//  installedItem is the struct we will store each application in
+			var installedItem RegistryApplication
+			itemKeyName := regPath + `\` + item
+			itemKey, checkErr := registry.OpenKey(registry.LOCAL_MACHINE, itemKeyName, registry.READ)
 			if checkErr != nil {
-				gorillalog.Warn("Unable to read DisplayName", checkErr)
+				gorillalog.Warn("Unable to read registry key:", checkErr)
+				return installedItems, checkErr
+			}
+			defer itemKey.Close()
+
+			// Put the names of all the values in a slice
+			itemValues, checkErr := itemKey.ReadValueNames(0)
+			if checkErr != nil {
+				gorillalog.Warn("Unable to read registry value names:", checkErr)
 				return installedItems, checkErr
 			}
 
-			installedItem.Version, _, checkErr = itemKey.GetStringValue("DisplayVersion")
-			if checkErr != nil {
-				gorillalog.Warn("Unable to read DisplayVersion", checkErr)
-				return installedItems, checkErr
-			}
+			// If checkValues() returns true, add the values to our struct
+			if checkValues(itemValues) {
+				installedItem.Key = itemKeyName
+				installedItem.Name, _, checkErr = itemKey.GetStringValue("DisplayName")
+				if checkErr != nil {
+					gorillalog.Warn("Unable to read DisplayName", checkErr)
+					return installedItems, checkErr
+				}
 
-			installedItem.Uninstall, _, checkErr = itemKey.GetStringValue("UninstallString")
-			if checkErr != nil {
-				gorillalog.Warn("Unable to read UninstallString", checkErr)
-				return installedItems, checkErr
+				installedItem.Version, _, checkErr = itemKey.GetStringValue("DisplayVersion")
+				if checkErr != nil {
+					gorillalog.Warn("Unable to read DisplayVersion", checkErr)
+					return installedItems, checkErr
+				}
+
+				installedItem.Uninstall, _, checkErr = itemKey.GetStringValue("UninstallString")
+				if checkErr != nil {
+					gorillalog.Warn("Unable to read UninstallString", checkErr)
+					return installedItems, checkErr
+				}
+				installedItems[installedItem.Name] = installedItem
 			}
-			installedItems[installedItem.Name] = installedItem
 		}
-
 	}
 	return installedItems, checkErr
 }


### PR DESCRIPTION
I've added a for loop to iterate the regPaths array that I created with the Windows registry paths for 32 and 64 bits apps, this make gorilla more flexible because it's easier to add more keys in case some application have custom registry paths. 

Tested passing in local and also tested the behaviour on Windows machine, but more testing is never a bad thing :D

Thanks :) 