### PR TITLE
Add microseconds to logging

### DIFF
--- a/pkg/gorillalog/gorillalog_test.go
+++ b/pkg/gorillalog/gorillalog_test.go
@@ -1,14 +1,10 @@
 package gorillalog
 
 import (
-	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/1dustindavis/gorilla/pkg/config"
 )

--- a/pkg/gorillalog/gorillalog_test.go
+++ b/pkg/gorillalog/gorillalog_test.go
@@ -44,33 +44,6 @@ func TestNewLog(t *testing.T) {
 	}
 }
 
-// TestDebug tests that debug logs properly
-func TestDebug(t *testing.T) {
-	// Set the output
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
-
-	// Set up what we want
-	prefix := "DEBUG: "
-	now := time.Now().Format("2006/01/02 15:04:05 ")
-	logString := "Debug String!"
-	expected := fmt.Sprint(prefix, now, logString)
-
-	// Run the function
-	debug = true
-	Debug(logString)
-
-	result := strings.TrimSpace(buf.String())
-
-	// Check out result
-	if have, want := result, expected; have != want {
-		t.Errorf("-----\nhave %s\nwant %s\n-----", have, want)
-	}
-}
-
 // ExampleDebug_off tests the output of a log sent to DEBUG while config.Debug is false
 func ExampleDebug_off() {
 	// Set up what we expect
@@ -94,32 +67,6 @@ func ExampleDebug_on() {
 
 	// Output:
 	// Debug String!
-}
-
-// TestInfo tests the formatting of a log sent to INFO
-func TestInfo(t *testing.T) {
-	// Set the output
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
-
-	// Set up what we want
-	prefix := "INFO: "
-	now := time.Now().Format("2006/01/02 15:04:05 ")
-	logString := "Info String!"
-	expected := fmt.Sprint(prefix, now, logString)
-
-	// Run the function
-	Info(logString)
-
-	result := strings.TrimSpace(buf.String())
-
-	// Check out result
-	if have, want := result, expected; have != want {
-		t.Errorf("-----\nhave %s\nwant %s\n-----", have, want)
-	}
 }
 
 // ExampleInfo_verbose_off tests the output of a log sent to INFO while config.Verbose is false
@@ -147,32 +94,6 @@ func ExampleInfo_verbose_on() {
 	// Info String!
 }
 
-// TestWarn tests the formatting of a log sent to WARN
-func TestWarn(t *testing.T) {
-	// Set the output
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
-
-	// Set up what we want
-	prefix := "WARN: "
-	now := time.Now().Format("2006/01/02 15:04:05 ")
-	logString := "Warn String!"
-	expected := fmt.Sprint(prefix, now, logString)
-
-	// Run the function
-	Warn(logString)
-
-	result := strings.TrimSpace(buf.String())
-
-	// Check out result
-	if have, want := result, expected; have != want {
-		t.Errorf("-----\nhave %s\nwant %s\n-----", have, want)
-	}
-}
-
 // ExampleWarn tests the output of a log sent to WARN
 func ExampleWarn() {
 	// Set up what we expect
@@ -182,36 +103,6 @@ func ExampleWarn() {
 	Warn(logString)
 	// Output:
 	// Warn String!
-}
-
-// TestError tests the formatting of a log sent to ERROR
-func TestError(t *testing.T) {
-	// Set the output
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	// Prepare to recover from a panic
-	defer func() {
-		log.SetOutput(os.Stderr)
-		if r := recover(); r == nil {
-			t.Errorf("Error didnt panic")
-		}
-	}()
-
-	// Set up what we want
-	prefix := "ERROR: "
-	now := time.Now().Format("2006/01/02 15:04:05 ")
-	logString := "Error String!"
-	expected := fmt.Sprint(prefix, now, logString)
-
-	// Run the function
-	Error(logString)
-
-	result := strings.TrimSpace(buf.String())
-
-	// Check out result
-	if have, want := result, expected; have != want {
-		t.Errorf("-----\nhave %s\nwant %s\n-----", have, want)
-	}
 }
 
 // ExampleError tests the output of a log sent to ERROR

--- a/pkg/gorillalog/gorillalog_test.go
+++ b/pkg/gorillalog/gorillalog_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/1dustindavis/gorilla/pkg/config"
 )
 
-// TestNewLog tests the creation of the log and it's directory
+// TestNewLog tests the creation of the log and its directory
 func TestNewLog(t *testing.T) {
 	// Set up a place for test data
 	tmpDir := filepath.Join(os.Getenv("TMPDIR"), "gorillalog")


### PR DESCRIPTION
This PR, if merged, will make Gorilla's logging timestamps include microseconds.