### PR TITLE
Pin actions hash, add timeout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,16 +5,17 @@ jobs:
   build:
     name: Build
     runs-on: windows-latest
+    timeout-minutes: 25
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@9fbc767707c286e568c92927bbf57d76b73e0892
       with:
         go-version: 1.13
       id: go
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
 
     - name: Build
       run: go build -v ./cmd/gorilla


### PR DESCRIPTION
* Pins setup-go at v1.1.2
* Pins checkout at v2.0.0
* Adds a 25 minute timeout to keep unresponsive builds from eating up your minutes

This PR pins the SHA1 commit hash for external actions, since an action maintainer could break your build process by tagging a later commit as `v1` or a malicious actor could compromise your build process. It's safer to point towards commit hashes instead. Git and [Github have protections against SHA1 collisions](https://github.blog/2017-03-20-sha-1-collision-detection-on-github-com/).

The `setup-go` step might not be necessary since the Windows runners already have [Go installed on them](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#windows-server-2019).