### PR TITLE
[ITP-7344] Adds support for pre/post install scripts

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -20,6 +20,8 @@ type Item struct {
 	Uninstaller  InstallerItem `yaml:"uninstaller"`
 	Version      string        `yaml:"version"`
 	BlockingApps []string	   `yaml:"blocking_apps"`
+	PreScript	 string        `yaml:"preinstall_script"`
+	PostScript   string        `yaml:"postinstall_script"`
 }
 
 // InstallerItem holds information about how to install a catalog item

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -336,8 +336,12 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string, ch
 			itemURL := urlPackages + item.Installer.Location
 			// Run PreInstall_Script if needed
 			if item.PreScript != "" {
-				gorillalog.Info("Running Pre-Install script for ", item.DisplayName)
-				preinstallScript(item, cachePath)
+				gorillalog.Info("Running Pre-Install script for", item.DisplayName)
+				preScriptSuccess, err := preinstallScript(item, cachePath)
+				if !preScriptSuccess {
+					gorillalog.Error("PreInstall-Script error:", err)
+					return "PreInstall-Script error"
+				}
 			}
 
 			// Run the installer
@@ -345,8 +349,12 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string, ch
 
 			// Run PostInstall_Script if needed
 			if item.PostScript != "" {
-				gorillalog.Info("Running Post-Install script for ", item.DisplayName)
-				postinstallScript(item, cachePath)
+				gorillalog.Info("Running Post-Install script for", item.DisplayName)
+				postScriptSuccess, err := postinstallScript(item, cachePath)
+				if !postScriptSuccess {
+					gorillalog.Error("PreInstall-Script error:", err)
+					return "PostInstall-Script error"
+				}
 			}
 		}
 	} else if installerType == "uninstall" {


### PR DESCRIPTION
This PR adds support for pre/post install PS scripts for any type of installer, this is an example:

```---
FakeApp:
  display_name: FakeApp
  check:
    registry:
      name: FakeApp
      version: 1.1.1.1
  installer:
    hash: ghui1uihp12uhi12hui12hui1221hui1hui1uhi11hui1hui12hiu21hiu321ui3h
    location: pkgs/apps/fake/installer.msi
    arguments:
      - BLABLA
    type: msi
  uninstaller:
    hash: ghui1uihp12uhi12hui12hui1221hui1hui1uhi11hui1hui12hiu21hiu321ui3h
    location: pkgs/apps/fake/installer.msi
    type: msi
  version: 1.1.1.1
  preinstall_script: |
    Write-Host "Test"
  postinstall_script: |
    Rename-Computer "Test"
    Restart-Computer
```

Currently it only supports Powershell scripts and errors during scripts execution does not affect to the final status of the installation, so if the pre script exits with an error it will perform the installation anyways (Not sure if it's the best behaviour).

Since it's a new feature IDK how to test it, some help to write the test would be nice.

Thanks!!