### PR TITLE
Add success/failure log entries for install/update/uninstall events

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -35,7 +35,7 @@ var (
 )
 
 // runCommand executes a command and it's argurments in the CMD environment
-func runCommand(command string, arguments []string) string {
+func runCommand(command string, arguments []string) (string, error) {
 	cmd := execCommand(command, arguments...)
 	var cmdOutput string
 	cmdReader, err := cmd.StdoutPipe()
@@ -73,7 +73,7 @@ func runCommand(command string, arguments []string) string {
 		gorillalog.Warn("Command error:", err)
 	}
 
-	return cmdOutput
+	return cmdOutput, err
 }
 
 // Get a Nupkg's id using `choco list`
@@ -84,7 +84,7 @@ func getNupkgID(nupkgDir, versionArg string) string {
 	arguments := []string{"list", versionArg, "--id-only", "-r", "-s", nupkgDir}
 
 	// Run the command and trim the output
-	cmdOut := runCommand(command, arguments)
+	cmdOut, _ := runCommand(command, arguments)
 	nupkgID := strings.TrimSpace(cmdOut)
 
 	// The final output should just be the nupkg id
@@ -157,7 +157,26 @@ func installItem(item catalog.Item, itemURL, cachePath string) string {
 	}
 
 	// Run the command
+<<<<<<< HEAD
+	installerOut, errOut := runCommand(installCmd, installArgs)
+
+	// Write success/failure event to log
+	productStr := item.DisplayName + "-" + item.Version
+
+	if errOut != nil {
+		gorillalog.Warn(productStr, "Installation: FAILED")
+	} else {
+		gorillalog.Info(productStr, "Installation: SUCCESSFUL")
+=======
 	installerOut := runCommand(installCmd, installArgs)
+	
+	// Write success/failure event to log
+	if installerOut != "" {
+		gorillalog.Warn(item.DisplayName, "Installation FAILED")
+	} else {
+		gorillalog.Info(item.DisplayName, "Installation SUCCESSFUL")
+>>>>>>> d12ac79fb20b779d857ed02cde5ca8a67d464ddb
+	}
 
 	// Add the item to InstalledItems in GorillaReport
 	report.InstalledItems = append(report.InstalledItems, item)
@@ -231,15 +250,29 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 	}
 
 	// Run the command
-	uninstallerOut := runCommand(uninstallCmd, uninstallArgs)
+	uninstallerOut, errOut := runCommand(uninstallCmd, uninstallArgs)
+
+	// Write success/failure event to log
+	productStr := item.DisplayName + "-" + item.Version
+
+	if errOut != nil {
+		gorillalog.Warn(productStr, "Installation FAILED")
+	} else {
+		gorillalog.Info(productStr, "Installation SUCCESSFUL")
+	}
+
+	// Write success/failure event to log
+	if uninstallerOut != "" {
+		gorillalog.Warn(item.DisplayName, "Installation FAILED")
+	} else {
+		gorillalog.Info(item.DisplayName, "Installation SUCCESSFUL")
+	}
 
 	// Add the item to InstalledItems in GorillaReport
 	report.UninstalledItems = append(report.UninstalledItems, item)
 
 	return uninstallerOut
 }
-
-
 
 func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded bool, checkErr error) {
 

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -2,15 +2,15 @@ package installer
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
-	"bytes"
-	"io/ioutil"
 
 	"github.com/1dustindavis/gorilla/pkg/catalog"
 	"github.com/1dustindavis/gorilla/pkg/download"
@@ -242,9 +242,9 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 
 	// Write success/failure event to log
 	if errOut != nil {
-		gorillalog.Warn(item.DisplayName, item.Version, "Installation FAILED")
+		gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
 	} else {
-		gorillalog.Info(item.DisplayName, item.Version, "Installation SUCCESSFUL")
+		gorillalog.Info(item.DisplayName, item.Version, "Uninstallation SUCCESSFUL")
 	}
 
 	// Add the item to InstalledItems in GorillaReport

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -157,25 +157,13 @@ func installItem(item catalog.Item, itemURL, cachePath string) string {
 	}
 
 	// Run the command
-<<<<<<< HEAD
 	installerOut, errOut := runCommand(installCmd, installArgs)
 
 	// Write success/failure event to log
-	productStr := item.DisplayName + "-" + item.Version
-
 	if errOut != nil {
-		gorillalog.Warn(productStr, "Installation: FAILED")
+		gorillalog.Warn(item.DisplayName, item.Version, "Installation FAILED")
 	} else {
-		gorillalog.Info(productStr, "Installation: SUCCESSFUL")
-=======
-	installerOut := runCommand(installCmd, installArgs)
-	
-	// Write success/failure event to log
-	if installerOut != "" {
-		gorillalog.Warn(item.DisplayName, "Installation FAILED")
-	} else {
-		gorillalog.Info(item.DisplayName, "Installation SUCCESSFUL")
->>>>>>> d12ac79fb20b779d857ed02cde5ca8a67d464ddb
+		gorillalog.Info(item.DisplayName, item.Version, "Installation SUCCESSFUL")
 	}
 
 	// Add the item to InstalledItems in GorillaReport
@@ -253,19 +241,10 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 	uninstallerOut, errOut := runCommand(uninstallCmd, uninstallArgs)
 
 	// Write success/failure event to log
-	productStr := item.DisplayName + "-" + item.Version
-
 	if errOut != nil {
-		gorillalog.Warn(productStr, "Installation FAILED")
+		gorillalog.Warn(item.DisplayName, item.Version, "Installation FAILED")
 	} else {
-		gorillalog.Info(productStr, "Installation SUCCESSFUL")
-	}
-
-	// Write success/failure event to log
-	if uninstallerOut != "" {
-		gorillalog.Warn(item.DisplayName, "Installation FAILED")
-	} else {
-		gorillalog.Info(item.DisplayName, "Installation SUCCESSFUL")
+		gorillalog.Info(item.DisplayName, item.Version, "Installation SUCCESSFUL")
 	}
 
 	// Add the item to InstalledItems in GorillaReport

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -35,7 +35,7 @@ var (
 	}
 	// CheckOnly flag disabled for testing
 	checkOnlyMode bool = false
-	
+
 	// These catalog items provide test data for each installer type
 	nupkgItem = catalog.Item{
 		Installer: catalog.InstallerItem{

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -65,6 +65,7 @@ var (
 			Location:  `packages/chef-client/chef-client-14.3.37-1-x64uninst.msi`,
 			Type:      `msi`,
 		},
+		Version: "1.2.3",
 	}
 	exeItem = catalog.Item{
 		Installer: catalog.InstallerItem{
@@ -580,4 +581,70 @@ func Example_runCommand() {
 	// --------------------
 	// [Command Test! arg1 arg2]
 	// --------------------
+}
+
+func Example_installItemSuccess() {
+	// Override execCommand and checkStatus with our fake versions
+	execCommand = fakeExecCommand
+	statusCheckStatus = fakeCheckStatus
+	download.SetConfig(downloadCfg)
+	defer func() {
+		execCommand = origExec
+		statusCheckStatus = origCheckStatus
+	}()
+
+	// Set shared testing variables
+	cachePath := "testdata/"
+	urlPackages := "https://example.com/"
+
+	//
+	// Msi
+	//
+	msiItem.DisplayName = statusNoActionNoError
+
+	// Run Install
+	installItem(msiItem, urlPackages, cachePath)
+
+	// Output:
+	// Installing msi for _gorilla_dev_noaction_noerror_
+	// command: C:\Windows\system32\msiexec.exe [/i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
+	// Command Output:
+	// --------------------
+	// [C:\Windows\system32\msiexec.exe /i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
+	// --------------------
+	// _gorilla_dev_noaction_noerror_ 1.2.3 Installation SUCCESSFUL
+
+}
+
+func Example_uninstallItemSuccess() {
+	// Override execCommand and checkStatus with our fake versions
+	execCommand = fakeExecCommand
+	statusCheckStatus = fakeCheckStatus
+	download.SetConfig(downloadCfg)
+	defer func() {
+		execCommand = origExec
+		statusCheckStatus = origCheckStatus
+	}()
+
+	// Set shared testing variables
+	cachePath := "testdata/"
+	urlPackages := "https://example.com/"
+
+	//
+	// Msi
+	//
+	msiItem.DisplayName = statusNoActionNoError
+
+	// Run Install
+	uninstallItem(msiItem, urlPackages, cachePath)
+
+	// Output:
+	// Uninstalling msi for _gorilla_dev_noaction_noerror_
+	// command: C:\Windows\system32\msiexec.exe [/x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
+	// Command Output:
+	// --------------------
+	// [C:\Windows\system32\msiexec.exe /x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
+	// --------------------
+	// _gorilla_dev_noaction_noerror_ 1.2.3 Uninstallation SUCCESSFUL
+
 }

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -155,11 +155,11 @@ func TestRunCommand(t *testing.T) {
 
 	// Define our test command and arguments
 	testCommand := "echo"
-	testArgs := []string{"pizza", "pizza"}
+	testArgs := []string{"pizza", "sushi"}
 	testCmd := append([]string{testCommand}, testArgs...)
 	expectedCmd := fmt.Sprint(testCmd)
 
-	actualCmd := runCommand(testCommand, testArgs)
+	actualCmd, _ := runCommand(testCommand, testArgs)
 
 	// Compare the result with our expectations
 	structsMatch := reflect.DeepEqual(expectedCmd, actualCmd)


### PR DESCRIPTION
This commit adds both `SUCCESSFUL` and `FAILED` messages to the `gorilla.log` file. Without the changes, Gorilla will log warnings if a "command" fails, but Gorilla does not write a log entry after running an `install`, `update`, or `uninstall`. Adding this change will make it easier to parse through the log and allow for quick analysis of just what Gorilla is installing, updating, or uninstalling along with the results of those events.