### PR TITLE
Automated releases with Github Actions! 

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -21,8 +21,5 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v2
 
-    - name: Test
-      run: go test -race -cover ./...
-
     - name: Build
       run: go build -v ./cmd/gorilla

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,0 +1,28 @@
+name:  Ensure PR builds
+
+# Trigger on every pull request to master
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    strategy:
+      matrix:
+        targetplatform: [x64]
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup go
+      uses: actions/setup-go@v2
+
+    - name: Test
+      run: go test -race -cover ./...
+
+    - name: Build
+      run: go build -v ./cmd/gorilla

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -61,6 +61,7 @@ jobs:
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
+        prelease: true
         artifacts: "./cmd/gorilla/gorilla.exe"
         tag: ${{ steps.create_tag.outputs.version_tag }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,66 @@
+name:  Build Release
+
+# Trigger on every master branch push
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    strategy:
+      matrix:
+        targetplatform: [x64]
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup go
+      uses: actions/setup-go@v2
+
+    - name: Get branch & rev
+      run: |
+        echo "Working Path: ${Env:GITHUB_WORKSPACE}"
+        $branchName = $Env:GITHUB_REF -replace 'refs/heads/', ''
+        echo "Branch: ${branchName}"
+        echo "CURRENT_BRANCH=${branchName}" >> $Env:GITHUB_ENV
+        $revision = (git rev-parse HEAD)
+        echo "REVISION=${revision}" >> $Env:GITHUB_ENV
+    - name: Get go version
+      run: |
+        $vers=((go version) -replace "go version go", "" -replace " windows/amd64" )
+        echo "GO_VERSION=${vers}" >> $Env:GITHUB_ENV
+
+    - name: Create version tag
+      id: create_tag
+      uses: paulhatch/semantic-version@v4.0.1
+      with: 
+        tag_prefix: "v"
+        major_pattern: "(MAJOR)"
+        minor_pattern: "/[\\s]*/"
+        format: "${major}.${minor}"
+        namespace: ''
+        short_tags: false
+        bump_each_commit: false
+
+    - name: Build
+      working-directory: ./cmd/gorilla
+      run: |
+        go build -v -ldflags="`
+          -X github.com/1dustindavis/gorilla/pkg/version.appName=gorilla`
+          -X github.com/1dustindavis/gorilla/pkg/version.version=${{ steps.create_tag.outputs.version_tag }}`
+          -X github.com/1dustindavis/gorilla/pkg/version.branch=${{ env.CURRENT_BRANCH }}`
+          -X github.com/1dustindavis/gorilla/pkg/version.buildDate=$(Get-Date -format s)`
+          -X github.com/1dustindavis/gorilla/pkg/version.revision=${{ env.REVISION }}`
+          -X github.com/1dustindavis/gorilla/pkg/version.goVersion=${{ env.GO_VERSION }}"`
+
+    - name: Cut release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: false
+        artifacts: "./cmd/gorilla/gorilla.exe"
+        tag: ${{ steps.create_tag.outputs.version_tag }}
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
What does this PR do? 

- Adds a Github Action to make sure every PR builds and passes tests in `build_pr.yml`
- Adds a second Github Action to automatically build and release `gorilla.exe` on every push to master in build_release.yml. Also the version tag is injected at build time so `gorilla.exe --version` is accurate.

Note: every change is considered a minor release based on the `minor_pattern` regex I wrote. I figured this was the best way to automatically version with reasonably nice version numbers. See build_release.yml and https://github.com/PaulHatch/semantic-version#usage for more context. There are many ways the automatic versioning could work though and I'm happy to make changes as desired.

Please let know if you have feedback or questions! Thanks!