### PR TITLE
Update workflow file with main branch name

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,10 +1,10 @@
-name:  Ensure PR builds
+name: Ensure PR builds
 
-# Trigger on every pull request to master
+# Trigger on every pull request to main
 on:
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   build:
     strategy:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,10 +1,10 @@
-name:  Build Release
+name: Build Release
 
-# Trigger on every master branch push
+# Trigger on every main branch push
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     strategy:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,8 +1,8 @@
 name: go-test
-on: 
+on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   release:
     types:


### PR DESCRIPTION
Since `master` was renamed to `main`, the GitHub workflow files need to be updated to reflect this.