### PR TITLE
Add install/uninstall failure testable examples

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -2,15 +2,15 @@ package installer
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
-	"bytes"
-	"io/ioutil"
 
 	"github.com/1dustindavis/gorilla/pkg/catalog"
 	"github.com/1dustindavis/gorilla/pkg/download"
@@ -242,9 +242,9 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 
 	// Write success/failure event to log
 	if errOut != nil {
-		gorillalog.Warn(item.DisplayName, item.Version, "Installation FAILED")
+		gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
 	} else {
-		gorillalog.Info(item.DisplayName, item.Version, "Installation SUCCESSFUL")
+		gorillalog.Info(item.DisplayName, item.Version, "Uninstallation SUCCESSFUL")
 	}
 
 	// Add the item to InstalledItems in GorillaReport

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -28,6 +28,7 @@ var (
 	// These abstractions allows us to override when testing
 	execCommand       = exec.Command
 	statusCheckStatus = status.CheckStatus
+	runCommand        = runCMD
 
 	// Stores url where we will download an item
 	installerURL   string
@@ -35,7 +36,7 @@ var (
 )
 
 // runCommand executes a command and it's argurments in the CMD environment
-func runCommand(command string, arguments []string) (string, error) {
+func runCMD(command string, arguments []string) (string, error) {
 	cmd := execCommand(command, arguments...)
 	var cmdOutput string
 	cmdReader, err := cmd.StdoutPipe()

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -65,6 +65,7 @@ var (
 			Location:  `packages/chef-client/chef-client-14.3.37-1-x64uninst.msi`,
 			Type:      `msi`,
 		},
+		Version: "1.2.3",
 	}
 	exeItem = catalog.Item{
 		Installer: catalog.InstallerItem{
@@ -580,4 +581,70 @@ func Example_runCommand() {
 	// --------------------
 	// [Command Test! arg1 arg2]
 	// --------------------
+}
+
+func Example_installItemSuccess() {
+	// Override execCommand and checkStatus with our fake versions
+	execCommand = fakeExecCommand
+	statusCheckStatus = fakeCheckStatus
+	download.SetConfig(downloadCfg)
+	defer func() {
+		execCommand = origExec
+		statusCheckStatus = origCheckStatus
+	}()
+
+	// Set shared testing variables
+	cachePath := "testdata/"
+	urlPackages := "https://example.com/"
+
+	//
+	// Msi
+	//
+	msiItem.DisplayName = statusNoActionNoError
+
+	// Run Install
+	installItem(msiItem, urlPackages, cachePath)
+
+	// Output:
+	// Installing msi for _gorilla_dev_noaction_noerror_
+	// command: C:\Windows\system32\msiexec.exe [/i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
+	// Command Output:
+	// --------------------
+	// [C:\Windows\system32\msiexec.exe /i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
+	// --------------------
+	// _gorilla_dev_noaction_noerror_ 1.2.3 Installation SUCCESSFUL
+
+}
+
+func Example_uninstallItemSuccess() {
+	// Override execCommand and checkStatus with our fake versions
+	execCommand = fakeExecCommand
+	statusCheckStatus = fakeCheckStatus
+	download.SetConfig(downloadCfg)
+	defer func() {
+		execCommand = origExec
+		statusCheckStatus = origCheckStatus
+	}()
+
+	// Set shared testing variables
+	cachePath := "testdata/"
+	urlPackages := "https://example.com/"
+
+	//
+	// Msi
+	//
+	msiItem.DisplayName = statusNoActionNoError
+
+	// Run Install
+	uninstallItem(msiItem, urlPackages, cachePath)
+
+	// Output:
+	// Uninstalling msi for _gorilla_dev_noaction_noerror_
+	// command: C:\Windows\system32\msiexec.exe [/x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
+	// Command Output:
+	// --------------------
+	// [C:\Windows\system32\msiexec.exe /x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
+	// --------------------
+	// _gorilla_dev_noaction_noerror_ 1.2.3 Uninstallation SUCCESSFUL
+
 }

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -24,6 +24,7 @@ var (
 	origCheckStatus     = statusCheckStatus
 	origReportInstalled = report.InstalledItems
 	origInstallItemFunc = installItemFunc
+	origRunCommand      = runCommand
 
 	// These tore the URL that `Install` generates during testing
 	installItemURL   string
@@ -111,6 +112,19 @@ func fakeExecCommand(command string, args ...string) *exec.Cmd {
 	cmd := exec.Command(os.Args[0], cs...)
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
 	return cmd
+}
+
+// fakeRunCommand just returns a string and error interface
+func fakeRunCommand(command string, arguments []string) (string, error) {
+	cmdOutput := "This is a fake test command return"
+	var err error
+	if msiItem.DisplayName == statusActionNoError {
+		err = nil
+	} else if msiItem.DisplayName == statusActionError {
+		err = fmt.Errorf("Deliberate test error has occurred!!")
+	}
+
+	return cmdOutput, err
 }
 
 // TestHelperProcess processes the commands passed to fakeExecCommand
@@ -587,10 +601,12 @@ func Example_installItemSuccess() {
 	// Override execCommand and checkStatus with our fake versions
 	execCommand = fakeExecCommand
 	statusCheckStatus = fakeCheckStatus
+	runCommand = fakeRunCommand
 	download.SetConfig(downloadCfg)
 	defer func() {
 		execCommand = origExec
 		statusCheckStatus = origCheckStatus
+		runCommand = origRunCommand
 	}()
 
 	// Set shared testing variables
@@ -600,19 +616,48 @@ func Example_installItemSuccess() {
 	//
 	// Msi
 	//
-	msiItem.DisplayName = statusNoActionNoError
+	msiItem.DisplayName = statusActionNoError
+
+	//
 
 	// Run Install
 	installItem(msiItem, urlPackages, cachePath)
 
 	// Output:
-	// Installing msi for _gorilla_dev_noaction_noerror_
-	// command: C:\Windows\system32\msiexec.exe [/i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
-	// Command Output:
-	// --------------------
-	// [C:\Windows\system32\msiexec.exe /i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
-	// --------------------
-	// _gorilla_dev_noaction_noerror_ 1.2.3 Installation SUCCESSFUL
+	// Installing msi for _gorilla_dev_action_noerror_
+	// _gorilla_dev_action_noerror_ 1.2.3 Installation SUCCESSFUL
+
+}
+
+func Example_installItemFailure() {
+	// Override execCommand and checkStatus with our fake versions
+	execCommand = fakeExecCommand
+	statusCheckStatus = fakeCheckStatus
+	runCommand = fakeRunCommand
+	download.SetConfig(downloadCfg)
+	defer func() {
+		execCommand = origExec
+		statusCheckStatus = origCheckStatus
+		runCommand = origRunCommand
+	}()
+
+	// Set shared testing variables
+	cachePath := "testdata/"
+	urlPackages := "https://example.com/"
+
+	//
+	// Msi
+	//
+	msiItem.DisplayName = statusActionError
+
+	//
+
+	// Run Install
+	installItem(msiItem, urlPackages, cachePath)
+
+	// Output:
+	// Installing msi for _gorilla_dev_action_error_
+	// _gorilla_dev_action_error_ 1.2.3 Installation FAILED
 
 }
 
@@ -620,10 +665,12 @@ func Example_uninstallItemSuccess() {
 	// Override execCommand and checkStatus with our fake versions
 	execCommand = fakeExecCommand
 	statusCheckStatus = fakeCheckStatus
+	runCommand = fakeRunCommand
 	download.SetConfig(downloadCfg)
 	defer func() {
 		execCommand = origExec
 		statusCheckStatus = origCheckStatus
+		runCommand = origRunCommand
 	}()
 
 	// Set shared testing variables
@@ -633,18 +680,43 @@ func Example_uninstallItemSuccess() {
 	//
 	// Msi
 	//
-	msiItem.DisplayName = statusNoActionNoError
+	msiItem.DisplayName = statusActionNoError
 
 	// Run Install
 	uninstallItem(msiItem, urlPackages, cachePath)
 
 	// Output:
-	// Uninstalling msi for _gorilla_dev_noaction_noerror_
-	// command: C:\Windows\system32\msiexec.exe [/x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
-	// Command Output:
-	// --------------------
-	// [C:\Windows\system32\msiexec.exe /x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
-	// --------------------
-	// _gorilla_dev_noaction_noerror_ 1.2.3 Uninstallation SUCCESSFUL
+	// Uninstalling msi for _gorilla_dev_action_noerror_
+	// _gorilla_dev_action_noerror_ 1.2.3 Uninstallation SUCCESSFUL
+
+}
+
+func Example_uninstallItemFailure() {
+	// Override execCommand and checkStatus with our fake versions
+	execCommand = fakeExecCommand
+	statusCheckStatus = fakeCheckStatus
+	runCommand = fakeRunCommand
+	download.SetConfig(downloadCfg)
+	defer func() {
+		execCommand = origExec
+		statusCheckStatus = origCheckStatus
+		runCommand = origRunCommand
+	}()
+
+	// Set shared testing variables
+	cachePath := "testdata/"
+	urlPackages := "https://example.com/"
+
+	//
+	// Msi
+	//
+	msiItem.DisplayName = statusActionError
+
+	// Run Install
+	uninstallItem(msiItem, urlPackages, cachePath)
+
+	// Output:
+	// Uninstalling msi for _gorilla_dev_action_error_
+	// _gorilla_dev_action_error_ 1.2.3 Uninstallation FAILED
 
 }


### PR DESCRIPTION
This PR includes some updated tests. Prior to this, the tests fail on macOS for `installer`. The below text is an example of the failed test(s) on macOS:
```
--- FAIL: Example_installItemSuccess (0.02s)
got:
Installing msi for _gorilla_dev_noaction_noerror_
command: system32/msiexec.exe [/i testdata/packages/chef-client/chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
Command Output:
--------------------
[system32/msiexec.exe /i testdata/packages/chef-client/chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
--------------------
_gorilla_dev_noaction_noerror_ 1.2.3 Installation SUCCESSFUL
want:
Installing msi for _gorilla_dev_noaction_noerror_
command: C:\Windows\system32\msiexec.exe [/i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
Command Output:
--------------------
[C:\Windows\system32\msiexec.exe /i testdata\packages\chef-client\chef-client-14.3.37-1-x64.msi /qn /norestart /L=1033 /S]
--------------------
_gorilla_dev_noaction_noerror_ 1.2.3 Installation SUCCESSFUL
--- FAIL: Example_uninstallItemSuccess (0.01s)
got:
Uninstalling msi for _gorilla_dev_noaction_noerror_
command: system32/msiexec.exe [/x testdata/packages/chef-client/chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
Command Output:
--------------------
[system32/msiexec.exe /x testdata/packages/chef-client/chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
--------------------
_gorilla_dev_noaction_noerror_ 1.2.3 Uninstallation SUCCESSFUL
want:
Uninstalling msi for _gorilla_dev_noaction_noerror_
command: C:\Windows\system32\msiexec.exe [/x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
Command Output:
--------------------
[C:\Windows\system32\msiexec.exe /x testdata\packages\chef-client\chef-client-14.3.37-1-x64uninst.msi /qn /norestart]
--------------------
_gorilla_dev_noaction_noerror_ 1.2.3 Uninstallation SUCCESSFUL
FAIL
FAIL	github.com/1dustindavis/gorilla/pkg/installer	1.182s
```