### PR TITLE
Remove windowStyle from PowerShell arguments

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -149,7 +149,7 @@ func installItem(item catalog.Item, itemURL, cachePath string) string {
 	} else if item.Installer.Type == "ps1" {
 		gorillalog.Info("Installing ps1 for", item.DisplayName)
 		installCmd = commandPs1
-		installArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-WindowStyle", "Normal", "-ExecutionPolicy", "Bypass", "-File", absFile}
+		installArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", absFile}
 
 	} else {
 		msg := fmt.Sprint("Unsupported installer type", item.Installer.Type)
@@ -230,7 +230,7 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 	} else if item.Uninstaller.Type == "ps1" {
 		gorillalog.Info("Uninstalling ps1 for", item.DisplayName)
 		uninstallCmd = commandPs1
-		uninstallArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-WindowStyle", "Normal", "-ExecutionPolicy", "Bypass", "-File", absFile}
+		uninstallArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", absFile}
 
 	} else {
 		msg := fmt.Sprint("Unsupported uninstaller type", item.Uninstaller.Type)
@@ -262,7 +262,7 @@ func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded 
 
 	// Build the command to execute the script
 	psCmd := filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
-	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-WindowStyle", "Normal", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
+	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
 
 	// Execute the script
 	cmd := execCommand(psCmd, psArgs...)
@@ -292,7 +292,7 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 
 	// Build the command to execute the script
 	psCmd := filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
-	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-WindowStyle", "Normal", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
+	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
 
 	// Execute the script
 	cmd := execCommand(psCmd, psArgs...)

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -268,7 +268,7 @@ func TestInstallItem(t *testing.T) {
 	// Check the result
 	ps1Cmd := filepath.Join(os.Getenv("WINDIR"), "system32/WindowsPowershell/v1.0/powershell.exe")
 	ps1File := filepath.Join(pkgCache, ps1Path)
-	expectedPs1 := "[" + ps1Cmd + " -NoProfile -NoLogo -NonInteractive -WindowStyle Normal -ExecutionPolicy Bypass -File " + ps1File + "]"
+	expectedPs1 := "[" + ps1Cmd + " -NoProfile -NoLogo -NonInteractive -ExecutionPolicy Bypass -File " + ps1File + "]"
 	if have, want := actualPs1, expectedPs1; have != want {
 		t.Errorf("\n-----\nhave\n%s\nwant\n%s\n-----", have, want)
 	}
@@ -386,7 +386,7 @@ func TestUninstallItem(t *testing.T) {
 	// Check the result
 	ps1Cmd := filepath.Join(os.Getenv("WINDIR"), "system32/WindowsPowershell/v1.0/powershell.exe")
 	ps1Path := filepath.Clean("testdata/packages/chef-client/chef-client-14.3.37-1-x64uninst.ps1")
-	expectedPs1 := "[" + ps1Cmd + " -NoProfile -NoLogo -NonInteractive -WindowStyle Normal -ExecutionPolicy Bypass -File " + ps1Path + "]"
+	expectedPs1 := "[" + ps1Cmd + " -NoProfile -NoLogo -NonInteractive -ExecutionPolicy Bypass -File " + ps1Path + "]"
 	if have, want := actualPs1, expectedPs1; have != want {
 		t.Errorf("\n-----\nhave\n%s\nwant\n%s\n-----", have, want)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -101,7 +101,7 @@ func checkScript(catalogItem catalog.Item, cachePath string, installType string)
 
 	// Build the command to execute the script
 	psCmd := filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
-	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-WindowStyle", "Normal", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
+	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
 
 	// Execute the script
 	cmd := execCommand(psCmd, psArgs...)


### PR DESCRIPTION
There is a potentially annoying problem with the way PowerShell scripts are executed via a `Script` check and running installers that are `ps1`. In the current state, and admin could have PowerShell open and run `gorilla` in a maximized or minimized window, and since there is a `windowStyle` argument of `Normal` the PowerShell window will always get resized to `Normal` unless the PowerShell window is already in that state/size.

This PR removes the `windowStyle` argument so that the window size/style does not change when `gorilla` is running. So, if an admin is running a maximized PowerShell window and runs `gorilla` the window will not resize.

The PR was tested via local run on Windows 10 after building.