### PR TITLE
Fix startup/script error handling and add main tests

### DIFF
--- a/cmd/gorilla/main_test.go
+++ b/cmd/gorilla/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/1dustindavis/gorilla/pkg/config"
+)
+
+func resetMainHooks() {
+	adminCheckFunc = adminCheck
+	mkdirAllFunc = os.MkdirAll
+}
+
+func TestRunAdminCheckError(t *testing.T) {
+	resetMainHooks()
+	defer resetMainHooks()
+
+	cfg := config.Configuration{CheckOnly: false}
+	adminCheckFunc = func() (bool, error) { return false, errors.New("boom") }
+	mkdirAllFunc = func(path string, mode os.FileMode) error {
+		t.Fatalf("mkdirAllFunc should not be called when admin check errors")
+		return nil
+	}
+
+	err := run(cfg)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "unable to check if running as admin: boom") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunRequiresAdmin(t *testing.T) {
+	resetMainHooks()
+	defer resetMainHooks()
+
+	cfg := config.Configuration{CheckOnly: false}
+	adminCheckFunc = func() (bool, error) { return false, nil }
+	mkdirAllFunc = func(path string, mode os.FileMode) error {
+		t.Fatalf("mkdirAllFunc should not be called when admin check fails")
+		return nil
+	}
+
+	err := run(cfg)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "requires admnisistrative access") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCheckOnlySkipsAdminCheck(t *testing.T) {
+	resetMainHooks()
+	defer resetMainHooks()
+
+	cfg := config.Configuration{CheckOnly: true, CachePath: "some/cache/path"}
+	adminCalled := false
+	adminCheckFunc = func() (bool, error) {
+		adminCalled = true
+		return false, nil
+	}
+	mkdirAllFunc = func(path string, mode os.FileMode) error { return errors.New("mkdir failed") }
+
+	err := run(cfg)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if adminCalled {
+		t.Fatalf("adminCheckFunc should not be called in check-only mode")
+	}
+	if !strings.Contains(err.Error(), "unable to create cache directory: mkdir failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCreateCacheError(t *testing.T) {
+	resetMainHooks()
+	defer resetMainHooks()
+
+	cfg := config.Configuration{CheckOnly: false, CachePath: "some/cache/path"}
+	adminCheckFunc = func() (bool, error) { return true, nil }
+	mkdirAllFunc = func(path string, mode os.FileMode) error { return errors.New("mkdir failed") }
+
+	err := run(cfg)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "unable to create cache directory: mkdir failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/gorillalog/gorillalog.go
+++ b/pkg/gorillalog/gorillalog.go
@@ -43,7 +43,7 @@ func NewLog(cfg config.Configuration) {
 	}
 
 	// Create the log directory
-	logPath := filepath.Join(cfg.AppDataPath, "/gorilla.log")
+	logPath := filepath.Join(cfg.AppDataPath, "gorilla.log")
 	err := os.MkdirAll(filepath.Dir(logPath), 0755)
 	if err != nil {
 		msg := fmt.Sprint("Unable to create directory:", logPath, err)


### PR DESCRIPTION
### PR Summary

This PR applies targeted Go best-practice fixes and adds unit tests for `cmd/gorilla/main.go` startup behavior.

### What changed

- Refactored startup flow in `main.go` to be testable:
  - Introduced `run(cfg)` that returns errors.
  - `main()` now prints the error to stderr and exits with code 1.
- Fixed admin-check error formatting bug:
  - Removed `fmt.Println(...%w...)` misuse by returning wrapped errors from `run`.
- Fixed rooted path join bug in logging:
  - `filepath.Join(cfg.AppDataPath, "/gorilla.log")` -> `filepath.Join(cfg.AppDataPath, "gorilla.log")`.
- Improved script helper robustness and error handling:
  - Ensure script cache directories exist before writing.
  - Return write errors from script temp-file creation.
  - Log temp-file cleanup errors (except `IsNotExist`).

### Files changed

- `cmd/gorilla/main.go`
- `cmd/gorilla/main_test.go` (new)
- `pkg/gorillalog/gorillalog.go`
- `pkg/status/status.go`
- `pkg/installer/installer.go`

### New tests

Added unit tests in `cmd/gorilla/main_test.go` for critical startup paths:

- admin-check returns error
- non-admin execution is rejected
- check-only mode skips admin check
- cache directory creation failure returns error

### Validation

- `go test ./...` passes
- `go build ./...` passes

### Branch / commit

- Branch: `codex/fix-go-best-practices`
- Commit: `30bbc4f`