### PR TITLE
Replace remaining ioutil usage with os/io APIs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -128,7 +127,7 @@ func Get() Configuration {
 	configPath, verbose, debug, checkonly := parseArguments()
 
 	// Read the config file
-	configFile, err := ioutil.ReadFile(configPath)
+	configFile, err := os.ReadFile(configPath)
 	if err != nil {
 		fmt.Println("Unable to read configuration file: ", err)
 		os.Exit(1)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -81,7 +80,7 @@ func Get(url string) ([]byte, error) {
 		}
 
 		// Load server certificates
-		serverCert, err := ioutil.ReadFile(downloadCfg.TLSServerCert)
+		serverCert, err := os.ReadFile(downloadCfg.TLSServerCert)
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +154,7 @@ func Get(url string) ([]byte, error) {
 	}
 
 	// Copy the download to a a buffer
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -102,7 +101,7 @@ func router() *http.ServeMux {
 // TestFileHash verifies that a file is downloaded properly
 func TestFileHash(t *testing.T) {
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +124,7 @@ func TestFileHash(t *testing.T) {
 // TestFileHashLocal verifies that a *local* file is downloaded properly
 func TestFileHashLocal(t *testing.T) {
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +159,7 @@ func TestFileTimeout(t *testing.T) {
 	fmt.Println("Run with '-short' to skip this longer test")
 
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +186,7 @@ func TestFileTimeout(t *testing.T) {
 // TestFileStatus verifies status codes are respected
 func TestFileStatus(t *testing.T) {
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +213,7 @@ func TestFileStatus(t *testing.T) {
 // TestFileBasicAuth verifies username and password are included in headers
 func TestFileBasicAuth(t *testing.T) {
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +240,7 @@ func TestFileBasicAuth(t *testing.T) {
 // TestFileTLS verifies TLS auth is functioning
 func TestFileTLS(t *testing.T) {
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,9 +258,9 @@ func TestFileTLS(t *testing.T) {
 	ts := httptest.NewUnstartedServer(router())
 
 	// Prepare server certs
-	serverCert, _ := ioutil.ReadFile(downloadCfg.TLSServerCert)
-	serverKey, _ := ioutil.ReadFile(serverKeyPath)
-	caCert, _ := ioutil.ReadFile(caCertPath)
+	serverCert, _ := os.ReadFile(downloadCfg.TLSServerCert)
+	serverKey, _ := os.ReadFile(serverKeyPath)
+	caCert, _ := os.ReadFile(caCertPath)
 
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(caCert)
@@ -329,7 +328,7 @@ func copy(src, dst string) error {
 func TestIfNeededValid(t *testing.T) {
 
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +376,7 @@ func TestIfNeededValid(t *testing.T) {
 func TestIfNeededInvalid(t *testing.T) {
 
 	// Create a temporary directory
-	dir, err := ioutil.TempDir("", "gorilla_test")
+	dir, err := os.MkdirTemp("", "gorilla_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -2,7 +2,6 @@ package installer
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -566,7 +565,7 @@ func TestUninstallURL(t *testing.T) {
 // Example_runCommand tests the output when running a command in debug
 func Example_runCommand() {
 	// Temp directory for logging
-	logTmp, _ := ioutil.TempDir("", "gorilla-installer_test")
+	logTmp, _ := os.MkdirTemp("", "gorilla-installer_test")
 
 	// Setup a testing Configuration struct with debug mode
 	cfgVerbose := config.Configuration{

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/1dustindavis/gorilla/pkg/config"
@@ -124,7 +123,7 @@ func Get(cfg config.Configuration) (manifests []Item, newCatalogs []string) {
 		for _, manifest := range cfg.LocalManifests {
 			var localManifest Item
 			gorillalog.Info("Manifest File:", manifest)
-			localManifestsYaml, err := ioutil.ReadFile(manifest)
+			localManifestsYaml, err := os.ReadFile(manifest)
 			if err != nil {
 				gorillalog.Warn("Unable to parse yaml manifest: ", manifest, err)
 			}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -3,7 +3,6 @@ package report
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -79,7 +78,7 @@ func End() {
 
 	// Write Items to disk as GorillaReport.json
 	reportPath := filepath.Join(os.Getenv("ProgramData"), "gorilla/GorillaReport.json")
-	writeErr := ioutil.WriteFile(reportPath, reportJSON, 0644)
+	writeErr := os.WriteFile(reportPath, reportJSON, 0644)
 	if writeErr != nil {
 		fmt.Println("Unable to write GorillaReport.json to disk:", writeErr)
 	}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -19,7 +18,7 @@ var (
 	origRegistryItems = RegistryItems
 
 	// Temp directory for logging
-	logTmp, _ = ioutil.TempDir("", "gorilla-status_test")
+	logTmp, _ = os.MkdirTemp("", "gorilla-status_test")
 
 	// Setup a testing Configuration struct
 	cfgVerbose = config.Configuration{


### PR DESCRIPTION
### PR Summary

This PR removes all remaining deprecated `ioutil` usage and migrates to modern `os`/`io` APIs.

### What changed

- Replaced `ioutil.ReadFile` with `os.ReadFile`
- Replaced `ioutil.ReadAll` with `io.ReadAll`
- Replaced `ioutil.WriteFile` with `os.WriteFile`
- Replaced `ioutil.TempDir` with `os.MkdirTemp`
- Removed stale `io/ioutil` imports in updated files

### Files updated

- `pkg/config/config.go`
- `pkg/download/download.go`
- `pkg/download/download_test.go`
- `pkg/installer/installer_test.go`
- `pkg/manifest/manifest.go`
- `pkg/report/report.go`
- `pkg/status/status_test.go`

### Why

`ioutil` has been deprecated for multiple Go releases. This aligns the codebase with current Go best practices and avoids future churn.

### Validation

- `go test ./...` passes
- `go build ./...` passes
- Verified no remaining `ioutil` usage under `cmd`/`pkg`

### Branch / commit

- Branch: `codex/remove-ioutil`
- Commit: `508cd55`