### PR TITLE
Improve item validation handling

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -15,8 +15,9 @@ import (
 	"github.com/1dustindavis/gorilla/pkg/manifest"
 )
 
-// firstItem returns the first occurrence of an item in a map of catalogs
-func firstItem(itemName string, catalogsMap map[int]map[string]catalog.Item) (catalog.Item, error) {
+// firstItem returns the first valid occurrence of an item in a map of catalogs.
+// It logs warnings for invalid/missing items and returns false when no valid item is found.
+func firstItem(itemName string, catalogsMap map[int]map[string]catalog.Item) (catalog.Item, bool) {
 	// Get the keys in the map and sort them so we can loop over them in order
 	keys := make([]int, 0)
 	for k := range catalogsMap {
@@ -35,7 +36,7 @@ func firstItem(itemName string, catalogsMap map[int]map[string]catalog.Item) (ca
 			validUninstallItem := (item.Uninstaller.Type != "" && item.Uninstaller.Location != "")
 
 			if validInstallItem || validUninstallItem {
-				return item, nil
+				return item, true
 			}
 
 			missing := []string{}
@@ -55,15 +56,17 @@ func firstItem(itemName string, catalogsMap map[int]map[string]catalog.Item) (ca
 		}
 	}
 
-	// return an empty catalog item if we didnt already find and return a match
+	// No valid item found. Log why and continue processing other items.
 	if len(invalidReasons) > 0 {
-		return catalog.Item{}, fmt.Errorf(
-			"did not find a valid item in any catalog; item %q exists but is missing required type/location fields (%s)",
+		gorillalog.Warn(fmt.Sprintf(
+			"skipping catalog item %q because it is missing required installer/uninstaller type/location fields (%s)",
 			itemName,
 			strings.Join(invalidReasons, "; "),
-		)
+		))
+		return catalog.Item{}, false
 	}
-	return catalog.Item{}, fmt.Errorf("did not find a valid item in any catalog; Item name: %v", itemName)
+	gorillalog.Warn(fmt.Sprintf("skipping item %q because it was not found in any catalog", itemName))
+	return catalog.Item{}, false
 
 }
 
@@ -75,9 +78,7 @@ func Manifests(manifests []manifest.Item, catalogsMap map[int]map[string]catalog
 		for _, item := range manifestItem.Installs {
 			// Check for the first valid item from our catalogs
 			// Continue to the next item in the loop if we get an error
-			_, err := firstItem(item, catalogsMap)
-			if err != nil {
-				gorillalog.Warn(err)
+			if _, ok := firstItem(item, catalogsMap); !ok {
 				continue
 			}
 
@@ -88,9 +89,7 @@ func Manifests(manifests []manifest.Item, catalogsMap map[int]map[string]catalog
 		for _, item := range manifestItem.Uninstalls {
 			// Check for the first valid item from our catalogs
 			// Continue to the next item in the loop if we get an error
-			_, err := firstItem(item, catalogsMap)
-			if err != nil {
-				gorillalog.Warn(err)
+			if _, ok := firstItem(item, catalogsMap); !ok {
 				continue
 			}
 
@@ -101,9 +100,7 @@ func Manifests(manifests []manifest.Item, catalogsMap map[int]map[string]catalog
 		for _, item := range manifestItem.Updates {
 			// Check for the first valid item from our catalogs
 			// Continue to the next item in the loop if we get an error
-			_, err := firstItem(item, catalogsMap)
-			if err != nil {
-				gorillalog.Warn(err)
+			if _, ok := firstItem(item, catalogsMap); !ok {
 				continue
 			}
 
@@ -123,17 +120,15 @@ func Installs(installs []string, catalogsMap map[int]map[string]catalog.Item, ur
 	for _, item := range installs {
 		// Get the first valid item from our catalogs
 		// Continue to the next item in the loop if we get an error
-		validItem, err := firstItem(item, catalogsMap)
-		if err != nil {
-			gorillalog.Warn(err)
+		validItem, ok := firstItem(item, catalogsMap)
+		if !ok {
 			continue
 		}
 		// Check for dependencies and install if found
 		if len(validItem.Dependencies) > 0 {
 			for _, dependency := range validItem.Dependencies {
-				validDependency, err := firstItem(dependency, catalogsMap)
-				if err != nil {
-					gorillalog.Warn(err)
+				validDependency, ok := firstItem(dependency, catalogsMap)
+				if !ok {
 					continue
 				}
 				installerInstall(validDependency, "install", urlPackages, cachePath, CheckOnly)
@@ -150,9 +145,8 @@ func Uninstalls(uninstalls []string, catalogsMap map[int]map[string]catalog.Item
 	for _, item := range uninstalls {
 		// Get the first valid item from our catalogs
 		// Continue to the next item in the loop if we get an error
-		validItem, err := firstItem(item, catalogsMap)
-		if err != nil {
-			gorillalog.Warn(err)
+		validItem, ok := firstItem(item, catalogsMap)
+		if !ok {
 			continue
 		}
 		// Uninstall the item
@@ -166,9 +160,8 @@ func Updates(updates []string, catalogsMap map[int]map[string]catalog.Item, urlP
 	for _, item := range updates {
 		// Get the first valid item from our catalogs
 		// Continue to the next item in the loop if we get an error
-		validItem, err := firstItem(item, catalogsMap)
-		if err != nil {
-			gorillalog.Warn(err)
+		validItem, ok := firstItem(item, catalogsMap)
+		if !ok {
 			continue
 		}
 		// Update the item

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -172,16 +171,28 @@ func TestManifests(t *testing.T) {
 	}
 }
 
-func TestFirstItemInvalidMessage(t *testing.T) {
-	_, err := firstItem("MissingInstallerType", testCatalogs)
-	if err == nil {
-		t.Fatalf("expected validation error for invalid catalog item")
+func TestFirstItemInvalidReturnsFalse(t *testing.T) {
+	_, ok := firstItem("MissingInstallerType", testCatalogs)
+	if ok {
+		t.Fatalf("expected invalid catalog item to be skipped")
 	}
-	if !strings.Contains(err.Error(), "missing required type/location fields") {
-		t.Fatalf("expected missing field warning in error, got: %v", err)
+
+	_, ok = firstItem("MissingInstallerLocation", testCatalogs)
+	if ok {
+		t.Fatalf("expected invalid catalog item to be skipped")
 	}
-	if !strings.Contains(err.Error(), "installer.type") {
-		t.Fatalf("expected specific missing installer.type field in error, got: %v", err)
+
+	_, ok = firstItem("DoesNotExist", testCatalogs)
+	if ok {
+		t.Fatalf("expected missing catalog item to be skipped")
+	}
+
+	item, ok := firstItem("Chocolatey", testCatalogs)
+	if !ok {
+		t.Fatalf("expected valid catalog item")
+	}
+	if item.DisplayName != "Chocolatey" {
+		t.Fatalf("unexpected item returned: %#v", item)
 	}
 }
 


### PR DESCRIPTION
This PR updates catalog item validation behavior in `pkg/process` to **warn and continue** instead of treating invalid items as errors.

### What changed
- `firstItem` now returns `(catalog.Item, bool)` and logs warnings when:
  - an item exists but is missing required installer/uninstaller `type` or `location`
  - an item is not found in any catalog
- Manifest and install/update/uninstall processing now skips invalid/missing items cleanly and continues with the rest.
- Added/updated tests in `pkg/process/process_test.go` to confirm:
  - invalid items are excluded from manifest processing
  - invalid/missing lookups return `ok == false`
  - valid lookups still return expected items