### PR TITLE
Fix update check-script behavior and fix example config syntax

### DIFF
--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -1,7 +1,8 @@
 ---
 url: https://example.com/gorilla/
 manifest: example_manifest
-catalog: example_catalog
+catalogs:
+  - example_catalog
 app_data_path: c:/cpe/gorilla/cache
 # auth_user: johnny
 # auth_pass: pizza

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -130,7 +130,7 @@ func checkScript(catalogItem catalog.Item, cachePath string, installType string)
 	// Application not installed if exit 0
 	if installType == "uninstall" {
 		actionNeeded = !cmdSuccess
-	} else if installType == "install" {
+	} else if installType == "install" || installType == "update" {
 		actionNeeded = cmdSuccess
 	}
 

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -285,6 +285,22 @@ func TestCheckScript(t *testing.T) {
 		fmt.Printf("action: %v; error: %v\n", actionNeeded, err)
 		t.Errorf("Expected checkScript to action and no error")
 	}
+
+	// Set cachepath and run checkScript for scriptActionNoError as update
+	cachepath = fmt.Sprintf("testdata/%s/", statusActionNoError)
+	actionNeeded, err = checkScript(scriptActionNoError, cachepath, "update")
+	if !actionNeeded || err != nil {
+		fmt.Printf("action: %v; error: %v\n", actionNeeded, err)
+		t.Errorf("Expected checkScript update to action and no error")
+	}
+
+	// Set cachepath and run checkScript for scriptNoActionNoError as update
+	cachepath = fmt.Sprintf("testdata/%s/", statusNoActionNoError)
+	actionNeeded, err = checkScript(scriptNoActionNoError, cachepath, "update")
+	if actionNeeded || err != nil {
+		fmt.Printf("action: %v; error: %v\n", actionNeeded, err)
+		t.Errorf("Expected checkScript update to no action and no error")
+	}
 }
 
 // TestCheckPath validates that the status of a path is checked correctly


### PR DESCRIPTION
This PR fixes two open issues:

- **#123** (`managed_updates` script checks):
  - Updated `pkg/status/status.go` so `checkScript` treats `installType == "update"` like install when mapping script exit status to `actionNeeded`.
  - Added test coverage in `pkg/status/status_test.go` for update mode:
    - update + success exit -> action needed
    - update + failure exit -> no action needed

- **#82** (outdated examples syntax):
  - Updated `examples/example_config.yaml` to use the correct config key:
    - from `catalog: example_catalog`
    - to:
      - `catalogs:`
      - `  - example_catalog`