### PR TITLE
Warn and continue when individual catalogs fail to load

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -83,22 +83,24 @@ func Get(cfg config.Configuration) map[int]map[string]Item {
 	// Loop through the catalogs and get each one in order
 	for _, catalog := range cfg.Catalogs {
 
-		catalogCount++
-
 		// Download the catalog
 		catalogURL := cfg.URL + "catalogs/" + catalog + ".yaml"
 		gorillalog.Info("Catalog Url:", catalogURL)
 		yamlFile, err := downloadGet(catalogURL)
 		if err != nil {
-			gorillalog.Error("Unable to retrieve catalog: ", err)
+			gorillalog.Warn("Unable to retrieve catalog, skipping:", catalogURL, err)
+			continue
 		}
 
 		// Parse the catalog
 		var catalogItems map[string]Item
 		err = yaml.Unmarshal(yamlFile, &catalogItems)
 		if err != nil {
-			gorillalog.Error("Unable to parse yaml catalog: ", err)
+			gorillalog.Warn("Unable to parse yaml catalog, skipping:", catalogURL, err)
+			continue
 		}
+
+		catalogCount++
 
 		// Add the new parsed catalog items to the catalogMap
 		catalogMap[catalogCount] = catalogItems

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -23,8 +24,21 @@ func fakeDownload(string string) ([]byte, error) {
 	return yamlBytes, nil
 }
 
+func fakeDownloadByURL(payloads map[string][]byte, failures map[string]error) func(string) ([]byte, error) {
+	return func(url string) ([]byte, error) {
+		if err, ok := failures[url]; ok {
+			return nil, err
+		}
+		if body, ok := payloads[url]; ok {
+			return body, nil
+		}
+		return nil, fmt.Errorf("unexpected URL in test: %s", url)
+	}
+}
+
 // TestGet verifies that a valid catlog is parsed correctly and returns the expected map
 func TestGet(t *testing.T) {
+	expected = make(map[string]Item)
 	// Set what we expect Get() to return
 	expected[`ChefClient`] = Item{
 		Dependencies: []string{`ruby`},
@@ -60,6 +74,8 @@ If ($upToDate) {
 	}
 
 	// Override the downloadFile function with our fake function
+	origDownload := downloadGet
+	defer func() { downloadGet = origDownload }()
 	downloadGet = fakeDownload
 
 	// Run `Get`
@@ -69,5 +85,86 @@ If ($upToDate) {
 
 	if !mapsMatch {
 		t.Errorf("\n\nExpected:\n\n%#v\n\nReceived:\n\n %#v", expected, testCatalog[1])
+	}
+}
+
+func TestGetSkipsMissingCatalog(t *testing.T) {
+	baseCatalog := map[string]Item{
+		"Chrome": {
+			DisplayName: "Chrome",
+			Installer: InstallerItem{
+				Type:     "nupkg",
+				Location: "packages/chrome/chrome.nupkg",
+				Hash:     "abc",
+			},
+		},
+	}
+	baseYAML, err := yaml.Marshal(baseCatalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Configuration{
+		URL:      "https://example.com/",
+		Catalogs: []string{"base", "missing"},
+	}
+
+	origDownload := downloadGet
+	defer func() { downloadGet = origDownload }()
+	downloadGet = fakeDownloadByURL(
+		map[string][]byte{
+			"https://example.com/catalogs/base.yaml": baseYAML,
+		},
+		map[string]error{
+			"https://example.com/catalogs/missing.yaml": errors.New("404"),
+		},
+	)
+
+	got := Get(cfg)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 successfully loaded catalog, got %d", len(got))
+	}
+	if _, ok := got[1]["Chrome"]; !ok {
+		t.Fatalf("expected Chrome item to be loaded from valid catalog")
+	}
+}
+
+func TestGetSkipsInvalidYAML(t *testing.T) {
+	baseCatalog := map[string]Item{
+		"ChefClient": {
+			DisplayName: "Chef Client",
+			Installer: InstallerItem{
+				Type:     "msi",
+				Location: "packages/chef/chef.msi",
+				Hash:     "abc",
+			},
+		},
+	}
+	baseYAML, err := yaml.Marshal(baseCatalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Configuration{
+		URL:      "https://example.com/",
+		Catalogs: []string{"valid", "broken"},
+	}
+
+	origDownload := downloadGet
+	defer func() { downloadGet = origDownload }()
+	downloadGet = fakeDownloadByURL(
+		map[string][]byte{
+			"https://example.com/catalogs/valid.yaml":  baseYAML,
+			"https://example.com/catalogs/broken.yaml": []byte(":\n- not valid yaml"),
+		},
+		nil,
+	)
+
+	got := Get(cfg)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 successfully parsed catalog, got %d", len(got))
+	}
+	if _, ok := got[1]["ChefClient"]; !ok {
+		t.Fatalf("expected ChefClient item to be loaded from valid catalog")
 	}
 }


### PR DESCRIPTION
This PR fixes issue #84 by making catalog loading resilient to individual catalog failures.

### What changed

- Updated `pkg/catalog/catalog.go` so `catalog.Get` now:
  - **warns and skips** when a catalog download fails
  - **warns and skips** when a catalog YAML parse fails
  - continues processing remaining catalogs instead of aborting the run

### Test updates

- Added `TestGetSkipsMissingCatalog` in `pkg/catalog/catalog_test.go`
  - verifies one missing catalog does not prevent loading a valid one
- Added `TestGetSkipsInvalidYAML` in `pkg/catalog/catalog_test.go`
  - verifies one malformed catalog does not prevent loading a valid one
- Updated existing test isolation by restoring `downloadGet` after tests

### Result

Gorilla now continues with available/valid catalogs and logs warnings for the ones that fail, instead of panicking or stopping the run.