### PR TITLE
Handle ambiguous nupkg IDs and add package_id override

### DIFF
--- a/examples/example_catalog.yaml
+++ b/examples/example_catalog.yaml
@@ -8,6 +8,7 @@ GoogleChrome:
   installer:
     hash: ce9c44417489d6c1f205422a4b9e8d5181d1ac24b6dcae3bd68ec315efdeb18b
     location: packages/google-chrome/GoogleChrome.68.0.3440.106.nupkg
+    package_id: GoogleChrome
     type: nupkg
   version: 68.0.3440.106
 
@@ -18,6 +19,7 @@ ColorPrinter:
   installer:
     hash: a8b4ff8bc7d77036644c1ed04713c550550f180e08da786fbca784818b918dac
     location: packages/colorprinter.1.0.nupkg
+    package_id: colorprinter
     type: nupkg
   version: 1.0
 
@@ -26,6 +28,7 @@ CanonDrivers:
   installer:
     hash: ca784818b91850f180e08da786ac1ed04713c5a8b4ff8bc7d77036644dac505aec
     location: packages/Canon-Drivers.1.0.nupkg
+    package_id: Canon-Drivers
     type: nupkg
   version: 1.0
 

--- a/examples/example_package-info.yaml
+++ b/examples/example_package-info.yaml
@@ -8,6 +8,7 @@ check:
 installer:
   hash: ce9c44417489d6c1f205422a4b9e8d5181d1ac24b6dcae3bd68ec315efdeb18b
   location: packages/google-chrome/GoogleChrome.68.0.3440.106.nupkg
+  package_id: GoogleChrome
   type: nupkg
 version: 68.0.3440.106
 catalog: testcatalog

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -29,6 +29,7 @@ type InstallerItem struct {
 	Type      string   `yaml:"type"`
 	Location  string   `yaml:"location"`
 	Hash      string   `yaml:"hash"`
+	PackageID string   `yaml:"package_id"`
 	Arguments []string `yaml:"arguments"`
 }
 


### PR DESCRIPTION
Implemented safer nupkg package selection and added explicit package ID support.

- Added optional `package_id` on installer/uninstaller entries so admins can explicitly set the Chocolatey package ID (`pkg/catalog/catalog.go`).
- Changed nupkg ID discovery to parse all IDs returned by `choco list` and fail fast when results are ambiguous or empty, instead of implicitly choosing one (`pkg/installer/installer.go`).
- Updated install/uninstall nupkg flows to:
  - prefer explicit `package_id` when provided
  - otherwise auto-discover only when unambiguous
  - return a clear warning/error message if not resolvable (`pkg/installer/installer.go`).
- Added tests covering explicit `package_id` behavior and ambiguous-ID failure cases for both install and uninstall (`pkg/installer/installer_test.go`).
- Updated catalog examples to show `package_id` usage for nupkg items (`examples/example_catalog.yaml`, `examples/example_package-info.yaml`).