### PR TITLE
Make slash-command PR feedback non-blocking

### DIFF
--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -15,6 +15,7 @@ permissions:
   actions: read
   checks: write
   issues: write
+  pull-requests: write
 
 jobs:
   integration:
@@ -36,6 +37,7 @@ jobs:
       - name: Resolve PR head sha
         if: github.event_name == 'issue_comment'
         id: pr_meta
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -47,6 +49,7 @@ jobs:
       - name: Create in-progress check run
         if: github.event_name == 'issue_comment'
         id: check_start
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -69,6 +72,7 @@ jobs:
       - name: Comment start on PR
         if: github.event_name == 'issue_comment'
         id: comment_start
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -142,6 +146,7 @@ jobs:
 
       - name: Finalize check run
         if: always() && github.event_name == 'issue_comment' && steps.check_start.outputs.check_run_id != ''
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -168,6 +173,7 @@ jobs:
 
       - name: Finalize PR comment
         if: always() && github.event_name == 'issue_comment' && steps.comment_start.outputs.comment_id != ''
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Changes in `.github/workflows/windows-release-integration.yml`:
- Added `pull-requests: write` permission.
- Marked PR feedback steps as non-blocking (`continue-on-error: true`):
  - `Resolve PR head sha`
  - `Create in-progress check run`
  - `Comment start on PR`
  - `Finalize check run`
  - `Finalize PR comment`

Result:
- `/run-integration-test` won’t fail just because comment/check write is blocked in a specific token context.
- Core integration run still executes; PR feedback is best-effort.