### PR TITLE
Validate InstallItem flow and state convergence

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Models/UiOptionalInstallItem.cs
@@ -24,7 +24,17 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
         }
     }
 
-    public bool IsInstalled { get; init; }
+    private bool _isInstalled;
+
+    public bool IsInstalled
+    {
+        get => _isInstalled;
+        set
+        {
+            _isInstalled = value;
+            OnPropertyChanged();
+        }
+    }
 
     public bool IsBusy
     {

--- a/gorilla-ui/src/Gorilla.UI.App/Services/OperationTracker.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Services/OperationTracker.cs
@@ -14,15 +14,18 @@ public sealed class OperationTracker
         _client = client;
     }
 
-    public async Task TrackAsync(
+    public async Task<OperationStatusEvent?> TrackAsync(
         string operationId,
         Action<OperationStatusEvent> onUpdate,
         CancellationToken cancellationToken
     )
     {
+        OperationStatusEvent? latest = null;
         await foreach (var update in _client.StreamOperationStatusAsync(operationId, cancellationToken))
         {
+            latest = update;
             onUpdate(update);
         }
+        return latest;
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.App/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/ViewModels/HomeViewModel.cs
@@ -68,7 +68,11 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
             try
             {
-                await _operationTracker.TrackAsync(accepted.OperationId, update => ApplyOperationUpdate(item, update), cancellationToken);
+                var terminal = await _operationTracker.TrackAsync(accepted.OperationId, update => ApplyOperationUpdate(item, update), cancellationToken);
+                if (terminal is not null)
+                {
+                    await RefreshItemsFromServiceAsync(cancellationToken);
+                }
             }
             catch (Exception ex)
             {
@@ -95,7 +99,11 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
             try
             {
-                await _operationTracker.TrackAsync(accepted.OperationId, update => ApplyOperationUpdate(item, update), cancellationToken);
+                var terminal = await _operationTracker.TrackAsync(accepted.OperationId, update => ApplyOperationUpdate(item, update), cancellationToken);
+                if (terminal is not null)
+                {
+                    await RefreshItemsFromServiceAsync(cancellationToken);
+                }
             }
             catch (Exception ex)
             {
@@ -151,6 +159,12 @@ public sealed class HomeViewModel : INotifyPropertyChanged
                 IsInstalled = item.IsInstalled,
             });
         }
+    }
+
+    private async Task RefreshItemsFromServiceAsync(CancellationToken cancellationToken)
+    {
+        var latest = await _client.ListOptionalInstallsAsync(cancellationToken);
+        ApplyItems(latest);
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/gorilla-ui/src/Gorilla.UI.App/WINDOWS_VM_EXECUTION.md
+++ b/gorilla-ui/src/Gorilla.UI.App/WINDOWS_VM_EXECUTION.md
@@ -89,3 +89,42 @@ Record results in PR notes with:
 - observed first-render list
 - observed post-refresh list
 - observed stale-data warning text
+
+## 7. Reproducible install validation against live service responses (TODO #4)
+Use these exact steps to validate operation acceptance, `operationId` handling, and item-state convergence with live data.
+
+1. Pick a target optional install item that is currently not installed.
+   - Confirm baseline with:
+     - `dotnet run --project gorilla-ui/tools/PipeHarness -- list`
+   - Record the target item and baseline status.
+2. Submit install and capture operation acceptance.
+   - Run:
+     - `dotnet run --project gorilla-ui/tools/PipeHarness -- install <itemName>`
+   - Expected:
+     - command prints a non-empty `operationId`
+     - acceptance is true
+     - queued timestamp is present
+3. Validate stream correlation and terminal event.
+   - Run:
+     - `dotnet run --project gorilla-ui/tools/PipeHarness -- stream <operationId>`
+   - Expected:
+     - stream acknowledgement uses the same `operationId`
+     - lifecycle includes queued/in-progress states and ends in a terminal state
+4. Validate UI state convergence after success.
+   - Launch Gorilla UI and install the same item.
+   - Expected:
+     - UI shows in-progress status while streaming.
+     - On terminal success, the item list refreshes from service data.
+     - The installed item converges to installed state (`IsInstalled=true` via refreshed list).
+5. Validate service truth after UI action.
+   - Re-run:
+     - `dotnet run --project gorilla-ui/tools/PipeHarness -- list`
+   - Expected:
+     - installed item state matches the UI post-success state.
+
+Record results in PR notes with:
+- VM image/build identifier
+- target item name
+- install acceptance output (`accepted`, `operationId`, `queuedAtUtc`)
+- observed stream states (first state + terminal state)
+- UI status during operation and final converged installed state

--- a/gorilla-ui/src/Gorilla.UI.App/template/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/template/Models/UiOptionalInstallItem.cs
@@ -25,7 +25,17 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
         }
     }
 
-    public bool IsInstalled { get; init; }
+    private bool _isInstalled;
+
+    public bool IsInstalled
+    {
+        get => _isInstalled;
+        set
+        {
+            _isInstalled = value;
+            OnPropertyChanged();
+        }
+    }
 
     public bool IsBusy
     {

--- a/gorilla-ui/src/Gorilla.UI.App/template/Services/OperationTracker.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/template/Services/OperationTracker.cs
@@ -11,15 +11,18 @@ public sealed class OperationTracker
         _client = client;
     }
 
-    public async Task TrackAsync(
+    public async Task<OperationStatusEvent?> TrackAsync(
         string operationId,
         Action<OperationStatusEvent> onUpdate,
         CancellationToken cancellationToken
     )
     {
+        OperationStatusEvent? latest = null;
         await foreach (var update in _client.StreamOperationStatusAsync(operationId, cancellationToken))
         {
+            latest = update;
             onUpdate(update);
         }
+        return latest;
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.App/template/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/template/ViewModels/HomeViewModel.cs
@@ -56,7 +56,11 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         try
         {
             var accepted = await _client.InstallItemAsync(item.ItemName, cancellationToken);
-            await _operationTracker.TrackAsync(accepted.OperationId, _ => { }, cancellationToken);
+            var terminal = await _operationTracker.TrackAsync(accepted.OperationId, _ => { }, cancellationToken);
+            if (terminal is not null)
+            {
+                await RefreshItemsFromServiceAsync(cancellationToken);
+            }
         }
         finally
         {
@@ -70,7 +74,11 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         try
         {
             var accepted = await _client.RemoveItemAsync(item.ItemName, cancellationToken);
-            await _operationTracker.TrackAsync(accepted.OperationId, _ => { }, cancellationToken);
+            var terminal = await _operationTracker.TrackAsync(accepted.OperationId, _ => { }, cancellationToken);
+            if (terminal is not null)
+            {
+                await RefreshItemsFromServiceAsync(cancellationToken);
+            }
         }
         finally
         {
@@ -97,6 +105,12 @@ public sealed class HomeViewModel : INotifyPropertyChanged
                 IsInstalled = item.IsInstalled,
             });
         }
+    }
+
+    private async Task RefreshItemsFromServiceAsync(CancellationToken cancellationToken)
+    {
+        var latest = await _client.ListOptionalInstallsAsync(cancellationToken);
+        ApplyItems(latest);
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
@@ -51,6 +51,7 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
             requestEnvelope,
             cancellationToken
         );
+        ProtocolValidation.ValidateOperationAccepted(responseEnvelope.OperationId, responseEnvelope.Payload);
 
         return new OperationAccepted(
             OperationId: responseEnvelope.OperationId,
@@ -72,6 +73,7 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
             requestEnvelope,
             cancellationToken
         );
+        ProtocolValidation.ValidateOperationAccepted(responseEnvelope.OperationId, responseEnvelope.Payload);
 
         return new OperationAccepted(
             OperationId: responseEnvelope.OperationId,

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
@@ -61,4 +61,17 @@ public static class ProtocolValidation
             throw new ProtocolValidationException("canceledBy is required when state is Canceled.");
         }
     }
+
+    public static void ValidateOperationAccepted(string operationId, OperationAcceptedResponse payload)
+    {
+        if (payload.Accepted && string.IsNullOrWhiteSpace(operationId))
+        {
+            throw new ProtocolValidationException("operationId is required when operation is accepted.");
+        }
+
+        if (payload.Accepted && payload.QueuedAtUtc == default)
+        {
+            throw new ProtocolValidationException("queuedAtUtc is required when operation is accepted.");
+        }
+    }
 }

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/Gorilla.UI.App.WindowsUiTests.csproj
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/Gorilla.UI.App.WindowsUiTests.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Gorilla.UI.App/Gorilla.UI.App.csproj" />
+  </ItemGroup>
 </Project>

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomeViewModelInstallFlowTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomeViewModelInstallFlowTests.cs
@@ -1,0 +1,211 @@
+using Gorilla.UI.App.Models;
+using Gorilla.UI.App.Services;
+using Gorilla.UI.App.ViewModels;
+using Gorilla.UI.Client;
+using Xunit;
+
+namespace Gorilla.UI.App.WindowsUiTests;
+
+public sealed class HomeViewModelInstallFlowTests
+{
+    [Fact]
+    public async Task InstallAsync_SucceededTerminalState_RefreshesItemsFromService()
+    {
+        var state = new FakeState();
+        state.ListResponses.Enqueue(
+            [
+                BuildItem("Slack", isInstalled: true, status: OptionalInstallStatus.Installed),
+            ]
+        );
+        state.InstallResult = new OperationAccepted(
+            OperationId: "op-install-1",
+            Accepted: true,
+            QueuedAtUtc: DateTimeOffset.Parse("2026-03-01T18:10:00Z")
+        );
+        state.StreamEvents =
+        [
+            BuildStatus("op-install-1", OperationState.Queued, "queued"),
+            BuildStatus("op-install-1", OperationState.Installing, "installing"),
+            BuildStatus("op-install-1", OperationState.Succeeded, "done"),
+        ];
+
+        var client = new FakeClient(state);
+        var cacheCoordinator = new OptionalInstallsCacheCoordinator(client, new InMemoryCacheStore(null));
+        var tracker = new OperationTracker(client);
+        var viewModel = new HomeViewModel(client, cacheCoordinator, tracker);
+
+        viewModel.Items.Add(new UiOptionalInstallItem
+        {
+            ItemName = "Slack",
+            DisplayName = "Slack",
+            Version = "1.0.0",
+            Status = OptionalInstallStatus.NotInstalled.ToString(),
+            IsInstalled = false,
+        });
+
+        var item = viewModel.FindItem("Slack");
+        Assert.NotNull(item);
+
+        await viewModel.InstallAsync(item!, CancellationToken.None);
+
+        var updated = viewModel.FindItem("Slack");
+        Assert.NotNull(updated);
+        Assert.True(updated!.IsInstalled);
+        Assert.Equal(OptionalInstallStatus.Installed.ToString(), updated.Status);
+        Assert.Equal(1, state.ListCalls);
+    }
+
+    [Fact]
+    public async Task InstallAsync_FailedTerminalState_RefreshesItemsFromService()
+    {
+        var state = new FakeState();
+        state.ListResponses.Enqueue(
+            [
+                BuildItem("Slack", isInstalled: false, status: OptionalInstallStatus.NotInstalled),
+            ]
+        );
+        state.InstallResult = new OperationAccepted(
+            OperationId: "op-install-2",
+            Accepted: true,
+            QueuedAtUtc: DateTimeOffset.Parse("2026-03-01T18:10:00Z")
+        );
+        state.StreamEvents =
+        [
+            BuildStatus("op-install-2", OperationState.Queued, "queued"),
+            BuildStatus("op-install-2", OperationState.Failed, "failed", errorMessage: "install failed"),
+        ];
+
+        var client = new FakeClient(state);
+        var cacheCoordinator = new OptionalInstallsCacheCoordinator(client, new InMemoryCacheStore(null));
+        var tracker = new OperationTracker(client);
+        var viewModel = new HomeViewModel(client, cacheCoordinator, tracker);
+
+        viewModel.Items.Add(new UiOptionalInstallItem
+        {
+            ItemName = "Slack",
+            DisplayName = "Slack",
+            Version = "1.0.0",
+            Status = OptionalInstallStatus.NotInstalled.ToString(),
+            IsInstalled = false,
+        });
+
+        var item = viewModel.FindItem("Slack");
+        Assert.NotNull(item);
+
+        await viewModel.InstallAsync(item!, CancellationToken.None);
+
+        var unchanged = viewModel.FindItem("Slack");
+        Assert.NotNull(unchanged);
+        Assert.False(unchanged!.IsInstalled);
+        Assert.Equal(1, state.ListCalls);
+        Assert.Contains("Failed", viewModel.WarningBanner);
+    }
+
+    private static OptionalInstallItem BuildItem(string itemName, bool isInstalled, OptionalInstallStatus status)
+    {
+        return new OptionalInstallItem(
+            ItemName: itemName,
+            DisplayName: itemName,
+            Version: "1.0.0",
+            Catalog: "testcatalog",
+            InstallerType: "nupkg",
+            InstallerPackageId: itemName,
+            InstallerLocation: $"packages/{itemName}/{itemName}.nupkg",
+            IsManaged: true,
+            IsInstalled: isInstalled,
+            Status: status,
+            StatusUpdatedAtUtc: DateTimeOffset.Parse("2026-03-01T18:10:00Z"),
+            LastOperationId: null
+        );
+    }
+
+    private static OperationStatusEvent BuildStatus(
+        string operationId,
+        OperationState state,
+        string message,
+        string? errorMessage = null
+    )
+    {
+        return new OperationStatusEvent(
+            OperationId: operationId,
+            State: state,
+            ProgressPercent: 50,
+            Message: message,
+            TimestampUtc: DateTimeOffset.Parse("2026-03-01T18:10:00Z"),
+            ErrorCode: state == OperationState.Failed ? "failed" : null,
+            ErrorMessage: errorMessage,
+            CanceledBy: state == OperationState.Canceled ? "service" : null
+        );
+    }
+
+    private sealed class FakeState
+    {
+        public Queue<IReadOnlyList<OptionalInstallItem>> ListResponses { get; } = new();
+        public OperationAccepted InstallResult { get; set; } = new("op-default", true, DateTimeOffset.UtcNow);
+        public IReadOnlyList<OperationStatusEvent> StreamEvents { get; set; } = [];
+        public int ListCalls { get; set; }
+    }
+
+    private sealed class FakeClient : IGorillaServiceClient
+    {
+        private readonly FakeState _state;
+
+        public FakeClient(FakeState state)
+        {
+            _state = state;
+        }
+
+        public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
+        {
+            _state.ListCalls++;
+            if (_state.ListResponses.Count == 0)
+            {
+                return Task.FromResult<IReadOnlyList<OptionalInstallItem>>([]);
+            }
+            return Task.FromResult(_state.ListResponses.Dequeue());
+        }
+
+        public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_state.InstallResult);
+        }
+
+        public Task<OperationAccepted> RemoveItemAsync(string itemName, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public async IAsyncEnumerable<OperationStatusEvent> StreamOperationStatusAsync(
+            string operationId,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken
+        )
+        {
+            await Task.CompletedTask;
+            foreach (var item in _state.StreamEvents)
+            {
+                yield return item;
+            }
+        }
+    }
+
+    private sealed class InMemoryCacheStore : IOptionalInstallsCacheStore
+    {
+        private OptionalInstallsCacheDocument? _document;
+
+        public InMemoryCacheStore(OptionalInstallsCacheDocument? document)
+        {
+            _document = document;
+        }
+
+        public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_document);
+        }
+
+        public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
+        {
+            _document = document;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
@@ -103,4 +103,45 @@ public class ContractsSmokeTests
         Assert.NotNull(ex.InnerException);
         Assert.Contains("missing payload", ex.InnerException!.Message);
     }
+
+    [Fact]
+    public void ValidateOperationAccepted_ThrowsWhenAcceptedWithoutOperationId()
+    {
+        var payload = new OperationAcceptedResponse(
+            Accepted: true,
+            QueuedAtUtc: DateTimeOffset.Parse("2026-02-14T18:10:00Z")
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() =>
+            ProtocolValidation.ValidateOperationAccepted("", payload)
+        );
+
+        Assert.Contains("operationId is required", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateOperationAccepted_ThrowsWhenAcceptedWithoutQueuedAtUtc()
+    {
+        var payload = new OperationAcceptedResponse(
+            Accepted: true,
+            QueuedAtUtc: default
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() =>
+            ProtocolValidation.ValidateOperationAccepted("op-1", payload)
+        );
+
+        Assert.Contains("queuedAtUtc is required", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateOperationAccepted_AllowsNotAcceptedWithoutOperationId()
+    {
+        var payload = new OperationAcceptedResponse(
+            Accepted: false,
+            QueuedAtUtc: default
+        );
+
+        ProtocolValidation.ValidateOperationAccepted("", payload);
+    }
 }

--- a/pkg/service/run_windows_test.go
+++ b/pkg/service/run_windows_test.go
@@ -238,6 +238,16 @@ func mustInstallAndGetOperationID(t *testing.T, cfg config.Configuration, seq in
 	if strings.TrimSpace(response.OperationID) == "" {
 		t.Fatalf("expected non-empty operationId from install response")
 	}
+	payload, err := decodeEnvelopePayload[operationAcceptedResponse](response.Payload)
+	if err != nil {
+		t.Fatalf("expected operation accepted payload, decode failed: %v", err)
+	}
+	if !payload.Accepted {
+		t.Fatalf("expected accepted=true in install response payload")
+	}
+	if _, err := time.Parse(time.RFC3339, payload.QueuedAtUTC); err != nil {
+		t.Fatalf("expected queuedAtUtc to be RFC3339 timestamp, got %q: %v", payload.QueuedAtUTC, err)
+	}
 
 	return response.OperationID
 }


### PR DESCRIPTION
## Summary
- refresh UI items from live ListOptionalInstalls data after any terminal install/remove stream state (Succeeded, Failed, Canceled)
- make install acceptance contract stricter in the UI client by validating accepted responses include operationId and queuedAtUtc
- add coverage for client protocol validation and Windows service install acceptance payload assertions
- add Windows UI test coverage for HomeViewModel.InstallAsync refresh behavior and update the Windows VM checklist with reproducible TODO #4 install validation steps

## Validation
- make test
- make ui-lint
- make ui-test

## Notes
- Windows UI tests were added in gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests but were not run locally on macOS.
