### PR TITLE
Fix MSIX released-binary integration tests

### DIFF
--- a/.github/workflows/build-integration-fixtures.yml
+++ b/.github/workflows/build-integration-fixtures.yml
@@ -24,12 +24,27 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Create and trust MSIX test certificate
+        id: msix_certificate
+        shell: pwsh
+        run: |
+          $certPath = "$env:RUNNER_TEMP\gorilla-it-sideload.cer"
+          $thumbprint = ./integration/windows/initialize-msix-test-certificate.ps1 `
+            -CertificatePath $certPath `
+            -Create
+          "path=$certPath" >> $env:GITHUB_OUTPUT
+          "thumbprint=$thumbprint" >> $env:GITHUB_OUTPUT
+
       - name: Prepare released-binary integration fixtures
         shell: pwsh
         run: |
           $workRoot = "$env:RUNNER_TEMP\gorilla-release-integration"
           ./integration/windows/prepare-release-integration.ps1 `
-            -WorkRoot "$workRoot"
+            -WorkRoot "$workRoot" `
+            -MsixCertThumbprint "${{ steps.msix_certificate.outputs.thumbprint }}"
+          Copy-Item `
+            -LiteralPath "${{ steps.msix_certificate.outputs.path }}" `
+            -Destination "$workRoot\fixture\tools\gorilla-it-sideload.cer"
 
       - name: Upload integration fixtures
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-integration-tests.yml
+++ b/.github/workflows/windows-integration-tests.yml
@@ -48,30 +48,22 @@ jobs:
           New-Item -Path $outDir -ItemType Directory -Force | Out-Null
           go build -v -o "$outDir\gorilla.exe" ./cmd/gorilla
 
-      - name: Trust sideload certificate for msix fixtures
+      - name: Create and trust MSIX test certificate
+        id: msix_certificate
         shell: pwsh
         run: |
           $certPath = "${{ runner.temp }}\gorilla-it-sideload.cer"
-          # Create a self-signed cert matching the Publisher in AppxManifest.xml (CN=GorillaIT)
-          $cert = New-SelfSignedCertificate `
-            -Subject "CN=GorillaIT" `
-            -CertStoreLocation "Cert:\CurrentUser\My" `
-            -Type CodeSigningCert `
-            -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3")
-          Export-Certificate -Cert $cert -FilePath $certPath | Out-Null
-          Import-Certificate -FilePath $certPath -CertStoreLocation "Cert:\LocalMachine\TrustedPeople" | Out-Null
-          Import-Certificate -FilePath $certPath -CertStoreLocation "Cert:\LocalMachine\Root" | Out-Null
-          Write-Host "[INFO] Sideload certificate installed: $($cert.Thumbprint)"
+          $thumbprint = ./integration/windows/initialize-msix-test-certificate.ps1 `
+            -CertificatePath $certPath `
+            -Create
+          "thumbprint=$thumbprint" >> $env:GITHUB_OUTPUT
 
       - name: Prepare integration fixtures
         shell: pwsh
         run: |
-          $cert = Get-ChildItem -Path "Cert:\CurrentUser\My" |
-            Where-Object { $_.Subject -eq "CN=GorillaIT" } |
-            Select-Object -First 1
           ./integration/windows/prepare-release-integration.ps1 `
             -WorkRoot "${{ runner.temp }}\gorilla-release-integration" `
-            -MsixCertThumbprint $cert.Thumbprint
+            -MsixCertThumbprint "${{ steps.msix_certificate.outputs.thumbprint }}"
 
       - name: Run integration tests
         shell: pwsh
@@ -79,3 +71,14 @@ jobs:
           ./integration/windows/run-release-integration.ps1 `
             -WorkRoot "${{ runner.temp }}\gorilla-release-integration" `
             -GorillaExePath "${{ runner.temp }}\gorilla-binary\gorilla.exe"
+
+      - name: Upload integration failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-integration-failure-${{ github.run_id }}
+          path: |
+            C:\ProgramData\gorilla-it\cache\gorilla.log
+            ${{ runner.temp }}/gorilla-release-integration/fixture/configs
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -1,6 +1,11 @@
 name: Windows Released-Binary Integration
 
 on:
+  pull_request:
+    paths:
+      - integration/windows/**
+      - .github/workflows/build-integration-fixtures.yml
+      - .github/workflows/windows-release-integration.yml
   workflow_run:
     workflows:
       - Build Release
@@ -23,6 +28,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     if: >-
+      github.event_name == 'pull_request' ||
       (github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main') ||
@@ -104,7 +110,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup go
         uses: actions/setup-go@v5
@@ -123,7 +129,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build gorilla.exe from PR merge ref
-        if: github.event_name == 'issue_comment'
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request'
         shell: pwsh
         run: |
           $outDir = "${{ runner.temp }}\gorilla-binary"
@@ -205,7 +211,7 @@ jobs:
           "thumbprint=$thumbprint" >> $env:GITHUB_OUTPUT
 
       - name: Prepare released-binary integration fixtures
-        if: github.event_name == 'workflow_run' || github.event_name == 'issue_comment' && (steps.fixture_mode.outputs.mode == 'full' || steps.fixture_download.outcome != 'success' || steps.msix_certificate.outputs.prebuilt_certificate != 'true')
+        if: github.event_name == 'workflow_run' || github.event_name == 'pull_request' || github.event_name == 'issue_comment' && (steps.fixture_mode.outputs.mode == 'full' || steps.fixture_download.outcome != 'success' || steps.msix_certificate.outputs.prebuilt_certificate != 'true')
         shell: pwsh
         run: |
           $workRoot = "$env:RUNNER_TEMP\gorilla-release-integration"

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -183,13 +183,35 @@ jobs:
 
           throw "Unable to resolve gorilla.exe path"
 
+      - name: Initialize MSIX test certificate
+        id: msix_certificate
+        shell: pwsh
+        run: |
+          $workRoot = "$env:RUNNER_TEMP\gorilla-release-integration"
+          $prebuiltCertificatePath = "$workRoot\fixture\tools\gorilla-it-sideload.cer"
+
+          if (Test-Path -LiteralPath $prebuiltCertificatePath) {
+            ./integration/windows/initialize-msix-test-certificate.ps1 `
+              -CertificatePath $prebuiltCertificatePath | Out-Null
+            "prebuilt_certificate=true" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          $localCertificatePath = "$env:RUNNER_TEMP\gorilla-it-sideload.cer"
+          $thumbprint = ./integration/windows/initialize-msix-test-certificate.ps1 `
+            -CertificatePath $localCertificatePath `
+            -Create
+          "prebuilt_certificate=false" >> $env:GITHUB_OUTPUT
+          "thumbprint=$thumbprint" >> $env:GITHUB_OUTPUT
+
       - name: Prepare released-binary integration fixtures
-        if: github.event_name == 'workflow_run' || github.event_name == 'issue_comment' && (steps.fixture_mode.outputs.mode == 'full' || steps.fixture_download.outcome != 'success')
+        if: github.event_name == 'workflow_run' || github.event_name == 'issue_comment' && (steps.fixture_mode.outputs.mode == 'full' || steps.fixture_download.outcome != 'success' || steps.msix_certificate.outputs.prebuilt_certificate != 'true')
         shell: pwsh
         run: |
           $workRoot = "$env:RUNNER_TEMP\gorilla-release-integration"
           ./integration/windows/prepare-release-integration.ps1 `
-            -WorkRoot "$workRoot"
+            -WorkRoot "$workRoot" `
+            -MsixCertThumbprint "${{ steps.msix_certificate.outputs.thumbprint }}"
 
       - name: Run released-binary integration tests
         shell: pwsh
@@ -198,6 +220,17 @@ jobs:
           ./integration/windows/run-release-integration.ps1 `
             -WorkRoot "$workRoot" `
             -GorillaExePath "$env:GORILLA_EXE_PATH"
+
+      - name: Upload integration failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: released-binary-integration-failure-${{ github.run_id }}
+          path: |
+            C:\ProgramData\gorilla-it\cache\gorilla.log
+            ${{ runner.temp }}/gorilla-release-integration/fixture/configs
+          if-no-files-found: warn
+          retention-days: 90
 
       - name: Finalize check run
         if: always() && github.event_name == 'issue_comment' && steps.check_start.outputs.check_run_id != ''

--- a/integration/windows/initialize-msix-test-certificate.ps1
+++ b/integration/windows/initialize-msix-test-certificate.ps1
@@ -1,0 +1,42 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CertificatePath,
+    [switch]$Create
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$resolvedCertificatePath = [System.IO.Path]::GetFullPath($CertificatePath)
+
+if ($Create) {
+    $certificateDirectory = Split-Path -Parent $resolvedCertificatePath
+    New-Item -Path $certificateDirectory -ItemType Directory -Force | Out-Null
+
+    $certificate = New-SelfSignedCertificate `
+        -Subject "CN=GorillaIT" `
+        -CertStoreLocation "Cert:\CurrentUser\My" `
+        -Type CodeSigningCert `
+        -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3")
+
+    Export-Certificate -Cert $certificate -FilePath $resolvedCertificatePath -Force | Out-Null
+} elseif (-not (Test-Path -LiteralPath $resolvedCertificatePath)) {
+    throw "MSIX test certificate not found: $resolvedCertificatePath"
+}
+
+$publicCertificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+    $resolvedCertificatePath
+)
+if ($publicCertificate.Subject -ne "CN=GorillaIT") {
+    throw "Unexpected MSIX test certificate subject: $($publicCertificate.Subject)"
+}
+
+Import-Certificate `
+    -FilePath $resolvedCertificatePath `
+    -CertStoreLocation "Cert:\LocalMachine\TrustedPeople" | Out-Null
+Import-Certificate `
+    -FilePath $resolvedCertificatePath `
+    -CertStoreLocation "Cert:\LocalMachine\Root" | Out-Null
+
+Write-Host "[INFO] Trusted MSIX test certificate: $($publicCertificate.Thumbprint)"
+Write-Output $publicCertificate.Thumbprint

--- a/integration/windows/run-release-integration.ps1
+++ b/integration/windows/run-release-integration.ps1
@@ -217,10 +217,12 @@ Overall: PASS
     }
 } catch {
     $errorMessage = $_.Exception.Message
+    $annotationMessage = ("Phase '$currentPhase': $errorMessage").Replace("%", "%25").Replace("`r", "%0D").Replace("`n", "%0A")
     Write-Host "========== Integration Test Summary =========="
     $results | ForEach-Object { Write-Host $_ }
     Write-Host "[FAIL] Phase: $currentPhase"
     Write-Host "[FAIL] $errorMessage"
+    Write-Host "::error title=Windows integration failed::$annotationMessage"
 
     if ($env:GITHUB_STEP_SUMMARY) {
         @"


### PR DESCRIPTION
## Summary

The most recent main-branch `Windows Released-Binary Integration` run failed after MSIX coverage was added in #169. The source-build Windows integration workflow created, trusted, and used a self-signed certificate, but the released-binary workflow and prebuilt fixture workflow still produced unsigned MSIX packages.

This change:

- centralizes creation/import of the ephemeral `CN=GorillaIT` test certificate
- signs MSIX fixtures in source-built, released-binary, and prebuilt-fixture paths
- includes the public certificate with prebuilt fixtures so consuming runners can trust those signed packages
- falls back to rebuilding fixtures when an older unsigned prebuilt artifact is selected
- runs the released-binary workflow on relevant PR changes, closing the validation gap that allowed the source-build integration test to pass while the release workflow was broken
- emits a persistent GitHub error annotation with the failing phase and message
- uploads the Gorilla log and generated configs for 90 days when integration tests fail

Only the public certificate is stored in fixture artifacts; the private key remains in the ephemeral fixture-build runner certificate store.

## Validation

- `make test` with Go 1.26.0 (including race detection): passed
- `actionlint`: passed
- [Go test](https://github.com/1dustindavis/gorilla/actions/runs/33206715651): passed
- [Windows Integration Tests](https://github.com/1dustindavis/gorilla/actions/runs/33206715632): passed
- [PR-native Windows Released-Binary Integration](https://github.com/1dustindavis/gorilla/actions/runs/33206715650): passed, including signed MSIX install, update, and uninstall

The earlier manual-comment run on this PR used the old workflow definition from `main` (GitHub evaluates `issue_comment` workflows from the default branch), so its expected failure is superseded by the passing PR-native run above.