### PR TITLE
Sign MSIX releases with Azure Artifact Signing

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -8,6 +8,16 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+
+env:
+  AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID || '2cd0243e-c60d-4cce-9225-e569d41b02e2' }}
+  AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID || '2d81f33c-5e91-4bc0-98a3-2267183edfcd' }}
+  AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID || '85049d10-3b29-403f-8849-fb54e4a5e0d3' }}
+  ARTIFACT_SIGNING_ENDPOINT: ${{ vars.ARTIFACT_SIGNING_ENDPOINT || 'https://wus3.codesigning.azure.net/' }}
+  ARTIFACT_SIGNING_ACCOUNT: ${{ vars.ARTIFACT_SIGNING_ACCOUNT || 'gorilla-signing' }}
+  ARTIFACT_SIGNING_PROFILE: ${{ vars.ARTIFACT_SIGNING_PROFILE || 'gorilla-public-trust' }}
+  ARTIFACT_SIGNING_SUBJECT: 'CN=Dustin Davis, O=Dustin Davis, L=Walnut Creek, S=ca, C=US'
 
 jobs:
   build:
@@ -46,7 +56,7 @@ jobs:
     - name: Create version tag
       id: create_tag
       uses: paulhatch/semantic-version@v5.4.0
-      with: 
+      with:
         tag_prefix: "v"
         major_pattern: "(MAJOR)"
         minor_pattern: "/[\\s]*/"
@@ -101,35 +111,9 @@ jobs:
         path: ./cmd/gorilla/gorilla.exe
         if-no-files-found: error
 
-    - name: Restore MSIX signing certificate
-      env:
-        MSIX_CERT_PFX_B64: ${{ secrets.MSIX_CERT_PFX_B64 }}
-        MSIX_CERT_PASSWORD: ${{ secrets.MSIX_CERT_PASSWORD }}
+    - name: Build unsigned Gorilla UI MSIX
       run: |
         New-Item -ItemType Directory -Force -Path build | Out-Null
-        if ([string]::IsNullOrWhiteSpace($Env:MSIX_CERT_PFX_B64)) {
-          throw "Missing required secret: MSIX_CERT_PFX_B64"
-        }
-        if ([string]::IsNullOrWhiteSpace($Env:MSIX_CERT_PASSWORD)) {
-          throw "Missing required secret: MSIX_CERT_PASSWORD"
-        }
-        [IO.File]::WriteAllBytes(
-          "$Env:GITHUB_WORKSPACE\build\Gorilla.UI.App.SelfSigned.pfx",
-          [Convert]::FromBase64String($Env:MSIX_CERT_PFX_B64)
-        )
-        $pfxPath = "$Env:GITHUB_WORKSPACE\build\Gorilla.UI.App.SelfSigned.pfx"
-        $cerPath = "$Env:GITHUB_WORKSPACE\build\Gorilla.UI.App.SelfSigned.cer"
-        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
-          $pfxPath,
-          $Env:MSIX_CERT_PASSWORD,
-          [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
-        )
-        [IO.File]::WriteAllBytes($cerPath, $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
-
-    - name: Build Gorilla UI MSIX
-      env:
-        MSIX_CERT_PASSWORD: ${{ secrets.MSIX_CERT_PASSWORD }}
-      run: |
         dotnet restore gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
         dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj `
           -c Release `
@@ -138,10 +122,9 @@ jobs:
           -p:PublishReadyToRun=false `
           -p:PublishTrimmed=false `
           -p:AppxPackageVersion="$Env:MSIX_VERSION" `
-          -p:PackageCertificateKeyFile="$Env:GITHUB_WORKSPACE\build\Gorilla.UI.App.SelfSigned.pfx" `
-          -p:PackageCertificatePassword="$Env:MSIX_CERT_PASSWORD"
+          -p:AppxPackageSigningEnabled=false
 
-    - name: Collect MSIX artifact
+    - name: Collect unsigned MSIX artifact
       run: |
         $msix = Get-ChildItem -Path gorilla-ui/src/Gorilla.UI.App/AppPackages -Recurse -Filter *.msix |
           Sort-Object LastWriteTime -Descending |
@@ -149,15 +132,56 @@ jobs:
         if ($null -eq $msix) {
           throw "No MSIX package found under gorilla-ui/src/Gorilla.UI.App/AppPackages"
         }
-        Copy-Item $msix.FullName "build/Gorilla.UI.App.SelfSigned.msix" -Force
+        Copy-Item $msix.FullName "build/Gorilla.UI.App.msix" -Force
+
+        $signature = Get-AuthenticodeSignature -FilePath "build/Gorilla.UI.App.msix"
+        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) {
+          throw "Expected the packaged MSIX to be unsigned before Artifact Signing, but status was $($signature.Status)."
+        }
+
+    - name: Login to Azure with GitHub OIDC
+      uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+      with:
+        client-id: ${{ env.AZURE_CLIENT_ID }}
+        tenant-id: ${{ env.AZURE_TENANT_ID }}
+        subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Sign Gorilla UI MSIX with Azure Artifact Signing
+      uses: Azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
+      with:
+        endpoint: ${{ env.ARTIFACT_SIGNING_ENDPOINT }}
+        signing-account-name: ${{ env.ARTIFACT_SIGNING_ACCOUNT }}
+        certificate-profile-name: ${{ env.ARTIFACT_SIGNING_PROFILE }}
+        files: ${{ github.workspace }}\build\Gorilla.UI.App.msix
+        file-digest: SHA256
+        timestamp-digest: SHA256
+
+    - name: Verify signed MSIX
+      shell: pwsh
+      run: |
+        $packagePath = "$Env:GITHUB_WORKSPACE\build\Gorilla.UI.App.msix"
+        $signature = Get-AuthenticodeSignature -FilePath $packagePath
+
+        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+          throw "Artifact Signing produced an invalid MSIX signature. Status: $($signature.Status); message: $($signature.StatusMessage)"
+        }
+        if ($null -eq $signature.SignerCertificate) {
+          throw "Signed MSIX does not expose a signer certificate."
+        }
+        if ($signature.SignerCertificate.Subject -cne $Env:ARTIFACT_SIGNING_SUBJECT) {
+          throw "Unexpected MSIX signer subject. Expected '$Env:ARTIFACT_SIGNING_SUBJECT'; got '$($signature.SignerCertificate.Subject)'."
+        }
+
+        Write-Host "Verified MSIX signature"
+        Write-Host "  Subject: $($signature.SignerCertificate.Subject)"
+        Write-Host "  Thumbprint: $($signature.SignerCertificate.Thumbprint)"
+        Write-Host "  Valid through: $($signature.SignerCertificate.NotAfter.ToUniversalTime().ToString('u'))"
 
     - name: Upload Gorilla UI MSIX workflow artifact
       uses: actions/upload-artifact@v4
       with:
-        name: gorilla-ui-msix-selfsigned-release
-        path: |
-          ./build/Gorilla.UI.App.SelfSigned.msix
-          ./build/Gorilla.UI.App.SelfSigned.cer
+        name: gorilla-ui-msix-release
+        path: ./build/Gorilla.UI.App.msix
         if-no-files-found: error
 
     - name: Cut release
@@ -165,6 +189,6 @@ jobs:
       with:
         allowUpdates: false
         prerelease: true
-        artifacts: "./cmd/gorilla/gorilla.exe,./build/Gorilla.UI.App.SelfSigned.msix,./build/Gorilla.UI.App.SelfSigned.cer"
+        artifacts: "./cmd/gorilla/gorilla.exe,./build/Gorilla.UI.App.msix"
         tag: ${{ steps.create_tag.outputs.version_tag }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest
+++ b/gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest
@@ -9,7 +9,7 @@
 
   <Identity
     Name="133b2116-358b-42fb-8bc8-35009cc5d5af"
-    Publisher="CN=GorillaUI"
+    Publisher="CN=Dustin Davis, O=Dustin Davis, L=Walnut Creek, S=ca, C=US"
     Version="1.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="133b2116-358b-42fb-8bc8-35009cc5d5af" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>


### PR DESCRIPTION
## Summary

- replace the self-signed MSIX release certificate with Azure Artifact Signing
- authenticate GitHub Actions to Azure using the configured OIDC federation, with no client secret
- build the MSIX unsigned and sign the completed package with `gorilla-public-trust`
- verify both Authenticode validity and the exact expected publisher subject before publishing
- publish `Gorilla.UI.App.msix` without a companion `.cer`
- update the MSIX manifest publisher to the verified Artifact Signing identity

## Signing configuration

The workflow uses the provisioned Gorilla Artifact Signing resources:

- endpoint: `https://wus3.codesigning.azure.net/`
- account: `gorilla-signing`
- certificate profile: `gorilla-public-trust`
- publisher: `CN=Dustin Davis, O=Dustin Davis, L=Walnut Creek, S=ca, C=US`

Azure tenant/client/subscription IDs and Artifact Signing resource identifiers can be overridden with repository variables. The checked-in values are non-secret identifiers and provide deterministic defaults. No Azure client secret or signing private key is stored in GitHub.

The Azure login and Artifact Signing actions are pinned to immutable commit SHAs.

## Validation

The release workflow now:

1. requires the generated MSIX to be unsigned before cloud signing
2. signs the final package with Azure Artifact Signing
3. requires `Get-AuthenticodeSignature` to report `Valid`
4. requires the signer certificate subject to exactly match the MSIX publisher identity
5. only uploads/releases the package after those checks pass

The existing GitHub OIDC federated credential is scoped to `1dustindavis/gorilla` on `main`, so the actual Artifact Signing step will first execute after this change reaches `main`.