### PR TITLE
Disable MSIX symbol package generation

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
+++ b/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
@@ -66,5 +66,6 @@
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+    <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Disable MSIX symbol package generation for the WinUI app to avoid the unused `mspdbcmf.exe` warning during release builds.