### PR TITLE
Make WinUI automation and accessibility contract explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,10 @@ Run `make help` for the current command summary.
 - Do not add App-local copies of Core presentation classes or regenerate the committed `Gorilla.UI.App` directory from starter templates.
 - Keep `cmd/gorilla` service-message commands updated in lockstep with Gorilla UI protocol changes for testing/debugging.
 - `ListOptionalInstalls` should return JSON-safe subset DTOs, not full internal item objects.
+- Treat explicit WinUI `AutomationProperties.AutomationId` values used by tests as a compatibility surface. Do not rename or remove them casually.
+- Use stable automation IDs for interactive or diagnostically important controls; do not make test identity depend on visible text or layout unless the visible text itself is the behavior under test.
+- Repeated templated controls may reuse an automation ID when tests scope the lookup to the relevant item/container. Do not encode changing item data into automation IDs unless global uniqueness is genuinely required.
+- Automation IDs do not replace accessibility semantics. Preserve meaningful accessible names, roles, keyboard/focus behavior, and state/value exposure when changing UI controls.
 
 ## Diagnostics
 

--- a/gorilla-ui/README.md
+++ b/gorilla-ui/README.md
@@ -42,6 +42,14 @@ Validation commands:
       - `dotnet test gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/Gorilla.UI.App.WindowsUiTests.csproj -c Release`
 - Optional local autofix: use `dotnet format` against the relevant portable project.
 
+UI automation and accessibility contract:
+- Interactive and diagnostically important WinUI controls that are part of automated tests use explicit `AutomationProperties.AutomationId` values.
+- Automation IDs are stable machine-facing identifiers and are treated as a compatibility surface for tests. Renaming or removing one requires updating and reviewing the affected automation contract.
+- FlaUI selectors should prefer automation properties over visible text, screen position, or layout. Visible text selectors are appropriate when the text itself is the behavior being validated.
+- Repeated controls inside an item template use stable IDs such as `InstallButton` and `RemoveButton`; automation should first scope to the relevant item/container and then locate the action within it instead of generating IDs from item names.
+- Automation IDs do not replace accessibility metadata. Controls should continue to expose meaningful accessible names, roles, focus/keyboard behavior, and state/value semantics.
+- The current home automation surface includes `HomeHeading`, `ServiceWarning`, `ItemsList`, `ItemStatus`, `InstallButton`, and `RemoveButton`. Add similarly intentional IDs as new interactive or diagnostically important UI is introduced.
+
 Signed package workflow (Windows VMs):
 - Build VM:
   - Run from repo root (`gorilla/`).

--- a/gorilla-ui/README.md
+++ b/gorilla-ui/README.md
@@ -46,9 +46,10 @@ UI automation and accessibility contract:
 - Interactive and diagnostically important WinUI controls that are part of automated tests use explicit `AutomationProperties.AutomationId` values.
 - Automation IDs are stable machine-facing identifiers and are treated as a compatibility surface for tests. Renaming or removing one requires updating and reviewing the affected automation contract.
 - FlaUI selectors should prefer automation properties over visible text, screen position, or layout. Visible text selectors are appropriate when the text itself is the behavior being validated.
-- Repeated controls inside an item template use stable IDs such as `InstallButton` and `RemoveButton`; automation should first scope to the relevant item/container and then locate the action within it instead of generating IDs from item names.
+- Each generated optional-install `ListViewItem` uses the protocol-level `ItemName` as its stable automation ID and the human-facing `DisplayName` as its accessible name. Automation should scope to that item container before locating repeated child controls.
+- Repeated controls inside an item template use stable IDs such as `InstallButton` and `RemoveButton`; do not generate their IDs from changing item data.
 - Automation IDs do not replace accessibility metadata. Controls should continue to expose meaningful accessible names, roles, focus/keyboard behavior, and state/value semantics.
-- The current home automation surface includes `HomeHeading`, `ServiceWarning`, `ItemsList`, `ItemStatus`, `InstallButton`, and `RemoveButton`. Add similarly intentional IDs as new interactive or diagnostically important UI is introduced.
+- The current home automation surface includes `HomeHeading`, `ServiceWarning`, `ItemsList`, item containers identified by `ItemName`, `ItemStatus`, `InstallButton`, and `RemoveButton`. Add similarly intentional IDs as new interactive or diagnostically important UI is introduced.
 
 Signed package workflow (Windows VMs):
 - Build VM:

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -11,11 +11,13 @@
             Text="Available Software"
             FontSize="28"
             FontWeight="SemiBold"
-            AutomationProperties.AutomationId="HomeHeading" />
+            AutomationProperties.AutomationId="HomeHeading"
+            AutomationProperties.HeadingLevel="Level1" />
 
         <TextBlock
             Grid.Row="1"
             Margin="0,8,0,0"
+            x:Name="ServiceWarning"
             Text="{Binding WarningBanner}"
             Foreground="DarkOrange"
             AutomationProperties.AutomationId="ServiceWarning"

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -7,21 +7,52 @@
     mc:Ignorable="d">
 
     <Grid Padding="24" RowDefinitions="Auto,Auto,*">
-        <TextBlock Text="Available Software" FontSize="28" FontWeight="SemiBold" />
+        <TextBlock
+            Text="Available Software"
+            FontSize="28"
+            FontWeight="SemiBold"
+            AutomationProperties.AutomationId="HomeHeading" />
 
-        <TextBlock Grid.Row="1" Margin="0,8,0,0" Text="{Binding WarningBanner}" Foreground="DarkOrange" />
+        <TextBlock
+            Grid.Row="1"
+            Margin="0,8,0,0"
+            Text="{Binding WarningBanner}"
+            Foreground="DarkOrange"
+            AutomationProperties.AutomationId="ServiceWarning"
+            AutomationProperties.LiveSetting="Polite" />
 
-        <ListView Grid.Row="2" Margin="0,16,0,0" x:Name="ItemsList" ItemsSource="{Binding Items}">
+        <ListView
+            Grid.Row="2"
+            Margin="0,16,0,0"
+            x:Name="ItemsList"
+            ItemsSource="{Binding Items}"
+            AutomationProperties.AutomationId="ItemsList"
+            AutomationProperties.Name="Available software">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Grid ColumnDefinitions="*,Auto,Auto" Padding="0,8">
                         <StackPanel>
                             <TextBlock Text="{Binding DisplayName}" FontSize="18" FontWeight="SemiBold" />
                             <TextBlock Text="{Binding Version}" Opacity="0.7" />
-                            <TextBlock Text="{Binding Status}" Opacity="0.7" />
+                            <TextBlock
+                                Text="{Binding Status}"
+                                Opacity="0.7"
+                                AutomationProperties.AutomationId="ItemStatus" />
                         </StackPanel>
-                        <Button Grid.Column="1" Margin="12,0,0,0" Content="Install" Tag="{Binding ItemName}" Click="InstallButton_Click" />
-                        <Button Grid.Column="2" Margin="8,0,0,0" Content="Remove" Tag="{Binding ItemName}" Click="RemoveButton_Click" />
+                        <Button
+                            Grid.Column="1"
+                            Margin="12,0,0,0"
+                            Content="Install"
+                            Tag="{Binding ItemName}"
+                            Click="InstallButton_Click"
+                            AutomationProperties.AutomationId="InstallButton" />
+                        <Button
+                            Grid.Column="2"
+                            Margin="8,0,0,0"
+                            Content="Remove"
+                            Tag="{Binding ItemName}"
+                            Click="RemoveButton_Click"
+                            AutomationProperties.AutomationId="RemoveButton" />
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -30,6 +30,12 @@
             ItemsSource="{Binding Items}"
             AutomationProperties.AutomationId="ItemsList"
             AutomationProperties.Name="Available software">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="AutomationProperties.AutomationId" Value="{Binding ItemName}" />
+                    <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}" />
+                </Style>
+            </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Grid ColumnDefinitions="*,Auto,Auto" Padding="0,8">

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Gorilla.UI.Core.ViewModels;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Gorilla.UI.App.Views;
@@ -10,6 +11,7 @@ namespace Gorilla.UI.App.Views;
 public sealed partial class HomePage : Page, IDisposable
 {
     private CancellationTokenSource? _cts;
+    private long _serviceWarningTextChangedToken;
 
     public HomeViewModel ViewModel { get; }
 
@@ -20,6 +22,10 @@ public sealed partial class HomePage : Page, IDisposable
         DataContext = ViewModel;
         Loaded += HomePage_Loaded;
         Unloaded += HomePage_Unloaded;
+        _serviceWarningTextChangedToken = ServiceWarning.RegisterPropertyChangedCallback(
+            TextBlock.TextProperty,
+            ServiceWarning_TextChanged
+        );
     }
 
     private async void HomePage_Loaded(object sender, RoutedEventArgs e)
@@ -32,6 +38,18 @@ public sealed partial class HomePage : Page, IDisposable
     private void HomePage_Unloaded(object sender, RoutedEventArgs e)
     {
         ResetCancellation();
+    }
+
+    private void ServiceWarning_TextChanged(DependencyObject sender, DependencyProperty dp)
+    {
+        if (string.IsNullOrWhiteSpace(ServiceWarning.Text))
+        {
+            return;
+        }
+
+        var peer = FrameworkElementAutomationPeer.FromElement(ServiceWarning)
+            ?? FrameworkElementAutomationPeer.CreatePeerForElement(ServiceWarning);
+        peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
     }
 
     private async void InstallButton_Click(object sender, RoutedEventArgs e)
@@ -96,6 +114,14 @@ public sealed partial class HomePage : Page, IDisposable
     {
         Loaded -= HomePage_Loaded;
         Unloaded -= HomePage_Unloaded;
+        if (_serviceWarningTextChangedToken != 0)
+        {
+            ServiceWarning.UnregisterPropertyChangedCallback(
+                TextBlock.TextProperty,
+                _serviceWarningTextChangedToken
+            );
+            _serviceWarningTextChangedToken = 0;
+        }
         ResetCancellation();
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AppLaunchSmokeTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AppLaunchSmokeTests.cs
@@ -14,7 +14,7 @@ namespace Gorilla.UI.App.WindowsUiTests;
 public sealed class AppLaunchSmokeTests
 {
     [Fact]
-    public void AppLaunchesAndShowsHomeHeading()
+    public void AppLaunchesAndExposesStableHomeAutomationContract()
     {
         var appExePath = ResolveAppExePath();
         var artifactsDir = ResolveArtifactsDirectory();
@@ -32,10 +32,11 @@ public sealed class AppLaunchSmokeTests
             Assert.Equal("App Catalog", mainWindow.Title);
 
             var heading = WaitFor(
-                () => mainWindow.FindFirstDescendant(cf => cf.ByText("Available Software")),
+                () => mainWindow.FindFirstDescendant(cf => cf.ByAutomationId("HomeHeading")),
                 TimeSpan.FromSeconds(30)
             );
             Assert.NotNull(heading);
+            Assert.Equal("Available Software", heading.Name);
 
             var textElements = mainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Text));
             Assert.DoesNotContain(
@@ -48,6 +49,7 @@ public sealed class AppLaunchSmokeTests
                 TimeSpan.FromSeconds(30)
             );
             Assert.NotNull(itemsList);
+            Assert.Equal("Available software", itemsList.Name);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

Implements Stage 3 of #171 with a focused WinUI automation/accessibility contract for the UI that exists today.

- adds explicit stable `AutomationProperties.AutomationId` values for the home heading, service warning, items list, item status, and install/remove actions
- gives each generated optional-install `ListViewItem` a stable machine-facing identity from protocol `ItemName` and a human-facing accessible name from `DisplayName`
- exposes the home heading semantically as `HeadingLevel="Level1"`
- gives the software list an explicit accessible name
- marks the asynchronous service warning as a polite live region and explicitly raises `AutomationEvents.LiveRegionChanged` when a non-empty warning is published
- keeps repeated item-template action IDs semantic (`InstallButton` / `RemoveButton`) and scopes them beneath the stable item container rather than encoding item data into the child IDs
- updates the FlaUI smoke test to locate the home heading through its stable automation ID and verify the exposed accessible names for the heading and list
- documents automation IDs and item identities as a test compatibility surface in `AGENTS.md` and the UI developer docs
- documents that accessible names/state/keyboard semantics remain separate requirements from machine-facing automation IDs

This PR intentionally does not add placeholder UI for planned future controls such as refresh, item details, or operation progress, and it does not change install/remove behavior. Those controls should adopt the same automation contract when they are introduced.

The current FlaUI smoke harness launches the UI without a seeded Gorilla service, so rendered list items are not deterministic in this stage. The always-present home automation surface is verified through live UI Automation now; deterministic Stage 4 workflow fixtures can use the established hierarchy `ItemsList -> ItemName -> InstallButton/RemoveButton` without relying on display text or layout.

## Validation intent

This is a WinUI application change, so the canonical validation path is:

- `make verify`
- `make verify-windows`
- `make verify-e2e`

The Windows UI test specifically verifies that `HomeHeading` and `ItemsList` are exposed through UIA with the expected accessible names. Windows compilation also validates the WinUI heading/live-region API usage and item-container style bindings.

Implements Stage 3 of #171. The umbrella issue should remain open for subsequent stages.