### PR TITLE
Validate accepted operation response metadata

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
@@ -51,6 +51,7 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
             requestEnvelope,
             cancellationToken
         );
+        ProtocolValidation.ValidateOperationAccepted(responseEnvelope.OperationId, responseEnvelope.Payload);
 
         return new OperationAccepted(
             OperationId: responseEnvelope.OperationId,
@@ -72,6 +73,7 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
             requestEnvelope,
             cancellationToken
         );
+        ProtocolValidation.ValidateOperationAccepted(responseEnvelope.OperationId, responseEnvelope.Payload);
 
         return new OperationAccepted(
             OperationId: responseEnvelope.OperationId,

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
@@ -61,4 +61,22 @@ public static class ProtocolValidation
             throw new ProtocolValidationException("canceledBy is required when state is Canceled.");
         }
     }
+
+    public static void ValidateOperationAccepted(string operationId, OperationAcceptedResponse payload)
+    {
+        if (!payload.Accepted)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            throw new ProtocolValidationException("operationId is required when operation is accepted.");
+        }
+
+        if (payload.QueuedAtUtc == default)
+        {
+            throw new ProtocolValidationException("queuedAtUtc is required when operation is accepted.");
+        }
+    }
 }

--- a/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
@@ -87,6 +87,58 @@ public class ContractsSmokeTests
     }
 
     [Fact]
+    public void ValidateOperationAccepted_RejectsMissingOperationIdWhenAccepted()
+    {
+        var payload = new OperationAcceptedResponse(
+            Accepted: true,
+            QueuedAtUtc: DateTimeOffset.Parse("2026-02-14T18:10:00Z")
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(
+            () => ProtocolValidation.ValidateOperationAccepted(string.Empty, payload)
+        );
+
+        Assert.Contains("operationId", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateOperationAccepted_RejectsMissingQueuedAtUtcWhenAccepted()
+    {
+        var payload = new OperationAcceptedResponse(
+            Accepted: true,
+            QueuedAtUtc: default
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(
+            () => ProtocolValidation.ValidateOperationAccepted("op-1", payload)
+        );
+
+        Assert.Contains("queuedAtUtc", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateOperationAccepted_AllowsCompleteAcceptedResponse()
+    {
+        var payload = new OperationAcceptedResponse(
+            Accepted: true,
+            QueuedAtUtc: DateTimeOffset.Parse("2026-02-14T18:10:00Z")
+        );
+
+        ProtocolValidation.ValidateOperationAccepted("op-1", payload);
+    }
+
+    [Fact]
+    public void ValidateOperationAccepted_AllowsRejectedResponseWithoutOperationMetadata()
+    {
+        var payload = new OperationAcceptedResponse(
+            Accepted: false,
+            QueuedAtUtc: default
+        );
+
+        ProtocolValidation.ValidateOperationAccepted(string.Empty, payload);
+    }
+
+    [Fact]
     public void HandleErrorEnvelopeIfPresent_NullPayload_ThrowsProtocolError()
     {
         using var doc = JsonDocument.Parse(


### PR DESCRIPTION
## Summary

- validate accepted install/remove responses include a non-empty `operationId`
- validate accepted responses include a non-default `queuedAtUtc`
- leave rejected responses exempt from queued-operation metadata requirements
- enforce the validation at the named-pipe client boundary for both install and remove
- add focused contract tests for valid, malformed, and rejected responses

This extracts the still-useful protocol-validation portion of superseded PR #168 without carrying forward its stale UI/state-convergence changes.

## Validation

CI should exercise the existing UI client test workflow for these contract tests.