### PR TITLE
Cancel superseded PR runs and update GitHub Actions

### DIFF
--- a/.github/workflows/build-integration-fixtures.yml
+++ b/.github/workflows/build-integration-fixtures.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure Go cache paths
         shell: pwsh
@@ -54,7 +54,7 @@ jobs:
             -Destination "$workRoot\fixture\tools\gorilla-it-sideload.cer"
 
       - name: Upload integration fixtures
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gorilla-release-fixtures
           path: ${{ runner.temp }}/gorilla-release-integration/fixture

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
         "NUGET_PACKAGES=$env:RUNNER_TEMP\nuget-packages" >> $env:GITHUB_ENV
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '8.0.x'
 
@@ -67,7 +67,7 @@ jobs:
 
     - name: Create version tag
       id: create_tag
-      uses: paulhatch/semantic-version@v5.4.0
+      uses: paulhatch/semantic-version@v6.0.2
       with:
         tag_prefix: "v"
         major_pattern: "(MAJOR)"
@@ -140,7 +140,7 @@ jobs:
           -X github.com/1dustindavis/gorilla/pkg/version.goVersion=${{ env.GO_VERSION }}"`
 
     - name: Upload gorilla.exe workflow artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: gorilla-exe-release
         path: ./cmd/gorilla/gorilla.exe
@@ -242,7 +242,7 @@ jobs:
         Write-Host "  Valid through: $($signature.SignerCertificate.NotAfter.ToUniversalTime().ToString('u'))"
 
     - name: Upload Gorilla UI MSIX workflow artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: gorilla-ui-msix-release
         path: ./build/Gorilla.UI.App.msix

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -41,7 +41,7 @@ jobs:
       run: git config --global core.autocrlf false
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Configure Go cache paths
       shell: pwsh

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -23,6 +23,10 @@ on:
       - go.sum
       - .github/workflows/go-test.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ui-client-test.yml
+++ b/.github/workflows/ui-client-test.yml
@@ -35,7 +35,7 @@ jobs:
       run: git config --global core.autocrlf false
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Configure NuGet package path
       shell: pwsh
@@ -44,7 +44,7 @@ jobs:
         "NUGET_PACKAGES=$nugetPackages" >> $env:GITHUB_ENV
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/ui-client-test.yml
+++ b/.github/workflows/ui-client-test.yml
@@ -18,6 +18,10 @@ on:
       - Makefile
       - .github/workflows/ui-client-test.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/windows-integration-tests.yml
+++ b/.github/workflows/windows-integration-tests.yml
@@ -13,6 +13,10 @@ on:
       - .github/workflows/windows-integration-tests.yml
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/windows-integration-tests.yml
+++ b/.github/workflows/windows-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload integration failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-integration-failure-${{ github.run_id }}
           path: |

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -8,6 +8,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Download gorilla.exe from Build Release run artifact
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           repository: ${{ github.repository }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload integration failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: released-binary-integration-failure-${{ github.run_id }}
           path: |

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -44,7 +44,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure NuGet package path
         shell: pwsh
@@ -52,7 +52,7 @@ jobs:
           "NUGET_PACKAGES=$env:RUNNER_TEMP\nuget-packages" >> $env:GITHUB_ENV
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload Windows UI test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-ui-test-results
           path: |

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -26,6 +26,10 @@ on:
       - Makefile
       - .github/workflows/windows-ui-test.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Improve GitHub Actions CI behavior and remove current Node.js 20 action deprecation warnings.

### Cancel superseded PR runs

Add workflow-level concurrency to every workflow that runs on pull requests:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

This cancels an older in-progress run when a newer commit is pushed to the same PR, while keeping different workflows and different PRs isolated from one another. Non-PR triggers fall back to the workflow ref.

### Update deprecated Actions runtimes

Recent workflow logs show GitHub forcing several Node.js 20 actions to run on Node.js 24. Update those references to Node.js 24-compatible releases:

- `actions/checkout@v4` -> pinned `v6.0.2`
- `actions/setup-dotnet@v4` -> `v5`
- `actions/upload-artifact@v4` -> `v6`
- `actions/download-artifact@v4` -> `v7`
- `paulhatch/semantic-version@v5.4.0` -> `v6.0.2`

`actions/setup-go`, Azure login/signing, and `ncipollo/release-action` did not produce the Node.js 20 warning in the reviewed runs and are intentionally unchanged.

An unrelated MSIX build warning about `mspdbcmf.exe` / symbols packaging was also observed, but is not an Actions deprecation and is intentionally outside this PR's scope.

## Workflows updated

- Build Integration Fixtures
- Build Release
- Go Tests
- UI Client Tests
- Windows Integration
- Released-Binary Integration
- Windows UI Tests