### PR TITLE
Simplify prerelease and stable versioning

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -96,9 +96,6 @@ jobs:
       shell: pwsh
       run: |
         "RELEASE_TAG=${{ steps.create_tag.outputs.version_tag }}" >> $Env:GITHUB_ENV
-        "PREVIOUS_RELEASE_TAG=v${{ steps.create_tag.outputs.previous_version }}" >> $Env:GITHUB_ENV
-        "IS_PRERELEASE=true" >> $Env:GITHUB_ENV
-        "MAKE_LATEST=false" >> $Env:GITHUB_ENV
 
     - name: Set stable release metadata
       if: github.event_name == 'workflow_dispatch'
@@ -120,8 +117,7 @@ jobs:
 
         $latestVersion = git tag --list 'v[0-9]*.[0-9]*.[0-9]*' |
           ForEach-Object {
-            $parsed = $null
-            if ([version]::TryParse($_.Substring(1), [ref]$parsed)) { $parsed }
+            try { [version]($_.Substring(1)) } catch { }
           } |
           Sort-Object -Descending |
           Select-Object -First 1
@@ -139,9 +135,7 @@ jobs:
           -Headers $headers
 
         "RELEASE_TAG=$releaseTag" >> $Env:GITHUB_ENV
-        "PREVIOUS_RELEASE_TAG=$($latestStable.tag_name)" >> $Env:GITHUB_ENV
-        "IS_PRERELEASE=false" >> $Env:GITHUB_ENV
-        "MAKE_LATEST=true" >> $Env:GITHUB_ENV
+        "PREVIOUS_STABLE_TAG=$($latestStable.tag_name)" >> $Env:GITHUB_ENV
 
     - name: Compute MSIX version from release tag
       run: |
@@ -315,14 +309,35 @@ jobs:
         path: ./build/Gorilla.UI.App.msix
         if-no-files-found: error
 
-    - name: Cut release
+    - name: Prepare prerelease notes
+      if: github.event_name == 'push'
+      shell: pwsh
+      run: |
+        $title = git log -1 --pretty=format:"%s"
+        "- $title" | Set-Content -Path release-notes.md -Encoding utf8
+
+    - name: Cut prerelease
+      if: github.event_name == 'push'
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
-        prerelease: ${{ env.IS_PRERELEASE }}
-        makeLatest: ${{ env.MAKE_LATEST }}
+        prerelease: true
+        makeLatest: false
+        bodyFile: release-notes.md
+        artifacts: "./cmd/gorilla/gorilla.exe,./build/Gorilla.UI.App.msix"
+        commit: ${{ github.sha }}
+        tag: ${{ env.RELEASE_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cut stable release
+      if: github.event_name == 'workflow_dispatch'
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: false
+        prerelease: false
+        makeLatest: true
         generateReleaseNotes: true
-        generateReleaseNotesPreviousTag: ${{ env.PREVIOUS_RELEASE_TAG }}
+        generateReleaseNotesPreviousTag: ${{ env.PREVIOUS_STABLE_TAG }}
         artifacts: "./cmd/gorilla/gorilla.exe,./build/Gorilla.UI.App.msix"
         commit: ${{ github.sha }}
         tag: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,10 +1,16 @@
 name: Build Release
 
-# Trigger on every main branch push
+# Every main branch push creates a patch prerelease. Stable releases are cut manually.
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      stable_version:
+        description: "Stable version to release (for example, 2.30.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -24,6 +30,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Require main for stable releases
+      if: github.event_name == 'workflow_dispatch'
+      shell: pwsh
+      run: |
+        if ("${{ github.ref }}" -ne "refs/heads/main") {
+          throw "Stable releases must be run from the main branch."
+        }
+
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -65,22 +79,75 @@ jobs:
         $vers=((go version) -replace "go version go", "" -replace " windows/amd64" )
         echo "GO_VERSION=${vers}" >> $Env:GITHUB_ENV
 
-    - name: Create version tag
+    - name: Compute automatic prerelease version
+      if: github.event_name == 'push'
       id: create_tag
       uses: paulhatch/semantic-version@v6.0.2
       with:
         tag_prefix: "v"
-        major_pattern: "(MAJOR)"
-        minor_pattern: "/[\\s]*/"
-        version_format: "${major}.${minor}"
+        major_pattern: "__NO_AUTOMATIC_MAJOR_BUMP__"
+        minor_pattern: "__NO_AUTOMATIC_MINOR_BUMP__"
+        version_format: "${major}.${minor}.${patch}"
         namespace: ''
-        bump_each_commit: false
+        bump_each_commit: true
+
+    - name: Set automatic prerelease metadata
+      if: github.event_name == 'push'
+      shell: pwsh
+      run: |
+        "RELEASE_TAG=${{ steps.create_tag.outputs.version_tag }}" >> $Env:GITHUB_ENV
+        "PREVIOUS_RELEASE_TAG=v${{ steps.create_tag.outputs.previous_version }}" >> $Env:GITHUB_ENV
+        "IS_PRERELEASE=true" >> $Env:GITHUB_ENV
+        "MAKE_LATEST=false" >> $Env:GITHUB_ENV
+
+    - name: Set stable release metadata
+      if: github.event_name == 'workflow_dispatch'
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        STABLE_VERSION: ${{ inputs.stable_version }}
+      run: |
+        $versionText = $Env:STABLE_VERSION.Trim()
+        if ($versionText -notmatch '^\d+\.\d+\.0$') {
+          throw "Stable version must use X.Y.0 format, for example 2.30.0."
+        }
+
+        $requestedVersion = [version]$versionText
+        $releaseTag = "v$versionText"
+        if (git tag --list $releaseTag) {
+          throw "Tag $releaseTag already exists."
+        }
+
+        $latestVersion = git tag --list 'v[0-9]*.[0-9]*.[0-9]*' |
+          ForEach-Object {
+            $parsed = $null
+            if ([version]::TryParse($_.Substring(1), [ref]$parsed)) { $parsed }
+          } |
+          Sort-Object -Descending |
+          Select-Object -First 1
+        if ($null -ne $latestVersion -and $requestedVersion -le $latestVersion) {
+          throw "Stable version $versionText must be newer than existing version $latestVersion."
+        }
+
+        $headers = @{
+          Accept = "application/vnd.github+json"
+          Authorization = "Bearer $Env:GITHUB_TOKEN"
+          "X-GitHub-Api-Version" = "2022-11-28"
+        }
+        $latestStable = Invoke-RestMethod `
+          -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/releases/latest" `
+          -Headers $headers
+
+        "RELEASE_TAG=$releaseTag" >> $Env:GITHUB_ENV
+        "PREVIOUS_RELEASE_TAG=$($latestStable.tag_name)" >> $Env:GITHUB_ENV
+        "IS_PRERELEASE=false" >> $Env:GITHUB_ENV
+        "MAKE_LATEST=true" >> $Env:GITHUB_ENV
 
     - name: Compute MSIX version from release tag
       run: |
-        $releaseTag = "${{ steps.create_tag.outputs.version_tag }}"
+        $releaseTag = "$Env:RELEASE_TAG"
         if ([string]::IsNullOrWhiteSpace($releaseTag)) {
-          throw "Release tag output is empty."
+          throw "Release tag is empty."
         }
 
         $normalized = $releaseTag -replace '^v', ''
@@ -133,7 +200,7 @@ jobs:
       run: |
         go build -v -ldflags="`
           -X github.com/1dustindavis/gorilla/pkg/version.appName=gorilla`
-          -X github.com/1dustindavis/gorilla/pkg/version.version=${{ steps.create_tag.outputs.version_tag }}`
+          -X github.com/1dustindavis/gorilla/pkg/version.version=${{ env.RELEASE_TAG }}`
           -X github.com/1dustindavis/gorilla/pkg/version.branch=${{ env.CURRENT_BRANCH }}`
           -X github.com/1dustindavis/gorilla/pkg/version.buildDate=$(Get-Date -format s)`
           -X github.com/1dustindavis/gorilla/pkg/version.revision=${{ env.REVISION }}`
@@ -252,7 +319,11 @@ jobs:
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
-        prerelease: true
+        prerelease: ${{ env.IS_PRERELEASE }}
+        makeLatest: ${{ env.MAKE_LATEST }}
+        generateReleaseNotes: true
+        generateReleaseNotesPreviousTag: ${{ env.PREVIOUS_RELEASE_TAG }}
         artifacts: "./cmd/gorilla/gorilla.exe,./build/Gorilla.UI.App.msix"
-        tag: ${{ steps.create_tag.outputs.version_tag }}
+        commit: ${{ github.sha }}
+        tag: ${{ env.RELEASE_TAG }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -12,8 +12,7 @@ on:
         required: true
         type: string
 
-# Release runs share a FIFO queue so version allocation and publication cannot race.
-# queue: max preserves rapid main pushes rather than replacing pending release runs.
+# Serialize release publication and retain rapid main pushes instead of replacing them.
 concurrency:
   group: gorilla-release-publication
   queue: max
@@ -90,29 +89,42 @@ jobs:
     - name: Compute automatic prerelease version
       if: github.event_name == 'push'
       shell: pwsh
+      env:
+        PREVIOUS_MAIN_SHA: ${{ github.event.before }}
       run: |
         # Allocate exactly one patch version for this main-push release. This is
         # intentionally independent of how many commits the merged PR contains.
-        $versions = git tag --list |
+        $latestTag = git tag --list |
           ForEach-Object {
             if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
-              [version]($Matches[1..3] -join '.')
+              [pscustomobject]@{
+                Tag = $_
+                Version = [version]($Matches[1..3] -join '.')
+              }
             }
           } |
-          Sort-Object -Descending
+          Sort-Object Version -Descending |
+          Select-Object -First 1
 
-        $latestVersion = $versions | Select-Object -First 1
-        if ($null -eq $latestVersion) {
+        if ($null -eq $latestTag) {
           throw "No existing vX.Y.Z version tag found."
         }
-        if ($latestVersion.Build -ge 65535) {
-          throw "Patch version cannot exceed the MSIX version segment limit of 65535."
+
+        # GitHub's queued concurrency ordering is not guaranteed to match dispatch
+        # ordering. The preceding main commit must already be the latest released
+        # commit; otherwise fail safely and rerun after its release completes.
+        $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
+        if ($latestTaggedCommit -ne $Env:PREVIOUS_MAIN_SHA) {
+          throw "Previous main commit $Env:PREVIOUS_MAIN_SHA is not the latest released commit ($latestTaggedCommit). An earlier release must complete first; rerun this workflow afterward."
         }
 
+        if ($latestTag.Version.Build -ge 65535) {
+          throw "Patch version cannot exceed the MSIX version segment limit of 65535."
+        }
         $nextVersion = [version]::new(
-          $latestVersion.Major,
-          $latestVersion.Minor,
-          $latestVersion.Build + 1
+          $latestTag.Version.Major,
+          $latestTag.Version.Minor,
+          $latestTag.Version.Build + 1
         )
         "RELEASE_TAG=v$nextVersion" >> $Env:GITHUB_ENV
         Write-Host "Next prerelease: v$nextVersion"
@@ -157,10 +169,8 @@ jobs:
           throw "Current main commit $Env:GITHUB_SHA has not completed its prerelease yet. Wait for Build Release to finish, then retry the stable release."
         }
 
-        # GitHub documents that queue ordering is based on when runs begin waiting,
-        # not dispatch time. Refuse a stable release if any push release is still
-        # queued behind it, rather than allowing an older prerelease to publish
-        # after the stable version.
+        # Refuse a stable release if a push release is queued behind it. This
+        # covers GitHub's documented lack of dispatch-order guarantees.
         $activePushRuns = @()
         foreach ($status in @('queued', 'pending', 'waiting', 'requested')) {
           $uri = "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/actions/workflows/build_release.yml/runs?event=push&status=$status&per_page=100"

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -12,13 +12,14 @@ on:
         required: true
         type: string
 
-# Release runs must be serialized so version allocation and publication cannot race.
+# Release runs share a FIFO queue so version allocation and publication cannot race.
 # queue: max preserves rapid main pushes rather than replacing pending release runs.
 concurrency:
   group: gorilla-release-publication
   queue: max
 
 permissions:
+  actions: read
   contents: write
   pull-requests: read
   id-token: write
@@ -95,7 +96,7 @@ jobs:
         $versions = git tag --list |
           ForEach-Object {
             if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
-              [version]$Matches[1..3] -join '.'
+              [version]($Matches[1..3] -join '.')
             }
           } |
           Sort-Object -Descending
@@ -128,29 +129,57 @@ jobs:
           throw "Stable version must use X.Y.0 format, for example 2.30.0."
         }
 
-        $requestedVersion = [version]$versionText
-        $releaseTag = "v$versionText"
-        if (git tag --list $releaseTag) {
-          throw "Tag $releaseTag already exists."
-        }
-
-        $latestVersion = git tag --list |
-          ForEach-Object {
-            if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
-              [version]($Matches[1..3] -join '.')
-            }
-          } |
-          Sort-Object -Descending |
-          Select-Object -First 1
-        if ($null -ne $latestVersion -and $requestedVersion -le $latestVersion) {
-          throw "Stable version $versionText must be newer than existing version $latestVersion."
-        }
-
         $headers = @{
           Accept = "application/vnd.github+json"
           Authorization = "Bearer $Env:GITHUB_TOKEN"
           "X-GitHub-Api-Version" = "2022-11-28"
         }
+
+        # A stable release is only valid once the current main commit has already
+        # completed its automatic prerelease. This prevents a manual release from
+        # overtaking a main push whose release run has not published yet.
+        $latestTag = git tag --list |
+          ForEach-Object {
+            if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
+              [pscustomobject]@{
+                Tag = $_
+                Version = [version]($Matches[1..3] -join '.')
+              }
+            }
+          } |
+          Sort-Object Version -Descending |
+          Select-Object -First 1
+        if ($null -eq $latestTag) {
+          throw "No existing vX.Y.Z version tag found."
+        }
+        $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
+        if ($latestTaggedCommit -ne $Env:GITHUB_SHA) {
+          throw "Current main commit $Env:GITHUB_SHA has not completed its prerelease yet. Wait for Build Release to finish, then retry the stable release."
+        }
+
+        # GitHub documents that queue ordering is based on when runs begin waiting,
+        # not dispatch time. Refuse a stable release if any push release is still
+        # queued behind it, rather than allowing an older prerelease to publish
+        # after the stable version.
+        $activePushRuns = @()
+        foreach ($status in @('queued', 'pending', 'waiting', 'requested')) {
+          $uri = "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/actions/workflows/build_release.yml/runs?event=push&status=$status&per_page=100"
+          $response = Invoke-RestMethod -Uri $uri -Headers $headers
+          $activePushRuns += @($response.workflow_runs)
+        }
+        if ($activePushRuns.Count -gt 0) {
+          throw "One or more automatic prerelease runs are still queued. Wait for Build Release to become idle, then retry the stable release."
+        }
+
+        $requestedVersion = [version]$versionText
+        $releaseTag = "v$versionText"
+        if (git tag --list $releaseTag) {
+          throw "Tag $releaseTag already exists."
+        }
+        if ($requestedVersion -le $latestTag.Version) {
+          throw "Stable version $versionText must be newer than existing version $($latestTag.Version)."
+        }
+
         $latestStable = Invoke-RestMethod `
           -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/releases/latest" `
           -Headers $headers

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -12,8 +12,15 @@ on:
         required: true
         type: string
 
+# Release runs must be serialized so version allocation and publication cannot race.
+# queue: max preserves rapid main pushes rather than replacing pending release runs.
+concurrency:
+  group: gorilla-release-publication
+  queue: max
+
 permissions:
   contents: write
+  pull-requests: read
   id-token: write
 
 env:
@@ -81,21 +88,33 @@ jobs:
 
     - name: Compute automatic prerelease version
       if: github.event_name == 'push'
-      id: create_tag
-      uses: paulhatch/semantic-version@v6.0.2
-      with:
-        tag_prefix: "v"
-        major_pattern: "__NO_AUTOMATIC_MAJOR_BUMP__"
-        minor_pattern: "__NO_AUTOMATIC_MINOR_BUMP__"
-        version_format: "${major}.${minor}.${patch}"
-        namespace: ''
-        bump_each_commit: true
-
-    - name: Set automatic prerelease metadata
-      if: github.event_name == 'push'
       shell: pwsh
       run: |
-        "RELEASE_TAG=${{ steps.create_tag.outputs.version_tag }}" >> $Env:GITHUB_ENV
+        # Allocate exactly one patch version for this main-push release. This is
+        # intentionally independent of how many commits the merged PR contains.
+        $versions = git tag --list |
+          ForEach-Object {
+            if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
+              [version]$Matches[1..3] -join '.'
+            }
+          } |
+          Sort-Object -Descending
+
+        $latestVersion = $versions | Select-Object -First 1
+        if ($null -eq $latestVersion) {
+          throw "No existing vX.Y.Z version tag found."
+        }
+        if ($latestVersion.Build -ge 65535) {
+          throw "Patch version cannot exceed the MSIX version segment limit of 65535."
+        }
+
+        $nextVersion = [version]::new(
+          $latestVersion.Major,
+          $latestVersion.Minor,
+          $latestVersion.Build + 1
+        )
+        "RELEASE_TAG=v$nextVersion" >> $Env:GITHUB_ENV
+        Write-Host "Next prerelease: v$nextVersion"
 
     - name: Set stable release metadata
       if: github.event_name == 'workflow_dispatch'
@@ -115,9 +134,11 @@ jobs:
           throw "Tag $releaseTag already exists."
         }
 
-        $latestVersion = git tag --list 'v[0-9]*.[0-9]*.[0-9]*' |
+        $latestVersion = git tag --list |
           ForEach-Object {
-            try { [version]($_.Substring(1)) } catch { }
+            if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
+              [version]($Matches[1..3] -join '.')
+            }
           } |
           Sort-Object -Descending |
           Select-Object -First 1
@@ -312,9 +333,28 @@ jobs:
     - name: Prepare prerelease notes
       if: github.event_name == 'push'
       shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $title = git log -1 --pretty=format:"%s"
-        "- $title" | Set-Content -Path release-notes.md -Encoding utf8
+        $headers = @{
+          Accept = "application/vnd.github+json"
+          Authorization = "Bearer $Env:GITHUB_TOKEN"
+          "X-GitHub-Api-Version" = "2022-11-28"
+        }
+        $pulls = @(Invoke-RestMethod `
+          -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/commits/$Env:GITHUB_SHA/pulls" `
+          -Headers $headers)
+        $pr = $pulls |
+          Where-Object { $_.merged_at -and $_.base.ref -eq 'main' } |
+          Sort-Object number -Descending |
+          Select-Object -First 1
+
+        if ($null -ne $pr) {
+          "- $($pr.title) (#$($pr.number))" | Set-Content -Path release-notes.md -Encoding utf8
+        } else {
+          $title = git log -1 --pretty=format:"%s"
+          "- $title" | Set-Content -Path release-notes.md -Encoding utf8
+        }
 
     - name: Cut prerelease
       if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

Simplify Gorilla releases around two paths:

- Every merge to `main` creates exactly one new patch version and marks it as a GitHub prerelease.
- Stable releases are manually dispatched from the **Build Release** workflow by entering an `X.Y.0` version such as `2.30.0`.

## Release notes

- Automatic prereleases resolve the pull request associated with the pushed commit through the GitHub API and contain one bullet with its title and number. This does not depend on squash-merge commit formatting.
- Stable releases use GitHub-generated release notes starting from the previous stable release, so they contain the accumulated merged PRs.

## Versioning behavior

Given the current `v2.29.0` prerelease:

- next merged PR -> `v2.29.1` prerelease
- next merged PR -> `v2.29.2` prerelease
- manually dispatch `2.30.0` -> `v2.30.0` stable
- next merged PR -> `v2.30.1` prerelease

Automatic patch allocation is based on the highest existing numeric version tag plus one patch, not commit count, so multi-commit merge/rebase strategies do not change the increment.

## Release serialization and ordering

Push and manual release runs share a `queue: max` concurrency group. GitHub queues up to 100 pending runs rather than replacing the previous pending release.

Because GitHub does not guarantee that queued runs execute in dispatch order, automatic releases also verify that the push event's previous `main` SHA is the commit carrying the latest version tag. If an out-of-order run ever reaches the front first, it fails safely instead of publishing a version out of order and can be rerun after its predecessor completes.

Stable releases require the current `main` commit to have completed its prerelease and refuse to run while any automatic prerelease is still queued. This prevents a stable release from overtaking pending push releases.

Manual stable versions must use `X.Y.0`, be newer than all existing version tags, and be run from `main`.