### PR TITLE
Make Windows UI CI failures blocking

### DIFF
--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -66,26 +66,18 @@ jobs:
         shell: pwsh
         run: |
           try {
-            $evidenceRoot = Join-Path $PWD 'build/windows-integration/ui-evidence'
-            $attempts = @()
-            if (Test-Path $evidenceRoot) {
-              $attempts = @(Get-ChildItem $evidenceRoot -Directory -Filter 'attempt-*' -ErrorAction SilentlyContinue)
-            }
-
-            $attemptCount = $attempts.Count
             $outcome = '${{ steps.ui-e2e.outcome }}'
             $summary = @(
               '## Windows UI evidence'
               ''
               ('**UI E2E outcome:** {0}  ' -f $outcome)
-              ('**Attempts captured:** {0}  ' -f $attemptCount)
               '**Artifact:** `windows-ui-evidence`'
               ''
               'Download `windows-ui-evidence` from this workflow run''s **Artifacts** section. Start with:'
               ''
-              '1. `attempt-1/healthy/screenshots/` and `attempt-1/service-unavailable/screenshots/` to see what actually rendered.'
+              '1. `healthy/screenshots/` and `service-unavailable/screenshots/` to see what actually rendered.'
               '2. `automation-tree.txt` to inspect the UI Automation hierarchy and exposed state.'
-              '3. `tests-attempt-*.trx` to identify failing tests and test context.'
+              '3. `tests.trx` to identify failing tests and test context.'
               '4. `ui-client.log` and `gorilla.log` to correlate client/service requests and operations.'
               '5. `process-info.txt` and `service-info.txt` for process, exit, and service state.'
             )
@@ -115,12 +107,6 @@ jobs:
         run: |
           try {
             $marker = '<!-- windows-ui-evidence -->'
-            $evidenceRoot = Join-Path $PWD 'build/windows-integration/ui-evidence'
-            $attempts = @()
-            if (Test-Path $evidenceRoot) {
-              $attempts = @(Get-ChildItem $evidenceRoot -Directory -Filter 'attempt-*' -ErrorAction SilentlyContinue)
-            }
-            $attemptCount = $attempts.Count
             $status = if ($Env:UI_E2E_OUTCOME -eq 'success') { '✅ Passed' } else { '❌ Failed' }
             $artifactLink = if ([string]::IsNullOrWhiteSpace($Env:EVIDENCE_URL)) {
               'Evidence artifact unavailable'
@@ -131,7 +117,7 @@ jobs:
             $body = @(
               $marker
               '### Windows UI evidence'
-              ('**{0}** · {1} attempt(s) · commit `{2}`' -f $status, $attemptCount, '${{ github.event.pull_request.head.sha }}')
+              ('**{0}** · commit `{1}`' -f $status, '${{ github.event.pull_request.head.sha }}')
               ('{0} · [Workflow run]({1})' -f $artifactLink, $Env:RUN_URL)
               ''
               'Includes screenshots, UI automation tree, TRX results, client/service logs, and process/service metadata.'

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -39,7 +39,6 @@ jobs:
     name: Verify
     runs-on: windows-latest
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - name: Set Git config
         run: git config --global core.autocrlf false
@@ -60,7 +59,7 @@ jobs:
       - name: Run FlaUI Windows UI validation
         id: ui-e2e
         shell: pwsh
-        run: make ui-e2e UI_E2E_MAX_ATTEMPTS=3
+        run: make ui-e2e
 
       - name: Summarize Windows UI evidence
         if: always()
@@ -89,8 +88,6 @@ jobs:
               '3. `tests-attempt-*.trx` to identify failing tests and test context.'
               '4. `ui-client.log` and `gorilla.log` to correlate client/service requests and operations.'
               '5. `process-info.txt` and `service-info.txt` for process, exit, and service state.'
-              ''
-              'If multiple attempts were captured, inspect the **earliest failed attempt first**; later retries may have succeeded after the original failure.'
             )
             $summary | Add-Content -Path $env:GITHUB_STEP_SUMMARY
           } catch {

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ UI_E2E_WORK_ROOT ?= $(WINDOWS_INTEGRATION_WORK_ROOT)
 RELEASE_INTEGRATION_WORK_ROOT ?= $(CURDIR)/build/release-integration
 RELEASE_USE_PREBUILT_FIXTURES ?= 0
 GORILLA_RELEASE_EXE ?=
-UI_E2E_MAX_ATTEMPTS ?= 1
 GO111MODULE = on
 
 ifneq ($(OS), Windows_NT)
@@ -228,7 +227,7 @@ endif
 
 ui-e2e-test:
 ifeq ($(OS), Windows_NT)
-	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-ui-e2e.ps1 -WorkRoot "$(UI_E2E_WORK_ROOT)" -GorillaExePath "$(CURDIR)/build/gorilla.exe" -MaxAttempts $(UI_E2E_MAX_ATTEMPTS)
+	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-ui-e2e.ps1 -WorkRoot "$(UI_E2E_WORK_ROOT)" -GorillaExePath "$(CURDIR)/build/gorilla.exe"
 else
 	@echo "ui-e2e-test requires Windows"
 	@exit 1

--- a/gorilla-ui/README.md
+++ b/gorilla-ui/README.md
@@ -34,7 +34,7 @@ Validation commands:
   - Harness: `integration/windows/run-ui-e2e.ps1` installs the source-built `gorilla.exe` as a temporary real Windows service, reuses the existing Windows integration fixture preparation, and owns service/server/cache cleanup.
   - Critical workflows: healthy startup with fixture software, install + terminal refresh, remove + terminal refresh, and service-unavailable startup using cached data.
   - CI workflow: `.github/workflows/windows-ui-test.yml` on `windows-latest`.
-  - CI runs one whole E2E scenario attempt and treats a failure as a workflow failure; it does not retry a failed scenario to turn the check green.
+  - CI runs the E2E scenario once and treats a failure as a workflow failure.
   - Stage 5 evidence capture remains enabled on success and failure so failed runs retain screenshots, automation trees, TRX results, client/service logs, and process/service metadata for diagnosis.
   - TRX results and existing failure diagnostics are written under the E2E work root (`build/windows-integration/ui-results` and `ui-artifacts` by default).
 - Optional local autofix: use `dotnet format` against the relevant portable project.

--- a/gorilla-ui/README.md
+++ b/gorilla-ui/README.md
@@ -34,8 +34,8 @@ Validation commands:
   - Harness: `integration/windows/run-ui-e2e.ps1` installs the source-built `gorilla.exe` as a temporary real Windows service, reuses the existing Windows integration fixture preparation, and owns service/server/cache cleanup.
   - Critical workflows: healthy startup with fixture software, install + terminal refresh, remove + terminal refresh, and service-unavailable startup using cached data.
   - CI workflow: `.github/workflows/windows-ui-test.yml` on `windows-latest`.
-  - CI remains non-blocking (`continue-on-error: true`) with up to 3 whole-scenario attempts until the later reliability stage tightens that policy.
-  - Retries recreate the service and test state rather than retrying individual UI interactions against dirty state.
+  - CI runs one whole E2E scenario attempt and treats a failure as a workflow failure; it does not retry a failed scenario to turn the check green.
+  - Stage 5 evidence capture remains enabled on success and failure so failed runs retain screenshots, automation trees, TRX results, client/service logs, and process/service metadata for diagnosis.
   - TRX results and existing failure diagnostics are written under the E2E work root (`build/windows-integration/ui-results` and `ui-artifacts` by default).
 - Optional local autofix: use `dotnet format` against the relevant portable project.
 

--- a/gorilla-ui/docs/ui-evidence.md
+++ b/gorilla-ui/docs/ui-evidence.md
@@ -6,34 +6,31 @@
 build/windows-integration/ui-evidence/
 ```
 
-Evidence is isolated by whole-scenario attempt and E2E phase so a retry cannot erase the diagnostics from the failed attempt:
+Evidence is isolated by E2E phase:
 
 ```text
 ui-evidence/
-  attempt-1/
-    healthy/
-      screenshots/
-        healthy-startup.png
-        after-install.png
-        after-remove.png
-      automation-tree.txt
-      ui-client.log
-      gorilla.log
-      process-info.txt
-      service-info.txt
-      tests-attempt-1.trx
-    service-unavailable/
-      screenshots/
-        cached-service-unavailable.png
-      automation-tree.txt
-      ui-client.log
-      gorilla.log
-      process-info.txt
-      service-info.txt
-      tests-attempt-1.trx
-    harness-failure.txt       # only when the scenario attempt fails
-  attempt-2/
-    ...                       # present only when a retry runs
+  healthy/
+    screenshots/
+      healthy-startup.png
+      after-install.png
+      after-remove.png
+    automation-tree.txt
+    ui-client.log
+    gorilla.log
+    process-info.txt
+    service-info.txt
+    tests.trx
+  service-unavailable/
+    screenshots/
+      cached-service-unavailable.png
+    automation-tree.txt
+    ui-client.log
+    gorilla.log
+    process-info.txt
+    service-info.txt
+    tests.trx
+  harness-failure.txt       # only when the E2E harness fails outside a phase test
 ```
 
 The exact set is best-effort. A failure that prevents the application or service from starting may naturally make some files unavailable. Diagnostic collection must never replace or hide the original test failure.
@@ -46,6 +43,6 @@ The exact set is best-effort. A failure that prevents the application or service
 - `gorilla.log` is copied from the isolated test service's configured `app_data_path`; E2E also enables service debug logging for protocol troubleshooting.
 - `process-info.txt` records the launched UI process ID and lifecycle/exit metadata when available. Failure-specific text diagnostics also embed this process information.
 - `service-info.txt` records the Windows service state and process metadata at the end of the phase when available.
-- `tests-attempt-1.trx` is the xUnit/.NET test result for that isolated phase. The inner test runner uses one attempt; retries happen at the outer scenario level and therefore get a new `attempt-N` directory.
+- `tests.trx` is the xUnit/.NET test result for that phase.
 
-When diagnosing a retry, inspect the earliest failed `attempt-N` first rather than only the final successful attempt. Correlate `ui-client.log` and `gorilla.log` by request/operation IDs where present, then use the screenshot and automation tree to confirm what WinUI actually exposed at the failing point.
+When diagnosing a failure, start with the affected phase directory. Correlate `ui-client.log` and `gorilla.log` by request/operation IDs where present, then use the screenshot and automation tree to confirm what WinUI actually exposed at the failing point.

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/run-tests.ps1
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/run-tests.ps1
@@ -3,7 +3,6 @@ param(
     [string]$ArtifactsDirectory = "$PSScriptRoot\artifacts",
     [string]$TestFilter = "",
     [string]$ResultPrefix = "windows-ui-test",
-    [int]$MaxAttempts = 1,
     [switch]$SkipBuild
 )
 
@@ -55,27 +54,18 @@ $env:GORILLA_UI_APP_EXE = $appExe
 $env:WINDOWS_UI_TEST_RESULTS_DIR = $ResultsDirectory
 $env:WINDOWS_UI_TEST_ARTIFACTS_DIR = $ArtifactsDirectory
 
-for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-    Write-Host "Windows UI test attempt $attempt/$MaxAttempts"
-    $testArgs = @(
-        "test", $testProject,
-        "-c", "Release",
-        "--no-build",
-        "--logger", "trx;LogFileName=$ResultPrefix-attempt-$attempt.trx",
-        "--results-directory", $ResultsDirectory
-    )
-    if (-not [string]::IsNullOrWhiteSpace($TestFilter)) {
-        $testArgs += @("--filter", $TestFilter)
-    }
-
-    & dotnet @testArgs
-    if ($LASTEXITCODE -eq 0) {
-        return
-    }
-
-    if ($attempt -lt $MaxAttempts) {
-        Start-Sleep -Seconds (15 * $attempt)
-    }
+$testArgs = @(
+    "test", $testProject,
+    "-c", "Release",
+    "--no-build",
+    "--logger", "trx;LogFileName=$ResultPrefix.trx",
+    "--results-directory", $ResultsDirectory
+)
+if (-not [string]::IsNullOrWhiteSpace($TestFilter)) {
+    $testArgs += @("--filter", $TestFilter)
 }
 
-throw "Windows UI tests failed after $MaxAttempts attempt(s)"
+& dotnet @testArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows UI tests failed"
+}

--- a/integration/windows/run-ui-e2e.ps1
+++ b/integration/windows/run-ui-e2e.ps1
@@ -1,7 +1,6 @@
 param(
     [string]$WorkRoot = "$env:RUNNER_TEMP\gorilla-ui-e2e",
-    [string]$GorillaExePath = "",
-    [int]$MaxAttempts = 1
+    [string]$GorillaExePath = ""
 )
 
 Set-StrictMode -Version Latest
@@ -133,11 +132,10 @@ function Copy-PhaseServiceEvidence {
 function Invoke-TestPhase {
     param(
         [Parameter(Mandatory)][string]$Phase,
-        [Parameter(Mandatory)][string]$Filter,
-        [Parameter(Mandatory)][int]$Attempt
+        [Parameter(Mandatory)][string]$Filter
     )
 
-    $phaseDirectory = Join-Path (Join-Path $evidenceRoot "attempt-$Attempt") $Phase
+    $phaseDirectory = Join-Path $evidenceRoot $Phase
     New-Item -ItemType Directory -Path $phaseDirectory -Force | Out-Null
 
     $env:GORILLA_UI_DEBUG = "1"
@@ -148,7 +146,6 @@ function Invoke-TestPhase {
             -ArtifactsDirectory $phaseDirectory `
             -TestFilter $Filter `
             -ResultPrefix "tests" `
-            -MaxAttempts 1 `
             -SkipBuild
     } finally {
         Copy-PhaseServiceEvidence -PhaseDirectory $phaseDirectory
@@ -156,29 +153,25 @@ function Invoke-TestPhase {
     }
 }
 
-for ($scenarioAttempt = 1; $scenarioAttempt -le $MaxAttempts; $scenarioAttempt++) {
-    Write-Host "UI E2E scenario attempt $scenarioAttempt/$MaxAttempts"
-    $attemptDirectory = Join-Path $evidenceRoot "attempt-$scenarioAttempt"
-    New-Item -ItemType Directory -Path $attemptDirectory -Force | Out-Null
-    $serverProc = $null
-    try {
-        Remove-TestService
-        Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
-        Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
-        Remove-Item -LiteralPath (Split-Path -Parent $uiCachePath) -Recurse -Force -ErrorAction SilentlyContinue
-        New-Item -ItemType Directory -Path (Split-Path -Parent $configPath), $evidenceRoot -Force | Out-Null
+$serverProc = $null
+try {
+    Remove-TestService
+    Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Split-Path -Parent $uiCachePath) -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path (Split-Path -Parent $configPath), $evidenceRoot -Force | Out-Null
 
-        $serverPort = Get-Random -Minimum 19000 -Maximum 19999
-        $serverProc = Start-Process -FilePath $serverExe `
-            -ArgumentList @("-addr", "127.0.0.1:$serverPort", "-root", $repoFixtureRoot) `
-            -PassThru -WindowStyle Hidden
-        Start-Sleep -Seconds 1
-        if ($serverProc.HasExited) {
-            throw "Fixture HTTP server exited during startup"
-        }
+    $serverPort = Get-Random -Minimum 19000 -Maximum 19999
+    $serverProc = Start-Process -FilePath $serverExe `
+        -ArgumentList @("-addr", "127.0.0.1:$serverPort", "-root", $repoFixtureRoot) `
+        -PassThru -WindowStyle Hidden
+    Start-Sleep -Seconds 1
+    if ($serverProc.HasExited) {
+        throw "Fixture HTTP server exited during startup"
+    }
 
-        $fileUrl = "http://127.0.0.1:$serverPort/"
-        @"
+    $fileUrl = "http://127.0.0.1:$serverPort/"
+    @"
 url: $fileUrl
 manifest: ui-e2e
 catalogs:
@@ -190,42 +183,37 @@ service_interval: 24h
 debug: true
 "@ | Set-Content -LiteralPath $configPath -NoNewline
 
-        $env:GORILLA_UI_PIPE_NAME = $servicePipeName
-        $env:GORILLA_UI_CACHE_PATH = $uiCachePath
-        $env:GORILLA_UI_E2E_MARKER_PATH = $markerPath
-        $env:GORILLA_UI_E2E_CACHE_PATH = $uiCachePath
+    $env:GORILLA_UI_PIPE_NAME = $servicePipeName
+    $env:GORILLA_UI_CACHE_PATH = $uiCachePath
+    $env:GORILLA_UI_E2E_MARKER_PATH = $markerPath
+    $env:GORILLA_UI_E2E_CACHE_PATH = $uiCachePath
 
-        & $GorillaExePath -config $configPath -serviceinstall | Out-Host
-        if ($LASTEXITCODE -ne 0) { throw "Failed to install source-built Gorilla service" }
-        & $GorillaExePath -config $configPath -servicestart | Out-Host
-        if ($LASTEXITCODE -ne 0) { throw "Failed to start source-built Gorilla service" }
-        Wait-ServiceState -Expected "Running"
+    & $GorillaExePath -config $configPath -serviceinstall | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Failed to install source-built Gorilla service" }
+    & $GorillaExePath -config $configPath -servicestart | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Failed to start source-built Gorilla service" }
+    Wait-ServiceState -Expected "Running"
 
-        Invoke-TestPhase -Phase "healthy" -Filter "E2EPhase=Healthy|FullyQualifiedName~AppLaunchSmokeTests" -Attempt $scenarioAttempt
+    Invoke-TestPhase -Phase "healthy" -Filter "E2EPhase=Healthy|FullyQualifiedName~AppLaunchSmokeTests"
 
-        # The unavailable-service workflow deliberately terminates the real service process.
-        # This avoids coupling E2E reliability to graceful SCM shutdown while still proving
-        # that the UI recovers from the production service boundary disappearing.
-        Stop-TestServiceProcess
-        Invoke-TestPhase -Phase "service-unavailable" -Filter "E2EPhase=ServiceUnavailable" -Attempt $scenarioAttempt
-        Write-Host "UI E2E scenario passed"
-        return
+    # The unavailable-service workflow deliberately terminates the real service process.
+    # This avoids coupling E2E reliability to graceful SCM shutdown while still proving
+    # that the UI recovers from the production service boundary disappearing.
+    Stop-TestServiceProcess
+    Invoke-TestPhase -Phase "service-unavailable" -Filter "E2EPhase=ServiceUnavailable"
+    Write-Host "UI E2E scenario passed"
+} catch {
+    $originalError = $_
+    try {
+        $originalError | Out-String | Set-Content -LiteralPath (Join-Path $evidenceRoot "harness-failure.txt")
     } catch {
-        $originalError = $_
-        try {
-            $originalError | Out-String | Set-Content -LiteralPath (Join-Path $attemptDirectory "harness-failure.txt")
-        } catch {
-            Write-Warning "Unable to capture UI E2E harness failure evidence: $_"
-        }
-        Write-Warning "UI E2E scenario attempt $scenarioAttempt failed: $originalError"
-        if ($scenarioAttempt -ge $MaxAttempts) {
-            throw $originalError
-        }
-        Start-Sleep -Seconds (15 * $scenarioAttempt)
-    } finally {
-        Remove-TestService
-        if ($serverProc -and -not $serverProc.HasExited) {
-            Stop-Process -Id $serverProc.Id -Force -ErrorAction SilentlyContinue
-        }
+        Write-Warning "Unable to capture UI E2E harness failure evidence: $_"
+    }
+    Write-Warning "UI E2E scenario failed: $originalError"
+    throw $originalError
+} finally {
+    Remove-TestService
+    if ($serverProc -and -not $serverProc.HasExited) {
+        Stop-Process -Id $serverProc.Id -Force -ErrorAction SilentlyContinue
     }
 }


### PR DESCRIPTION
## Summary

Makes Windows UI validation behave like the repository's other CI checks: one run, one result, no retry model.

- removes job-level `continue-on-error`, so a real UI E2E failure is reported as a workflow failure
- removes retry configuration from the Makefile, outer E2E harness, and inner Windows UI test runner
- flattens UI evidence from `ui-evidence/attempt-1/<phase>/` to `ui-evidence/<phase>/`
- uses stable `tests.trx` names instead of attempt-suffixed result files
- removes attempt counting/references from the workflow summary and PR evidence comment
- keeps Stage 5 evidence capture and PR linking active on success or failure
- updates UI documentation to describe the single-run model and flat evidence layout

This intentionally does **not** add soak infrastructure or a per-test reliability aggregator. The current real-service E2E suite is new, and the repository does not contain evidence that the former retry policy was based on measured flakiness. If intermittent failures are observed, the evidence bundle should provide the data needed to address the actual failure mode.

## Validation

The full PR diff was reviewed against `main` after every commit and again after final CI. The final branch changes only the Windows UI workflow, Makefile UI E2E invocation, E2E/test runner scripts, and related documentation.

Fresh PR CI on final head `642c839ddc33614cf5747b92525022648903984a` confirms the intended behavior:

- Windows UI Tests: success
  - workflow invoked plain `make ui-e2e`
  - Makefile invoked `run-ui-e2e.ps1` with no retry/attempt parameter
  - healthy phase: 3/3 passed, result at `ui-evidence/healthy/tests.trx`
  - service-unavailable phase: 1/1 passed, result at `ui-evidence/service-unavailable/tests.trx`
  - no attempt/retry messages were emitted by the E2E/test runners
- `windows-ui-evidence` uploaded successfully with 16 files
  - artifact root contains `healthy/` and `service-unavailable/` directly
  - no `attempt-*` directory exists
  - both phases contain `tests.trx`
- PR evidence comment was updated in place and contains pass/fail, commit, artifact, and workflow links with no attempt count
- Go Tests: success
- UI Client Tests: success
- Windows Integration: success
- Released-Binary Integration: success

No application or service behavior changes are included.

## Scope note

The repository currently has no required status-check contexts configured in branch protection. This PR makes the Windows UI workflow itself fail on a UI E2E failure; it does not change branch-protection/ruleset policy.

This implements the retry/non-blocking policy cleanup portion of #171. It deliberately does not claim the original Stage 6 soak/per-test reliability acceptance items; those should only be revisited if actual flakiness evidence justifies the extra machinery.