### PR TITLE
Prepare CI checks for required status enforcement

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,15 +13,6 @@ on:
       - go.sum
       - .github/workflows/go-test.yml
   pull_request:
-    paths:
-      - cmd/**
-      - pkg/**
-      - utils/**
-      - integration/**
-      - Makefile
-      - go.mod
-      - go.sum
-      - .github/workflows/go-test.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -33,7 +24,7 @@ permissions:
 jobs:
 
   build:
-    name: Verify
+    name: Go Tests
     runs-on: windows-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/ui-client-test.yml
+++ b/.github/workflows/ui-client-test.yml
@@ -11,12 +11,6 @@ on:
       - Makefile
       - .github/workflows/ui-client-test.yml
   pull_request:
-    paths:
-      - gorilla-ui/**
-      - '!gorilla-ui/*.md'
-      - '!gorilla-ui/**/*.md'
-      - Makefile
-      - .github/workflows/ui-client-test.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,7 +21,7 @@ permissions:
 
 jobs:
   build:
-    name: Verify
+    name: UI Client Tests
     runs-on: windows-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/windows-integration-tests.yml
+++ b/.github/workflows/windows-integration-tests.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   integration-tests:
-    name: Verify
+    name: Windows Integration
     runs-on: windows-latest
     timeout-minutes: 60
 

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -15,16 +15,6 @@ on:
       - Makefile
       - .github/workflows/windows-ui-test.yml
   pull_request:
-    paths:
-      - gorilla-ui/**
-      - '!gorilla-ui/*.md'
-      - '!gorilla-ui/**/*.md'
-      - cmd/gorilla/**
-      - pkg/config/**
-      - pkg/service/**
-      - integration/windows/**
-      - Makefile
-      - .github/workflows/windows-ui-test.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -36,7 +26,7 @@ permissions:
 
 jobs:
   windows-ui-tests:
-    name: Verify
+    name: Windows UI Tests
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -45,24 +35,71 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine whether UI E2E is required
+        id: changes
+        shell: pwsh
+        run: |
+          if ('${{ github.event_name }}' -ne 'pull_request') {
+            'run=true' >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          $base = '${{ github.event.pull_request.base.sha }}'
+          $head = '${{ github.event.pull_request.head.sha }}'
+          $files = @(git diff --name-only $base $head)
+          $runUi = $false
+
+          foreach ($file in $files) {
+            $isUiSource = $file -like 'gorilla-ui/*' -and $file -notmatch '\.md$'
+            $isRelevant = $isUiSource -or
+              $file -like 'cmd/gorilla/*' -or
+              $file -like 'pkg/config/*' -or
+              $file -like 'pkg/service/*' -or
+              $file -like 'integration/windows/*' -or
+              $file -eq 'Makefile' -or
+              $file -eq '.github/workflows/windows-ui-test.yml'
+
+            if ($isRelevant) {
+              $runUi = $true
+              break
+            }
+          }
+
+          ('run={0}' -f $runUi.ToString().ToLowerInvariant()) >> $env:GITHUB_OUTPUT
 
       - name: Configure NuGet package path
+        if: steps.changes.outputs.run == 'true'
         shell: pwsh
         run: |
           "NUGET_PACKAGES=$env:RUNNER_TEMP\nuget-packages" >> $env:GITHUB_ENV
 
       - name: Set up .NET
+        if: steps.changes.outputs.run == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
       - name: Run FlaUI Windows UI validation
+        if: steps.changes.outputs.run == 'true'
         id: ui-e2e
         shell: pwsh
         run: make ui-e2e
 
+      - name: Summarize skipped Windows UI validation
+        if: steps.changes.outputs.run != 'true'
+        shell: pwsh
+        run: |
+          @(
+            '## Windows UI validation'
+            ''
+            'UI E2E was not required for the files changed by this pull request.'
+          ) | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+
       - name: Summarize Windows UI evidence
-        if: always()
+        if: always() && steps.changes.outputs.run == 'true'
         shell: pwsh
         run: |
           try {
@@ -88,7 +125,7 @@ jobs:
 
       - name: Upload Windows UI evidence bundle
         id: upload-evidence
-        if: always()
+        if: always() && steps.changes.outputs.run == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: windows-ui-evidence
@@ -96,7 +133,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Link Windows UI evidence from PR
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.changes.outputs.run == 'true'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -49,7 +49,7 @@ jobs:
 
           $base = '${{ github.event.pull_request.base.sha }}'
           $head = '${{ github.event.pull_request.head.sha }}'
-          $files = @(git diff --name-only $base $head)
+          $files = @(git diff --name-only "$base...$head")
           $runUi = $false
 
           foreach ($file in $files) {


### PR DESCRIPTION
## Summary

Prepares Gorilla's CI checks to be safely required by the repository's `main-branch-protection` ruleset.

- makes Go Tests run on every pull request instead of using PR path filters
- makes UI Client Tests run on every pull request instead of using PR path filters
- keeps Windows Integration running on every pull request
- gives each required workflow job a unique, stable check-run name instead of the ambiguous shared `Verify` name
- makes Windows UI Tests publish a check on every pull request while only running the expensive FlaUI E2E validation when relevant files changed
- uses merge-base (`base...head`) diff semantics so UI relevance is based on the PR's own changed files even if `main` advances
- preserves the existing Windows UI path scope for `push` runs and for deciding whether a PR needs E2E
- avoids posting UI evidence comments or artifacts when UI E2E was intentionally not needed

## Why

The active repository ruleset currently requires pull requests but no status checks. Requiring the existing checks without these workflow changes would be unsafe:

1. Go Tests and UI Client Tests currently use `pull_request.paths`, so unrelated PRs can have no check run to satisfy a required-check rule.
2. All current Actions jobs are named `Verify`, so GitHub check runs are not uniquely identifiable by validation layer.
3. Windows UI Tests is intentionally path-scoped; this change makes its check context always available while retaining selective execution of the expensive E2E body.

## Intended ruleset after merge

Add required status checks for these GitHub Actions check-run contexts:

- `Go Tests`
- `UI Client Tests`
- `Windows Integration`
- `Windows UI Tests`

Where supported, bind them to the GitHub Actions integration (integration ID `15368`) rather than accepting an identically named status from another integration.

Do **not** require Released-Binary Integration for every PR.

The repository ruleset itself is GitHub repository configuration rather than a versioned repository file, so this PR prepares and validates the workflow side. The `main-branch-protection` ruleset should be updated after this PR merges and the new check names have appeared in GitHub Actions.

## Validation

Fresh CI on final head `2600435fab8e2a3601043a3af9d1e6a1d49650d1` passed all five workflows:

- Go Tests: success
- UI Client Tests: success
- Windows Integration: success
- Windows UI Tests: success
- Released-Binary Integration: success

The live check suite shows the intended unique required-check names. Windows UI Tests also validated the relevance detector on the final head: because this PR changes `.github/workflows/windows-ui-test.yml`, the detector selected the full E2E path and `Run FlaUI Windows UI validation` ran successfully.

The UI relevance diff uses `git diff --name-only "$base...$head"`, matching GitHub PR changed-file semantics via the merge base and avoiding false-positive E2E runs if `main` advances after the PR was opened.

The full PR diff was reviewed after every commit and again after final CI. It changes only the four affected workflow files; no product behavior is modified.

Relates to #171.