### PR TITLE
Implement Stage 7 installed-product validation

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -289,9 +289,9 @@ jobs:
         if ($null -eq $msix) {
           throw "No MSIX package found under gorilla-ui/src/Gorilla.UI.App/AppPackages"
         }
-        Copy-Item $msix.FullName "build/Gorilla.UI.App.msix" -Force
+        Copy-Item $msix.FullName "build/gorilla.msix" -Force
 
-        $packagePath = (Resolve-Path "build/Gorilla.UI.App.msix").Path
+        $packagePath = (Resolve-Path "build/gorilla.msix").Path
         $signature = Get-AuthenticodeSignature -FilePath $packagePath
         if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) {
           throw "Expected the packaged MSIX to be unsigned before Artifact Signing, but status was $($signature.Status)."
@@ -337,14 +337,14 @@ jobs:
         endpoint: ${{ env.ARTIFACT_SIGNING_ENDPOINT }}
         signing-account-name: ${{ env.ARTIFACT_SIGNING_ACCOUNT }}
         certificate-profile-name: ${{ env.ARTIFACT_SIGNING_PROFILE }}
-        files: ${{ github.workspace }}\build\Gorilla.UI.App.msix
+        files: ${{ github.workspace }}\build\gorilla.msix
         file-digest: SHA256
         timestamp-digest: SHA256
 
     - name: Verify signed MSIX
       shell: pwsh
       run: |
-        $packagePath = "$Env:GITHUB_WORKSPACE\build\Gorilla.UI.App.msix"
+        $packagePath = "$Env:GITHUB_WORKSPACE\build\gorilla.msix"
         $signature = Get-AuthenticodeSignature -FilePath $packagePath
 
         if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
@@ -366,7 +366,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: gorilla-ui-msix-release
-        path: ./build/Gorilla.UI.App.msix
+        path: ./build/gorilla.msix
         if-no-files-found: error
 
     - name: Prepare prerelease notes
@@ -403,7 +403,7 @@ jobs:
         prerelease: true
         makeLatest: false
         bodyFile: release-notes.md
-        artifacts: "./cmd/gorilla/gorilla.exe,./build/Gorilla.UI.App.msix"
+        artifacts: "./cmd/gorilla/gorilla.exe,./build/gorilla.msix"
         commit: ${{ github.sha }}
         tag: ${{ env.RELEASE_TAG }}
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -417,7 +417,7 @@ jobs:
         makeLatest: true
         generateReleaseNotes: true
         generateReleaseNotesPreviousTag: ${{ env.PREVIOUS_STABLE_TAG }}
-        artifacts: "./cmd/gorilla/gorilla.exe,./build/Gorilla.UI.App.msix"
+        artifacts: "./cmd/gorilla/gorilla.exe,./build/gorilla.msix"
         commit: ${{ github.sha }}
         tag: ${{ env.RELEASE_TAG }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -90,6 +90,7 @@ jobs:
       if: github.event_name == 'push'
       shell: pwsh
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PREVIOUS_MAIN_SHA: ${{ github.event.before }}
       run: |
         # Allocate exactly one patch version for this main-push release. This is
@@ -111,11 +112,39 @@ jobs:
         }
 
         # GitHub's queued concurrency ordering is not guaranteed to match dispatch
-        # ordering. The preceding main commit must already be the latest released
-        # commit; otherwise fail safely and rerun after its release completes.
+        # ordering. Normally the preceding main commit must already be the latest
+        # released commit. The one exception is a predecessor that reached and
+        # failed the installed-product gate: because it was never published, the
+        # next main commit may safely reuse the next available patch version.
         $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
         if ($latestTaggedCommit -ne $Env:PREVIOUS_MAIN_SHA) {
-          throw "Previous main commit $Env:PREVIOUS_MAIN_SHA is not the latest released commit ($latestTaggedCommit). An earlier release must complete first; rerun this workflow afterward."
+          $headers = @{
+            Accept = "application/vnd.github+json"
+            Authorization = "Bearer $Env:GITHUB_TOKEN"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $runsUri = "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/actions/workflows/build_release.yml/runs?event=push&status=completed&head_sha=$Env:PREVIOUS_MAIN_SHA&per_page=20"
+          $runs = @(Invoke-RestMethod -Uri $runsUri -Headers $headers).workflow_runs
+          $predecessorFailedReleaseGate = $false
+
+          foreach ($run in $runs) {
+            $jobs = @(Invoke-RestMethod -Uri $run.jobs_url -Headers $headers).jobs
+            foreach ($job in $jobs) {
+              $gate = @($job.steps | Where-Object { $_.name -eq 'Validate exact release artifacts before publication' })
+              if ($gate.Count -gt 0 -and $gate[0].conclusion -eq 'failure') {
+                $predecessorFailedReleaseGate = $true
+                break
+              }
+            }
+            if ($predecessorFailedReleaseGate) {
+              break
+            }
+          }
+
+          if (-not $predecessorFailedReleaseGate) {
+            throw "Previous main commit $Env:PREVIOUS_MAIN_SHA is not the latest released commit ($latestTaggedCommit). An earlier release must complete first; rerun this workflow afterward."
+          }
+          Write-Warning "Previous main commit $Env:PREVIOUS_MAIN_SHA failed pre-publication release validation and was not released; reusing the next available patch version."
         }
 
         if ($latestTag.Version.Build -ge 65535) {

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -92,40 +92,21 @@ jobs:
       env:
         PREVIOUS_MAIN_SHA: ${{ github.event.before }}
       run: |
-        # Allocate exactly one patch version for this main-push release. This is
-        # intentionally independent of how many commits the merged PR contains.
         $latestTag = git tag --list |
           ForEach-Object {
             if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
-              [pscustomobject]@{
-                Tag = $_
-                Version = [version]($Matches[1..3] -join '.')
-              }
+              [pscustomobject]@{ Tag = $_; Version = [version]($Matches[1..3] -join '.') }
             }
           } |
           Sort-Object Version -Descending |
           Select-Object -First 1
-
-        if ($null -eq $latestTag) {
-          throw "No existing vX.Y.Z version tag found."
-        }
-
-        # GitHub's queued concurrency ordering is not guaranteed to match dispatch
-        # ordering. The preceding main commit must already be the latest released
-        # commit; otherwise fail safely and rerun after its release completes.
+        if ($null -eq $latestTag) { throw "No existing vX.Y.Z version tag found." }
         $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
         if ($latestTaggedCommit -ne $Env:PREVIOUS_MAIN_SHA) {
           throw "Previous main commit $Env:PREVIOUS_MAIN_SHA is not the latest released commit ($latestTaggedCommit). An earlier release must complete first; rerun this workflow afterward."
         }
-
-        if ($latestTag.Version.Build -ge 65535) {
-          throw "Patch version cannot exceed the MSIX version segment limit of 65535."
-        }
-        $nextVersion = [version]::new(
-          $latestTag.Version.Major,
-          $latestTag.Version.Minor,
-          $latestTag.Version.Build + 1
-        )
+        if ($latestTag.Version.Build -ge 65535) { throw "Patch version cannot exceed the MSIX version segment limit of 65535." }
+        $nextVersion = [version]::new($latestTag.Version.Major,$latestTag.Version.Minor,$latestTag.Version.Build + 1)
         "RELEASE_TAG=v$nextVersion" >> $Env:GITHUB_ENV
         Write-Host "Next prerelease: v$nextVersion"
 
@@ -137,91 +118,57 @@ jobs:
         STABLE_VERSION: ${{ inputs.stable_version }}
       run: |
         $versionText = $Env:STABLE_VERSION.Trim()
-        if ($versionText -notmatch '^\d+\.\d+\.0$') {
-          throw "Stable version must use X.Y.0 format, for example 2.30.0."
-        }
-
-        $headers = @{
-          Accept = "application/vnd.github+json"
-          Authorization = "Bearer $Env:GITHUB_TOKEN"
-          "X-GitHub-Api-Version" = "2022-11-28"
-        }
-
-        # A stable release is only valid once the current main commit has already
-        # completed its automatic prerelease. This prevents a manual release from
-        # overtaking a main push whose release run has not published yet.
+        if ($versionText -notmatch '^\d+\.\d+\.0$') { throw "Stable version must use X.Y.0 format, for example 2.30.0." }
+        $headers = @{ Accept = "application/vnd.github+json"; Authorization = "Bearer $Env:GITHUB_TOKEN"; "X-GitHub-Api-Version" = "2022-11-28" }
         $latestTag = git tag --list |
           ForEach-Object {
             if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
-              [pscustomobject]@{
-                Tag = $_
-                Version = [version]($Matches[1..3] -join '.')
-              }
+              [pscustomobject]@{ Tag = $_; Version = [version]($Matches[1..3] -join '.') }
             }
           } |
           Sort-Object Version -Descending |
           Select-Object -First 1
-        if ($null -eq $latestTag) {
-          throw "No existing vX.Y.Z version tag found."
-        }
+        if ($null -eq $latestTag) { throw "No existing vX.Y.Z version tag found." }
         $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
-        if ($latestTaggedCommit -ne $Env:GITHUB_SHA) {
-          throw "Current main commit $Env:GITHUB_SHA has not completed its prerelease yet. Wait for Build Release to finish, then retry the stable release."
-        }
-
-        # Refuse a stable release if a push release is queued behind it. This
-        # covers GitHub's documented lack of dispatch-order guarantees.
+        if ($latestTaggedCommit -ne $Env:GITHUB_SHA) { throw "Current main commit $Env:GITHUB_SHA has not completed its prerelease yet. Wait for Build Release to finish, then retry the stable release." }
         $activePushRuns = @()
         foreach ($status in @('queued', 'pending', 'waiting', 'requested')) {
           $uri = "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/actions/workflows/build_release.yml/runs?event=push&status=$status&per_page=100"
           $response = Invoke-RestMethod -Uri $uri -Headers $headers
           $activePushRuns += @($response.workflow_runs)
         }
-        if ($activePushRuns.Count -gt 0) {
-          throw "One or more automatic prerelease runs are still queued. Wait for Build Release to become idle, then retry the stable release."
-        }
-
+        if ($activePushRuns.Count -gt 0) { throw "One or more automatic prerelease runs are still queued. Wait for Build Release to become idle, then retry the stable release." }
         $requestedVersion = [version]$versionText
         $releaseTag = "v$versionText"
-        if (git tag --list $releaseTag) {
-          throw "Tag $releaseTag already exists."
-        }
-        if ($requestedVersion -le $latestTag.Version) {
-          throw "Stable version $versionText must be newer than existing version $($latestTag.Version)."
-        }
-
-        $latestStable = Invoke-RestMethod `
-          -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/releases/latest" `
-          -Headers $headers
-
+        if (git tag --list $releaseTag) { throw "Tag $releaseTag already exists." }
+        if ($requestedVersion -le $latestTag.Version) { throw "Stable version $versionText must be newer than existing version $($latestTag.Version)." }
+        $latestStable = Invoke-RestMethod -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/releases/latest" -Headers $headers
         "RELEASE_TAG=$releaseTag" >> $Env:GITHUB_ENV
         "PREVIOUS_STABLE_TAG=$($latestStable.tag_name)" >> $Env:GITHUB_ENV
+
+    - name: Compute release artifact names
+      shell: pwsh
+      run: |
+        $version = "$Env:RELEASE_TAG" -replace '^v', ''
+        if ([string]::IsNullOrWhiteSpace($version)) { throw "Release version is empty." }
+        "RELEASE_VERSION=$version" >> $Env:GITHUB_ENV
+        "RELEASE_EXE_NAME=gorilla-$version.exe" >> $Env:GITHUB_ENV
+        "RELEASE_MSIX_NAME=gorilla-$version.msix" >> $Env:GITHUB_ENV
 
     - name: Compute MSIX version from release tag
       run: |
         $releaseTag = "$Env:RELEASE_TAG"
-        if ([string]::IsNullOrWhiteSpace($releaseTag)) {
-          throw "Release tag is empty."
-        }
-
+        if ([string]::IsNullOrWhiteSpace($releaseTag)) { throw "Release tag is empty." }
         $normalized = $releaseTag -replace '^v', ''
         $parts = $normalized.Split('.')
-        if ($parts.Count -lt 1 -or $parts.Count -gt 4) {
-          throw "Unsupported release tag format for MSIX version: $releaseTag"
-        }
-
+        if ($parts.Count -lt 1 -or $parts.Count -gt 4) { throw "Unsupported release tag format for MSIX version: $releaseTag" }
         $versionParts = @(0, 0, 0, 0)
         for ($i = 0; $i -lt $parts.Count; $i++) {
           [int]$value = 0
-          if (-not [int]::TryParse($parts[$i], [ref]$value)) {
-            throw "Release tag contains non-numeric segment: $releaseTag"
-          }
-          if ($value -lt 0 -or $value -gt 65535) {
-            throw "MSIX version segment out of range (0-65535): $value"
-          }
+          if (-not [int]::TryParse($parts[$i], [ref]$value)) { throw "Release tag contains non-numeric segment: $releaseTag" }
+          if ($value -lt 0 -or $value -gt 65535) { throw "MSIX version segment out of range (0-65535): $value" }
           $versionParts[$i] = $value
         }
-
         $msixVersion = "{0}.{1}.{2}.{3}" -f $versionParts[0], $versionParts[1], $versionParts[2], $versionParts[3]
         echo "MSIX_VERSION=$msixVersion" >> $Env:GITHUB_ENV
         Write-Host "MSIX version: $msixVersion"
@@ -232,21 +179,13 @@ jobs:
         $manifestPath = "gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest"
         [xml]$manifest = Get-Content -LiteralPath $manifestPath -Raw
         $identity = $manifest.Package.Identity
-        if ($null -eq $identity) {
-          throw "Package.appxmanifest does not contain an Identity element."
-        }
-
+        if ($null -eq $identity) { throw "Package.appxmanifest does not contain an Identity element." }
         $identity.Version = $Env:MSIX_VERSION
         $settings = New-Object System.Xml.XmlWriterSettings
         $settings.Indent = $true
         $settings.Encoding = New-Object System.Text.UTF8Encoding($false)
         $writer = [System.Xml.XmlWriter]::Create((Resolve-Path $manifestPath), $settings)
-        try {
-          $manifest.Save($writer)
-        } finally {
-          $writer.Dispose()
-        }
-
+        try { $manifest.Save($writer) } finally { $writer.Dispose() }
         Write-Host "Set manifest Identity Version to $Env:MSIX_VERSION"
 
     - name: Build
@@ -260,16 +199,21 @@ jobs:
           -X github.com/1dustindavis/gorilla/pkg/version.revision=${{ env.REVISION }}`
           -X github.com/1dustindavis/gorilla/pkg/version.goVersion=${{ env.GO_VERSION }}"`
 
+    - name: Collect versioned gorilla.exe
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path build | Out-Null
+        Copy-Item ./cmd/gorilla/gorilla.exe "./build/$Env:RELEASE_EXE_NAME" -Force
+
     - name: Upload gorilla.exe workflow artifact
       uses: actions/upload-artifact@v6
       with:
         name: gorilla-exe-release
-        path: ./cmd/gorilla/gorilla.exe
+        path: ./build/${{ env.RELEASE_EXE_NAME }}
         if-no-files-found: error
 
     - name: Build unsigned Gorilla UI MSIX
       run: |
-        New-Item -ItemType Directory -Force -Path build | Out-Null
         dotnet restore gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
         dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj `
           --no-restore `
@@ -283,46 +227,24 @@ jobs:
     - name: Collect and validate unsigned MSIX artifact
       shell: pwsh
       run: |
-        $msix = Get-ChildItem -Path gorilla-ui/src/Gorilla.UI.App/AppPackages -Recurse -Filter *.msix |
-          Sort-Object LastWriteTime -Descending |
-          Select-Object -First 1
-        if ($null -eq $msix) {
-          throw "No MSIX package found under gorilla-ui/src/Gorilla.UI.App/AppPackages"
-        }
-        Copy-Item $msix.FullName "build/gorilla.msix" -Force
-
-        $packagePath = (Resolve-Path "build/gorilla.msix").Path
+        $msix = Get-ChildItem -Path gorilla-ui/src/Gorilla.UI.App/AppPackages -Recurse -Filter *.msix | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($null -eq $msix) { throw "No MSIX package found under gorilla-ui/src/Gorilla.UI.App/AppPackages" }
+        $outputPath = "build/$Env:RELEASE_MSIX_NAME"
+        Copy-Item $msix.FullName $outputPath -Force
+        $packagePath = (Resolve-Path $outputPath).Path
         $signature = Get-AuthenticodeSignature -FilePath $packagePath
-        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) {
-          throw "Expected the packaged MSIX to be unsigned before Artifact Signing, but status was $($signature.Status)."
-        }
-
+        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) { throw "Expected the packaged MSIX to be unsigned before Artifact Signing, but status was $($signature.Status)." }
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         $archive = [System.IO.Compression.ZipFile]::OpenRead($packagePath)
         try {
           $manifestEntry = $archive.GetEntry("AppxManifest.xml")
-          if ($null -eq $manifestEntry) {
-            throw "Produced MSIX does not contain AppxManifest.xml."
-          }
-
+          if ($null -eq $manifestEntry) { throw "Produced MSIX does not contain AppxManifest.xml." }
           $reader = New-Object System.IO.StreamReader($manifestEntry.Open())
-          try {
-            [xml]$packagedManifest = $reader.ReadToEnd()
-          } finally {
-            $reader.Dispose()
-          }
-        } finally {
-          $archive.Dispose()
-        }
-
+          try { [xml]$packagedManifest = $reader.ReadToEnd() } finally { $reader.Dispose() }
+        } finally { $archive.Dispose() }
         $packagedVersion = $packagedManifest.Package.Identity.Version
-        if ($packagedVersion -cne $Env:MSIX_VERSION) {
-          throw "Produced MSIX has Identity Version '$packagedVersion'; expected '$Env:MSIX_VERSION'."
-        }
-
-        Write-Host "Validated unsigned MSIX"
-        Write-Host "  Path: $packagePath"
-        Write-Host "  Identity Version: $packagedVersion"
+        if ($packagedVersion -cne $Env:MSIX_VERSION) { throw "Produced MSIX has Identity Version '$packagedVersion'; expected '$Env:MSIX_VERSION'." }
+        Write-Host "Validated unsigned MSIX: $packagePath"
 
     - name: Login to Azure with GitHub OIDC
       uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
@@ -337,36 +259,24 @@ jobs:
         endpoint: ${{ env.ARTIFACT_SIGNING_ENDPOINT }}
         signing-account-name: ${{ env.ARTIFACT_SIGNING_ACCOUNT }}
         certificate-profile-name: ${{ env.ARTIFACT_SIGNING_PROFILE }}
-        files: ${{ github.workspace }}\build\gorilla.msix
+        files: ${{ github.workspace }}\build\${{ env.RELEASE_MSIX_NAME }}
         file-digest: SHA256
         timestamp-digest: SHA256
 
     - name: Verify signed MSIX
       shell: pwsh
       run: |
-        $packagePath = "$Env:GITHUB_WORKSPACE\build\gorilla.msix"
+        $packagePath = "$Env:GITHUB_WORKSPACE\build\$Env:RELEASE_MSIX_NAME"
         $signature = Get-AuthenticodeSignature -FilePath $packagePath
-
-        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
-          throw "Artifact Signing produced an invalid MSIX signature. Status: $($signature.Status); message: $($signature.StatusMessage)"
-        }
-        if ($null -eq $signature.SignerCertificate) {
-          throw "Signed MSIX does not expose a signer certificate."
-        }
-        if ($signature.SignerCertificate.Subject -cne $Env:ARTIFACT_SIGNING_SUBJECT) {
-          throw "Unexpected MSIX signer subject. Expected '$Env:ARTIFACT_SIGNING_SUBJECT'; got '$($signature.SignerCertificate.Subject)'."
-        }
-
-        Write-Host "Verified MSIX signature"
-        Write-Host "  Subject: $($signature.SignerCertificate.Subject)"
-        Write-Host "  Thumbprint: $($signature.SignerCertificate.Thumbprint)"
-        Write-Host "  Valid through: $($signature.SignerCertificate.NotAfter.ToUniversalTime().ToString('u'))"
+        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) { throw "Artifact Signing produced an invalid MSIX signature. Status: $($signature.Status); message: $($signature.StatusMessage)" }
+        if ($null -eq $signature.SignerCertificate) { throw "Signed MSIX does not expose a signer certificate." }
+        if ($signature.SignerCertificate.Subject -cne $Env:ARTIFACT_SIGNING_SUBJECT) { throw "Unexpected MSIX signer subject. Expected '$Env:ARTIFACT_SIGNING_SUBJECT'; got '$($signature.SignerCertificate.Subject)'." }
 
     - name: Upload Gorilla UI MSIX workflow artifact
       uses: actions/upload-artifact@v6
       with:
         name: gorilla-ui-msix-release
-        path: ./build/gorilla.msix
+        path: ./build/${{ env.RELEASE_MSIX_NAME }}
         if-no-files-found: error
 
     - name: Prepare prerelease notes
@@ -375,25 +285,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $headers = @{
-          Accept = "application/vnd.github+json"
-          Authorization = "Bearer $Env:GITHUB_TOKEN"
-          "X-GitHub-Api-Version" = "2022-11-28"
-        }
-        $pulls = @(Invoke-RestMethod `
-          -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/commits/$Env:GITHUB_SHA/pulls" `
-          -Headers $headers)
-        $pr = $pulls |
-          Where-Object { $_.merged_at -and $_.base.ref -eq 'main' } |
-          Sort-Object number -Descending |
-          Select-Object -First 1
-
-        if ($null -ne $pr) {
-          "- $($pr.title) (#$($pr.number))" | Set-Content -Path release-notes.md -Encoding utf8
-        } else {
-          $title = git log -1 --pretty=format:"%s"
-          "- $title" | Set-Content -Path release-notes.md -Encoding utf8
-        }
+        $headers = @{ Accept = "application/vnd.github+json"; Authorization = "Bearer $Env:GITHUB_TOKEN"; "X-GitHub-Api-Version" = "2022-11-28" }
+        $pulls = @(Invoke-RestMethod -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/commits/$Env:GITHUB_SHA/pulls" -Headers $headers)
+        $pr = $pulls | Where-Object { $_.merged_at -and $_.base.ref -eq 'main' } | Sort-Object number -Descending | Select-Object -First 1
+        if ($null -ne $pr) { "- $($pr.title) (#$($pr.number))" | Set-Content -Path release-notes.md -Encoding utf8 }
+        else { $title = git log -1 --pretty=format:"%s"; "- $title" | Set-Content -Path release-notes.md -Encoding utf8 }
 
     - name: Cut prerelease
       if: github.event_name == 'push'
@@ -403,7 +299,7 @@ jobs:
         prerelease: true
         makeLatest: false
         bodyFile: release-notes.md
-        artifacts: "./cmd/gorilla/gorilla.exe,./build/gorilla.msix"
+        artifacts: "./build/${{ env.RELEASE_EXE_NAME }},./build/${{ env.RELEASE_MSIX_NAME }}"
         commit: ${{ github.sha }}
         tag: ${{ env.RELEASE_TAG }}
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -417,7 +313,7 @@ jobs:
         makeLatest: true
         generateReleaseNotes: true
         generateReleaseNotesPreviousTag: ${{ env.PREVIOUS_STABLE_TAG }}
-        artifacts: "./cmd/gorilla/gorilla.exe,./build/gorilla.msix"
+        artifacts: "./build/${{ env.RELEASE_EXE_NAME }},./build/${{ env.RELEASE_MSIX_NAME }}"
         commit: ${{ github.sha }}
         tag: ${{ env.RELEASE_TAG }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -379,6 +379,27 @@ jobs:
         Write-Host "  Thumbprint: $($signature.SignerCertificate.Thumbprint)"
         Write-Host "  Valid through: $($signature.SignerCertificate.NotAfter.ToUniversalTime().ToString('u'))"
 
+    - name: Validate exact release artifacts before publication
+      shell: pwsh
+      run: |
+        make verify-release `
+          GORILLA_RELEASE_EXE="$env:GITHUB_WORKSPACE\build\$env:RELEASE_EXE_NAME" `
+          GORILLA_RELEASE_MSIX="$env:GITHUB_WORKSPACE\build\$env:RELEASE_MSIX_NAME" `
+          RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration" `
+          INSTALLED_PRODUCT_WORK_ROOT="$env:RUNNER_TEMP\gorilla-installed-product"
+
+    - name: Upload release validation failure diagnostics
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: release-validation-failure-${{ github.run_id }}
+        path: |
+          C:\ProgramData\gorilla-it\cache\gorilla.log
+          ${{ runner.temp }}/gorilla-release-integration/fixture/configs
+          ${{ runner.temp }}/gorilla-installed-product/installed-product-evidence
+        if-no-files-found: warn
+        retention-days: 90
+
     - name: Upload Gorilla UI MSIX workflow artifact
       uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -92,21 +92,40 @@ jobs:
       env:
         PREVIOUS_MAIN_SHA: ${{ github.event.before }}
       run: |
+        # Allocate exactly one patch version for this main-push release. This is
+        # intentionally independent of how many commits the merged PR contains.
         $latestTag = git tag --list |
           ForEach-Object {
             if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
-              [pscustomobject]@{ Tag = $_; Version = [version]($Matches[1..3] -join '.') }
+              [pscustomobject]@{
+                Tag = $_
+                Version = [version]($Matches[1..3] -join '.')
+              }
             }
           } |
           Sort-Object Version -Descending |
           Select-Object -First 1
-        if ($null -eq $latestTag) { throw "No existing vX.Y.Z version tag found." }
+
+        if ($null -eq $latestTag) {
+          throw "No existing vX.Y.Z version tag found."
+        }
+
+        # GitHub's queued concurrency ordering is not guaranteed to match dispatch
+        # ordering. The preceding main commit must already be the latest released
+        # commit; otherwise fail safely and rerun after its release completes.
         $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
         if ($latestTaggedCommit -ne $Env:PREVIOUS_MAIN_SHA) {
           throw "Previous main commit $Env:PREVIOUS_MAIN_SHA is not the latest released commit ($latestTaggedCommit). An earlier release must complete first; rerun this workflow afterward."
         }
-        if ($latestTag.Version.Build -ge 65535) { throw "Patch version cannot exceed the MSIX version segment limit of 65535." }
-        $nextVersion = [version]::new($latestTag.Version.Major,$latestTag.Version.Minor,$latestTag.Version.Build + 1)
+
+        if ($latestTag.Version.Build -ge 65535) {
+          throw "Patch version cannot exceed the MSIX version segment limit of 65535."
+        }
+        $nextVersion = [version]::new(
+          $latestTag.Version.Major,
+          $latestTag.Version.Minor,
+          $latestTag.Version.Build + 1
+        )
         "RELEASE_TAG=v$nextVersion" >> $Env:GITHUB_ENV
         Write-Host "Next prerelease: v$nextVersion"
 
@@ -118,31 +137,63 @@ jobs:
         STABLE_VERSION: ${{ inputs.stable_version }}
       run: |
         $versionText = $Env:STABLE_VERSION.Trim()
-        if ($versionText -notmatch '^\d+\.\d+\.0$') { throw "Stable version must use X.Y.0 format, for example 2.30.0." }
-        $headers = @{ Accept = "application/vnd.github+json"; Authorization = "Bearer $Env:GITHUB_TOKEN"; "X-GitHub-Api-Version" = "2022-11-28" }
+        if ($versionText -notmatch '^\d+\.\d+\.0$') {
+          throw "Stable version must use X.Y.0 format, for example 2.30.0."
+        }
+
+        $headers = @{
+          Accept = "application/vnd.github+json"
+          Authorization = "Bearer $Env:GITHUB_TOKEN"
+          "X-GitHub-Api-Version" = "2022-11-28"
+        }
+
+        # A stable release is only valid once the current main commit has already
+        # completed its automatic prerelease. This prevents a manual release from
+        # overtaking a main push whose release run has not published yet.
         $latestTag = git tag --list |
           ForEach-Object {
             if ($_ -match '^v(\d+)\.(\d+)\.(\d+)$') {
-              [pscustomobject]@{ Tag = $_; Version = [version]($Matches[1..3] -join '.') }
+              [pscustomobject]@{
+                Tag = $_
+                Version = [version]($Matches[1..3] -join '.')
+              }
             }
           } |
           Sort-Object Version -Descending |
           Select-Object -First 1
-        if ($null -eq $latestTag) { throw "No existing vX.Y.Z version tag found." }
+        if ($null -eq $latestTag) {
+          throw "No existing vX.Y.Z version tag found."
+        }
         $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
-        if ($latestTaggedCommit -ne $Env:GITHUB_SHA) { throw "Current main commit $Env:GITHUB_SHA has not completed its prerelease yet. Wait for Build Release to finish, then retry the stable release." }
+        if ($latestTaggedCommit -ne $Env:GITHUB_SHA) {
+          throw "Current main commit $Env:GITHUB_SHA has not completed its prerelease yet. Wait for Build Release to finish, then retry the stable release."
+        }
+
+        # Refuse a stable release if a push release is queued behind it. This
+        # covers GitHub's documented lack of dispatch-order guarantees.
         $activePushRuns = @()
         foreach ($status in @('queued', 'pending', 'waiting', 'requested')) {
           $uri = "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/actions/workflows/build_release.yml/runs?event=push&status=$status&per_page=100"
           $response = Invoke-RestMethod -Uri $uri -Headers $headers
           $activePushRuns += @($response.workflow_runs)
         }
-        if ($activePushRuns.Count -gt 0) { throw "One or more automatic prerelease runs are still queued. Wait for Build Release to become idle, then retry the stable release." }
+        if ($activePushRuns.Count -gt 0) {
+          throw "One or more automatic prerelease runs are still queued. Wait for Build Release to become idle, then retry the stable release."
+        }
+
         $requestedVersion = [version]$versionText
         $releaseTag = "v$versionText"
-        if (git tag --list $releaseTag) { throw "Tag $releaseTag already exists." }
-        if ($requestedVersion -le $latestTag.Version) { throw "Stable version $versionText must be newer than existing version $($latestTag.Version)." }
-        $latestStable = Invoke-RestMethod -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/releases/latest" -Headers $headers
+        if (git tag --list $releaseTag) {
+          throw "Tag $releaseTag already exists."
+        }
+        if ($requestedVersion -le $latestTag.Version) {
+          throw "Stable version $versionText must be newer than existing version $($latestTag.Version)."
+        }
+
+        $latestStable = Invoke-RestMethod `
+          -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/releases/latest" `
+          -Headers $headers
+
         "RELEASE_TAG=$releaseTag" >> $Env:GITHUB_ENV
         "PREVIOUS_STABLE_TAG=$($latestStable.tag_name)" >> $Env:GITHUB_ENV
 
@@ -150,25 +201,37 @@ jobs:
       shell: pwsh
       run: |
         $version = "$Env:RELEASE_TAG" -replace '^v', ''
-        if ([string]::IsNullOrWhiteSpace($version)) { throw "Release version is empty." }
-        "RELEASE_VERSION=$version" >> $Env:GITHUB_ENV
+        if ([string]::IsNullOrWhiteSpace($version)) {
+          throw "Release version is empty."
+        }
         "RELEASE_EXE_NAME=gorilla-$version.exe" >> $Env:GITHUB_ENV
         "RELEASE_MSIX_NAME=gorilla-$version.msix" >> $Env:GITHUB_ENV
 
     - name: Compute MSIX version from release tag
       run: |
         $releaseTag = "$Env:RELEASE_TAG"
-        if ([string]::IsNullOrWhiteSpace($releaseTag)) { throw "Release tag is empty." }
+        if ([string]::IsNullOrWhiteSpace($releaseTag)) {
+          throw "Release tag is empty."
+        }
+
         $normalized = $releaseTag -replace '^v', ''
         $parts = $normalized.Split('.')
-        if ($parts.Count -lt 1 -or $parts.Count -gt 4) { throw "Unsupported release tag format for MSIX version: $releaseTag" }
+        if ($parts.Count -lt 1 -or $parts.Count -gt 4) {
+          throw "Unsupported release tag format for MSIX version: $releaseTag"
+        }
+
         $versionParts = @(0, 0, 0, 0)
         for ($i = 0; $i -lt $parts.Count; $i++) {
           [int]$value = 0
-          if (-not [int]::TryParse($parts[$i], [ref]$value)) { throw "Release tag contains non-numeric segment: $releaseTag" }
-          if ($value -lt 0 -or $value -gt 65535) { throw "MSIX version segment out of range (0-65535): $value" }
+          if (-not [int]::TryParse($parts[$i], [ref]$value)) {
+            throw "Release tag contains non-numeric segment: $releaseTag"
+          }
+          if ($value -lt 0 -or $value -gt 65535) {
+            throw "MSIX version segment out of range (0-65535): $value"
+          }
           $versionParts[$i] = $value
         }
+
         $msixVersion = "{0}.{1}.{2}.{3}" -f $versionParts[0], $versionParts[1], $versionParts[2], $versionParts[3]
         echo "MSIX_VERSION=$msixVersion" >> $Env:GITHUB_ENV
         Write-Host "MSIX version: $msixVersion"
@@ -179,13 +242,21 @@ jobs:
         $manifestPath = "gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest"
         [xml]$manifest = Get-Content -LiteralPath $manifestPath -Raw
         $identity = $manifest.Package.Identity
-        if ($null -eq $identity) { throw "Package.appxmanifest does not contain an Identity element." }
+        if ($null -eq $identity) {
+          throw "Package.appxmanifest does not contain an Identity element."
+        }
+
         $identity.Version = $Env:MSIX_VERSION
         $settings = New-Object System.Xml.XmlWriterSettings
         $settings.Indent = $true
         $settings.Encoding = New-Object System.Text.UTF8Encoding($false)
         $writer = [System.Xml.XmlWriter]::Create((Resolve-Path $manifestPath), $settings)
-        try { $manifest.Save($writer) } finally { $writer.Dispose() }
+        try {
+          $manifest.Save($writer)
+        } finally {
+          $writer.Dispose()
+        }
+
         Write-Host "Set manifest Identity Version to $Env:MSIX_VERSION"
 
     - name: Build
@@ -214,6 +285,7 @@ jobs:
 
     - name: Build unsigned Gorilla UI MSIX
       run: |
+        New-Item -ItemType Directory -Force -Path build | Out-Null
         dotnet restore gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
         dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj `
           --no-restore `
@@ -227,24 +299,47 @@ jobs:
     - name: Collect and validate unsigned MSIX artifact
       shell: pwsh
       run: |
-        $msix = Get-ChildItem -Path gorilla-ui/src/Gorilla.UI.App/AppPackages -Recurse -Filter *.msix | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-        if ($null -eq $msix) { throw "No MSIX package found under gorilla-ui/src/Gorilla.UI.App/AppPackages" }
+        $msix = Get-ChildItem -Path gorilla-ui/src/Gorilla.UI.App/AppPackages -Recurse -Filter *.msix |
+          Sort-Object LastWriteTime -Descending |
+          Select-Object -First 1
+        if ($null -eq $msix) {
+          throw "No MSIX package found under gorilla-ui/src/Gorilla.UI.App/AppPackages"
+        }
         $outputPath = "build/$Env:RELEASE_MSIX_NAME"
         Copy-Item $msix.FullName $outputPath -Force
+
         $packagePath = (Resolve-Path $outputPath).Path
         $signature = Get-AuthenticodeSignature -FilePath $packagePath
-        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) { throw "Expected the packaged MSIX to be unsigned before Artifact Signing, but status was $($signature.Status)." }
+        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) {
+          throw "Expected the packaged MSIX to be unsigned before Artifact Signing, but status was $($signature.Status)."
+        }
+
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         $archive = [System.IO.Compression.ZipFile]::OpenRead($packagePath)
         try {
           $manifestEntry = $archive.GetEntry("AppxManifest.xml")
-          if ($null -eq $manifestEntry) { throw "Produced MSIX does not contain AppxManifest.xml." }
+          if ($null -eq $manifestEntry) {
+            throw "Produced MSIX does not contain AppxManifest.xml."
+          }
+
           $reader = New-Object System.IO.StreamReader($manifestEntry.Open())
-          try { [xml]$packagedManifest = $reader.ReadToEnd() } finally { $reader.Dispose() }
-        } finally { $archive.Dispose() }
+          try {
+            [xml]$packagedManifest = $reader.ReadToEnd()
+          } finally {
+            $reader.Dispose()
+          }
+        } finally {
+          $archive.Dispose()
+        }
+
         $packagedVersion = $packagedManifest.Package.Identity.Version
-        if ($packagedVersion -cne $Env:MSIX_VERSION) { throw "Produced MSIX has Identity Version '$packagedVersion'; expected '$Env:MSIX_VERSION'." }
-        Write-Host "Validated unsigned MSIX: $packagePath"
+        if ($packagedVersion -cne $Env:MSIX_VERSION) {
+          throw "Produced MSIX has Identity Version '$packagedVersion'; expected '$Env:MSIX_VERSION'."
+        }
+
+        Write-Host "Validated unsigned MSIX"
+        Write-Host "  Path: $packagePath"
+        Write-Host "  Identity Version: $packagedVersion"
 
     - name: Login to Azure with GitHub OIDC
       uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
@@ -268,9 +363,21 @@ jobs:
       run: |
         $packagePath = "$Env:GITHUB_WORKSPACE\build\$Env:RELEASE_MSIX_NAME"
         $signature = Get-AuthenticodeSignature -FilePath $packagePath
-        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) { throw "Artifact Signing produced an invalid MSIX signature. Status: $($signature.Status); message: $($signature.StatusMessage)" }
-        if ($null -eq $signature.SignerCertificate) { throw "Signed MSIX does not expose a signer certificate." }
-        if ($signature.SignerCertificate.Subject -cne $Env:ARTIFACT_SIGNING_SUBJECT) { throw "Unexpected MSIX signer subject. Expected '$Env:ARTIFACT_SIGNING_SUBJECT'; got '$($signature.SignerCertificate.Subject)'." }
+
+        if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+          throw "Artifact Signing produced an invalid MSIX signature. Status: $($signature.Status); message: $($signature.StatusMessage)"
+        }
+        if ($null -eq $signature.SignerCertificate) {
+          throw "Signed MSIX does not expose a signer certificate."
+        }
+        if ($signature.SignerCertificate.Subject -cne $Env:ARTIFACT_SIGNING_SUBJECT) {
+          throw "Unexpected MSIX signer subject. Expected '$Env:ARTIFACT_SIGNING_SUBJECT'; got '$($signature.SignerCertificate.Subject)'."
+        }
+
+        Write-Host "Verified MSIX signature"
+        Write-Host "  Subject: $($signature.SignerCertificate.Subject)"
+        Write-Host "  Thumbprint: $($signature.SignerCertificate.Thumbprint)"
+        Write-Host "  Valid through: $($signature.SignerCertificate.NotAfter.ToUniversalTime().ToString('u'))"
 
     - name: Upload Gorilla UI MSIX workflow artifact
       uses: actions/upload-artifact@v6
@@ -285,11 +392,25 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $headers = @{ Accept = "application/vnd.github+json"; Authorization = "Bearer $Env:GITHUB_TOKEN"; "X-GitHub-Api-Version" = "2022-11-28" }
-        $pulls = @(Invoke-RestMethod -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/commits/$Env:GITHUB_SHA/pulls" -Headers $headers)
-        $pr = $pulls | Where-Object { $_.merged_at -and $_.base.ref -eq 'main' } | Sort-Object number -Descending | Select-Object -First 1
-        if ($null -ne $pr) { "- $($pr.title) (#$($pr.number))" | Set-Content -Path release-notes.md -Encoding utf8 }
-        else { $title = git log -1 --pretty=format:"%s"; "- $title" | Set-Content -Path release-notes.md -Encoding utf8 }
+        $headers = @{
+          Accept = "application/vnd.github+json"
+          Authorization = "Bearer $Env:GITHUB_TOKEN"
+          "X-GitHub-Api-Version" = "2022-11-28"
+        }
+        $pulls = @(Invoke-RestMethod `
+          -Uri "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/commits/$Env:GITHUB_SHA/pulls" `
+          -Headers $headers)
+        $pr = $pulls |
+          Where-Object { $_.merged_at -and $_.base.ref -eq 'main' } |
+          Sort-Object number -Descending |
+          Select-Object -First 1
+
+        if ($null -ne $pr) {
+          "- $($pr.title) (#$($pr.number))" | Set-Content -Path release-notes.md -Encoding utf8
+        } else {
+          $title = git log -1 --pretty=format:"%s"
+          "- $title" | Set-Content -Path release-notes.md -Encoding utf8
+        }
 
     - name: Cut prerelease
       if: github.event_name == 'push'

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -117,6 +117,14 @@ jobs:
         # failed the installed-product gate: because it was never published, the
         # next main commit may safely reuse the next available patch version.
         $latestTaggedCommit = (git rev-list -n 1 $latestTag.Tag).Trim()
+        if ($latestTaggedCommit -eq $Env:GITHUB_SHA) {
+          throw "Current main commit $Env:GITHUB_SHA is already released as $($latestTag.Tag)."
+        }
+        git merge-base --is-ancestor $latestTaggedCommit $Env:GITHUB_SHA
+        if ($LASTEXITCODE -ne 0) {
+          throw "Latest released commit $latestTaggedCommit is not an ancestor of this workflow commit $Env:GITHUB_SHA. Refusing to publish an older commit with a newer version."
+        }
+
         if ($latestTaggedCommit -ne $Env:PREVIOUS_MAIN_SHA) {
           $headers = @{
             Accept = "application/vnd.github+json"
@@ -124,11 +132,13 @@ jobs:
             "X-GitHub-Api-Version" = "2022-11-28"
           }
           $runsUri = "https://api.github.com/repos/$Env:GITHUB_REPOSITORY/actions/workflows/build_release.yml/runs?event=push&status=completed&head_sha=$Env:PREVIOUS_MAIN_SHA&per_page=20"
-          $runs = @(Invoke-RestMethod -Uri $runsUri -Headers $headers).workflow_runs
+          $runResponse = Invoke-RestMethod -Uri $runsUri -Headers $headers
+          $runs = @($runResponse.workflow_runs)
           $predecessorFailedReleaseGate = $false
 
           foreach ($run in $runs) {
-            $jobs = @(Invoke-RestMethod -Uri $run.jobs_url -Headers $headers).jobs
+            $jobResponse = Invoke-RestMethod -Uri $run.jobs_url -Headers $headers
+            $jobs = @($jobResponse.jobs)
             foreach ($job in $jobs) {
               $gate = @($job.steps | Where-Object { $_.name -eq 'Validate exact release artifacts before publication' })
               if ($gate.Count -gt 0 -and $gate[0].conclusion -eq 'failure') {

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -144,7 +144,7 @@ jobs:
         shell: pwsh
         run: |
           $exePath = "${{ runner.temp }}\gorilla-artifact\gorilla.exe"
-          $msixPath = "${{ runner.temp }}\gorilla-msix-artifact\Gorilla.UI.App.msix"
+          $msixPath = "${{ runner.temp }}\gorilla-msix-artifact\gorilla.msix"
           if (-not (Test-Path -LiteralPath $exePath)) {
             throw "Unable to resolve produced gorilla.exe artifact"
           }

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -2,6 +2,7 @@ name: Released-Binary Integration
 
 on:
   pull_request:
+  workflow_dispatch:
   workflow_run:
     workflows:
       - Build Release
@@ -9,7 +10,7 @@ on:
       - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.id || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -20,9 +21,10 @@ jobs:
   integration:
     name: Verify
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: >-
       github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main')
@@ -46,6 +48,18 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      - name: Configure NuGet package path
+        if: github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          "NUGET_PACKAGES=$env:RUNNER_TEMP\nuget-packages" >> $env:GITHUB_ENV
+
+      - name: Setup dotnet
+        if: github.event_name != 'pull_request'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Download gorilla.exe from Build Release run artifact
         if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v7
@@ -56,6 +70,16 @@ jobs:
           path: ${{ runner.temp }}/gorilla-artifact
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download Gorilla MSIX from Build Release run artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v7
+        with:
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: gorilla-ui-msix-release
+          path: ${{ runner.temp }}/gorilla-msix-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build gorilla.exe from PR merge ref
         if: github.event_name == 'pull_request'
         shell: pwsh
@@ -64,30 +88,99 @@ jobs:
           New-Item -Path $outDir -ItemType Directory -Force | Out-Null
           go build -v -o "$outDir\gorilla.exe" ./cmd/gorilla
 
-      - name: Resolve gorilla.exe path
+      - name: Build test-signed installed product
+        if: github.event_name == 'workflow_dispatch'
         shell: pwsh
         run: |
-          $candidate1 = "${{ runner.temp }}\gorilla-artifact\gorilla.exe"
-          $candidate2 = "${{ runner.temp }}\gorilla-binary\gorilla.exe"
+          make build
 
-          if (Test-Path -LiteralPath $candidate1) {
-            "GORILLA_EXE_PATH=$candidate1" >> $env:GITHUB_ENV
-            exit 0
+          $certificatePath = "$env:RUNNER_TEMP\gorilla-installed-product.cer"
+          $thumbprint = (& integration/windows/initialize-msix-test-certificate.ps1 `
+            -CertificatePath $certificatePath `
+            -Create | Select-Object -Last 1).Trim()
+          if ([string]::IsNullOrWhiteSpace($thumbprint)) {
+            throw "Unable to create MSIX test certificate"
           }
 
-          if (Test-Path -LiteralPath $candidate2) {
-            "GORILLA_EXE_PATH=$candidate2" >> $env:GITHUB_ENV
-            exit 0
+          $manifestPath = "gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest"
+          [xml]$manifest = Get-Content -LiteralPath $manifestPath -Raw
+          $manifest.Package.Identity.Publisher = "CN=GorillaIT"
+          $settings = New-Object System.Xml.XmlWriterSettings
+          $settings.Indent = $true
+          $settings.Encoding = New-Object System.Text.UTF8Encoding($false)
+          $writer = [System.Xml.XmlWriter]::Create((Resolve-Path $manifestPath), $settings)
+          try {
+            $manifest.Save($writer)
+          } finally {
+            $writer.Dispose()
           }
 
-          throw "Unable to resolve gorilla.exe path"
+          dotnet restore gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
+          dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj `
+            --no-restore `
+            -c Release `
+            -p:Platform=x64 `
+            -p:GenerateAppxPackageOnBuild=true `
+            -p:PublishReadyToRun=false `
+            -p:PublishTrimmed=false `
+            -p:AppxPackageSigningEnabled=true `
+            -p:PackageCertificateThumbprint=$thumbprint
+          if ($LASTEXITCODE -ne 0) {
+            throw "Test-signed Gorilla MSIX build failed"
+          }
 
-      - name: Run canonical released-binary validation
+          $msix = Get-ChildItem -Path gorilla-ui/src/Gorilla.UI.App/AppPackages -Recurse -Filter *.msix |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if ($null -eq $msix) {
+            throw "No test-signed Gorilla MSIX was produced"
+          }
+
+          "GORILLA_EXE_PATH=$env:GITHUB_WORKSPACE\build\gorilla.exe" >> $env:GITHUB_ENV
+          "GORILLA_MSIX_PATH=$($msix.FullName)" >> $env:GITHUB_ENV
+
+      - name: Resolve produced release artifact paths
+        if: github.event_name == 'workflow_run'
+        shell: pwsh
+        run: |
+          $exePath = "${{ runner.temp }}\gorilla-artifact\gorilla.exe"
+          $msixPath = "${{ runner.temp }}\gorilla-msix-artifact\Gorilla.UI.App.msix"
+          if (-not (Test-Path -LiteralPath $exePath)) {
+            throw "Unable to resolve produced gorilla.exe artifact"
+          }
+          if (-not (Test-Path -LiteralPath $msixPath)) {
+            throw "Unable to resolve produced Gorilla MSIX artifact"
+          }
+          "GORILLA_EXE_PATH=$exePath" >> $env:GITHUB_ENV
+          "GORILLA_MSIX_PATH=$msixPath" >> $env:GITHUB_ENV
+
+      - name: Resolve PR gorilla.exe path
+        if: github.event_name == 'pull_request'
+        shell: pwsh
+        run: |
+          $exePath = "${{ runner.temp }}\gorilla-binary\gorilla.exe"
+          if (-not (Test-Path -LiteralPath $exePath)) {
+            throw "Unable to resolve PR gorilla.exe path"
+          }
+          "GORILLA_EXE_PATH=$exePath" >> $env:GITHUB_ENV
+
+      - name: Run PR released-binary integration
+        if: github.event_name == 'pull_request'
         shell: pwsh
         run: |
           make release-integration `
             GORILLA_RELEASE_EXE="$env:GORILLA_EXE_PATH" `
             RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration"
+
+      - name: Run canonical installed release validation
+        if: github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          make verify-release `
+            GORILLA_RELEASE_EXE="$env:GORILLA_EXE_PATH" `
+            GORILLA_RELEASE_MSIX="$env:GORILLA_MSIX_PATH" `
+            RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration" `
+            INSTALLED_PRODUCT_WORK_ROOT="$env:RUNNER_TEMP\gorilla-installed-product"
 
       - name: Upload integration failure diagnostics
         if: failure()
@@ -97,5 +190,6 @@ jobs:
           path: |
             C:\ProgramData\gorilla-it\cache\gorilla.log
             ${{ runner.temp }}/gorilla-release-integration/fixture/configs
+            ${{ runner.temp }}/gorilla-installed-product/installed-product-evidence
           if-no-files-found: warn
           retention-days: 90

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -3,37 +3,23 @@ name: Released-Binary Integration
 on:
   pull_request:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Build Release
-    types:
-      - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.id || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  actions: read
 
 jobs:
   integration:
     name: Verify
     runs-on: windows-latest
     timeout-minutes: 90
-    if: >-
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main')
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Configure Go cache paths
         shell: pwsh
@@ -49,36 +35,16 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Configure NuGet package path
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         shell: pwsh
         run: |
           "NUGET_PACKAGES=$env:RUNNER_TEMP\nuget-packages" >> $env:GITHUB_ENV
 
       - name: Setup dotnet
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
-
-      - name: Download gorilla.exe from Build Release run artifact
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v7
-        with:
-          repository: ${{ github.repository }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: gorilla-exe-release
-          path: ${{ runner.temp }}/gorilla-artifact
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download Gorilla MSIX from Build Release run artifact
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v7
-        with:
-          repository: ${{ github.repository }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: gorilla-ui-msix-release
-          path: ${{ runner.temp }}/gorilla-msix-artifact
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build gorilla.exe from PR merge ref
         if: github.event_name == 'pull_request'
@@ -87,6 +53,7 @@ jobs:
           $outDir = "${{ runner.temp }}\gorilla-binary"
           New-Item -Path $outDir -ItemType Directory -Force | Out-Null
           go build -v -o "$outDir\gorilla.exe" ./cmd/gorilla
+          "GORILLA_EXE_PATH=$outDir\gorilla.exe" >> $env:GITHUB_ENV
 
       - name: Build test-signed installed product
         if: github.event_name == 'workflow_dispatch'
@@ -141,38 +108,6 @@ jobs:
           "GORILLA_EXE_PATH=$immutableExePath" >> $env:GITHUB_ENV
           "GORILLA_MSIX_PATH=$($msix.FullName)" >> $env:GITHUB_ENV
 
-      - name: Resolve produced release artifact paths
-        if: github.event_name == 'workflow_run'
-        shell: pwsh
-        run: |
-          $exeFiles = @(Get-ChildItem -Path "${{ runner.temp }}\gorilla-artifact" -File -Filter 'gorilla-*.exe')
-          $msixFiles = @(Get-ChildItem -Path "${{ runner.temp }}\gorilla-msix-artifact" -File -Filter 'gorilla-*.msix')
-          if ($exeFiles.Count -ne 1) {
-            throw "Expected exactly one versioned gorilla-*.exe artifact; found $($exeFiles.Count)"
-          }
-          if ($msixFiles.Count -ne 1) {
-            throw "Expected exactly one versioned gorilla-*.msix artifact; found $($msixFiles.Count)"
-          }
-
-          $exeVersion = $exeFiles[0].BaseName -replace '^gorilla-', ''
-          $msixVersion = $msixFiles[0].BaseName -replace '^gorilla-', ''
-          if ($exeVersion -ne $msixVersion) {
-            throw "Release artifact versions do not match: exe=$exeVersion msix=$msixVersion"
-          }
-
-          "GORILLA_EXE_PATH=$($exeFiles[0].FullName)" >> $env:GITHUB_ENV
-          "GORILLA_MSIX_PATH=$($msixFiles[0].FullName)" >> $env:GITHUB_ENV
-
-      - name: Resolve PR gorilla.exe path
-        if: github.event_name == 'pull_request'
-        shell: pwsh
-        run: |
-          $exePath = "${{ runner.temp }}\gorilla-binary\gorilla.exe"
-          if (-not (Test-Path -LiteralPath $exePath)) {
-            throw "Unable to resolve PR gorilla.exe path"
-          }
-          "GORILLA_EXE_PATH=$exePath" >> $env:GITHUB_ENV
-
       - name: Run PR released-binary integration
         if: github.event_name == 'pull_request'
         shell: pwsh
@@ -181,8 +116,8 @@ jobs:
             GORILLA_RELEASE_EXE="$env:GORILLA_EXE_PATH" `
             RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration"
 
-      - name: Run canonical installed release validation
-        if: github.event_name != 'pull_request'
+      - name: Run manual installed-product validation
+        if: github.event_name == 'workflow_dispatch'
         shell: pwsh
         run: |
           make verify-release `

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -136,7 +136,9 @@ jobs:
             throw "No test-signed Gorilla MSIX was produced"
           }
 
-          "GORILLA_EXE_PATH=$env:GITHUB_WORKSPACE\build\gorilla.exe" >> $env:GITHUB_ENV
+          $immutableExePath = "$env:RUNNER_TEMP\gorilla-installed-product.exe"
+          Copy-Item -LiteralPath "$env:GITHUB_WORKSPACE\build\gorilla.exe" -Destination $immutableExePath -Force
+          "GORILLA_EXE_PATH=$immutableExePath" >> $env:GITHUB_ENV
           "GORILLA_MSIX_PATH=$($msix.FullName)" >> $env:GITHUB_ENV
 
       - name: Resolve produced release artifact paths

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -143,16 +143,23 @@ jobs:
         if: github.event_name == 'workflow_run'
         shell: pwsh
         run: |
-          $exePath = "${{ runner.temp }}\gorilla-artifact\gorilla.exe"
-          $msixPath = "${{ runner.temp }}\gorilla-msix-artifact\gorilla.msix"
-          if (-not (Test-Path -LiteralPath $exePath)) {
-            throw "Unable to resolve produced gorilla.exe artifact"
+          $exeFiles = @(Get-ChildItem -Path "${{ runner.temp }}\gorilla-artifact" -File -Filter 'gorilla-*.exe')
+          $msixFiles = @(Get-ChildItem -Path "${{ runner.temp }}\gorilla-msix-artifact" -File -Filter 'gorilla-*.msix')
+          if ($exeFiles.Count -ne 1) {
+            throw "Expected exactly one versioned gorilla-*.exe artifact; found $($exeFiles.Count)"
           }
-          if (-not (Test-Path -LiteralPath $msixPath)) {
-            throw "Unable to resolve produced Gorilla MSIX artifact"
+          if ($msixFiles.Count -ne 1) {
+            throw "Expected exactly one versioned gorilla-*.msix artifact; found $($msixFiles.Count)"
           }
-          "GORILLA_EXE_PATH=$exePath" >> $env:GITHUB_ENV
-          "GORILLA_MSIX_PATH=$msixPath" >> $env:GITHUB_ENV
+
+          $exeVersion = $exeFiles[0].BaseName -replace '^gorilla-', ''
+          $msixVersion = $msixFiles[0].BaseName -replace '^gorilla-', ''
+          if ($exeVersion -ne $msixVersion) {
+            throw "Release artifact versions do not match: exe=$exeVersion msix=$msixVersion"
+          }
+
+          "GORILLA_EXE_PATH=$($exeFiles[0].FullName)" >> $env:GITHUB_ENV
+          "GORILLA_MSIX_PATH=$($msixFiles[0].FullName)" >> $env:GITHUB_ENV
 
       - name: Resolve PR gorilla.exe path
         if: github.event_name == 'pull_request'

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -88,6 +88,68 @@ jobs:
         shell: pwsh
         run: make ui-e2e
 
+      - name: Build and inspect unsigned packaged product
+        if: steps.changes.outputs.run == 'true'
+        shell: pwsh
+        run: |
+          dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj `
+            -c Release `
+            -p:Platform=x64 `
+            -p:GenerateAppxPackageOnBuild=true `
+            -p:PublishReadyToRun=false `
+            -p:PublishTrimmed=false `
+            -p:AppxPackageSigningEnabled=false
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unsigned Gorilla MSIX build failed"
+          }
+
+          $msix = Get-ChildItem -Path gorilla-ui/src/Gorilla.UI.App/AppPackages -Recurse -Filter *.msix |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if ($null -eq $msix) {
+            throw "No Gorilla MSIX was produced"
+          }
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $archive = [System.IO.Compression.ZipFile]::OpenRead($msix.FullName)
+          try {
+            if ($null -eq $archive.GetEntry('gorilla.exe')) {
+              throw "Produced MSIX does not contain the Gorilla service executable"
+            }
+
+            $manifestEntry = $archive.GetEntry('AppxManifest.xml')
+            if ($null -eq $manifestEntry) {
+              throw "Produced MSIX does not contain AppxManifest.xml"
+            }
+            $reader = New-Object System.IO.StreamReader($manifestEntry.Open())
+            try {
+              [xml]$packagedManifest = $reader.ReadToEnd()
+            } finally {
+              $reader.Dispose()
+            }
+          } finally {
+            $archive.Dispose()
+          }
+
+          $serviceExtension = @($packagedManifest.Package.Applications.Application.Extensions.Extension) |
+            Where-Object { $_.Category -eq 'windows.service' }
+          if ($serviceExtension.Count -ne 1 -or $serviceExtension[0].Executable -ne 'gorilla.exe') {
+            throw "Produced MSIX does not declare the expected Gorilla packaged service"
+          }
+          $service = $serviceExtension[0].Service
+          if ($service.Name -ne 'gorilla' -or $service.StartupType -ne 'auto' -or $service.StartAccount -ne 'localSystem') {
+            throw "Produced MSIX has unexpected Gorilla service registration metadata"
+          }
+
+          $capabilities = @($packagedManifest.Package.Capabilities.Capability | ForEach-Object { $_.Name })
+          foreach ($required in @('runFullTrust', 'packagedServices', 'localSystemServices')) {
+            if ($required -notin $capabilities) {
+              throw "Produced MSIX is missing required capability '$required'"
+            }
+          }
+
+          Write-Host "Validated packaged Gorilla service payload and manifest"
+
       - name: Summarize skipped Windows UI validation
         if: steps.changes.outputs.run != 'true'
         shell: pwsh

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -131,17 +131,22 @@ jobs:
             $archive.Dispose()
           }
 
-          $serviceExtension = @($packagedManifest.Package.Applications.Application.Extensions.Extension) |
-            Where-Object { $_.Category -eq 'windows.service' }
-          if ($serviceExtension.Count -ne 1 -or $serviceExtension[0].Executable -ne 'gorilla.exe') {
+          $serviceExtensions = @($packagedManifest.SelectNodes("//*[local-name()='Extension' and @Category='windows.service']"))
+          if ($serviceExtensions.Count -ne 1 -or $serviceExtensions[0].GetAttribute('Executable') -ne 'gorilla.exe') {
             throw "Produced MSIX does not declare the expected Gorilla packaged service"
           }
-          $service = $serviceExtension[0].Service
-          if ($service.Name -ne 'gorilla' -or $service.StartupType -ne 'auto' -or $service.StartAccount -ne 'localSystem') {
+          $service = $serviceExtensions[0].SelectSingleNode("*[local-name()='Service']")
+          if ($null -eq $service -or
+              $service.GetAttribute('Name') -ne 'gorilla' -or
+              $service.GetAttribute('StartupType') -ne 'auto' -or
+              $service.GetAttribute('StartAccount') -ne 'localSystem') {
             throw "Produced MSIX has unexpected Gorilla service registration metadata"
           }
 
-          $capabilities = @($packagedManifest.Package.Capabilities.Capability | ForEach-Object { $_.Name })
+          $capabilities = @(
+            $packagedManifest.SelectNodes("//*[local-name()='Capabilities']/*[local-name()='Capability']") |
+              ForEach-Object { $_.GetAttribute('Name') }
+          )
           foreach ($required in @('runFullTrust', 'packagedServices', 'localSystemServices')) {
             if ($required -notin $capabilities) {
               throw "Produced MSIX is missing required capability '$required'"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Guidance for coding agents working in this repository.
 - CI runs in GitHub Actions and primarily targets Windows (`windows-latest`) to match deployment expectations.
 - Development often happens on macOS: keep macOS build/test/dev workflows working where practical, but do not add major complexity solely to preserve parity.
 - Where appropriate, macOS/non-Windows stub or no-op behavior is acceptable if it keeps development workflows usable.
-- `gorilla.msix` is the official Windows installer. It packages the WinUI app and `gorilla.exe`, and registers the automatic `LocalSystem` Gorilla service. The separately released `gorilla.exe` remains available for custom deployment.
+- Release assets are published as `gorilla-<version>.msix` (official Windows installer) and `gorilla-<version>.exe` (standalone custom-deployment binary). The MSIX contains the WinUI app plus an internal `gorilla.exe` and registers the automatic `LocalSystem` Gorilla service.
 - The packaged product requires Windows 10 version 2004 / build 19041 or newer. Mutable service configuration belongs at `%ProgramData%\gorilla\config.yaml`, outside the MSIX package.
 
 ## Preferred Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Guidance for coding agents working in this repository.
 - CI runs in GitHub Actions and primarily targets Windows (`windows-latest`) to match deployment expectations.
 - Development often happens on macOS: keep macOS build/test/dev workflows working where practical, but do not add major complexity solely to preserve parity.
 - Where appropriate, macOS/non-Windows stub or no-op behavior is acceptable if it keeps development workflows usable.
-- `Gorilla.UI.App.msix` is the official Windows installer. It packages the WinUI app and `gorilla.exe`, and registers the automatic `LocalSystem` Gorilla service. The separately released `gorilla.exe` remains available for custom deployment.
+- `gorilla.msix` is the official Windows installer. It packages the WinUI app and `gorilla.exe`, and registers the automatic `LocalSystem` Gorilla service. The separately released `gorilla.exe` remains available for custom deployment.
 - The packaged product requires Windows 10 version 2004 / build 19041 or newer. Mutable service configuration belongs at `%ProgramData%\gorilla\config.yaml`, outside the MSIX package.
 
 ## Preferred Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Guidance for coding agents working in this repository.
 - CI runs in GitHub Actions and primarily targets Windows (`windows-latest`) to match deployment expectations.
 - Development often happens on macOS: keep macOS build/test/dev workflows working where practical, but do not add major complexity solely to preserve parity.
 - Where appropriate, macOS/non-Windows stub or no-op behavior is acceptable if it keeps development workflows usable.
+- `Gorilla.UI.App.msix` is the official Windows installer. It packages the WinUI app and `gorilla.exe`, and registers the automatic `LocalSystem` Gorilla service. The separately released `gorilla.exe` remains available for custom deployment.
+- The packaged product requires Windows 10 version 2004 / build 19041 or newer. Mutable service configuration belongs at `%ProgramData%\gorilla\config.yaml`, outside the MSIX package.
 
 ## Preferred Workflow
 
@@ -40,11 +42,11 @@ The Makefile is the validation contract for both local development and CI. Prefe
   - Adds the real WinUI build and source-built Windows installer/integration validation.
 - `make verify-e2e`
   - Windows only.
-  - Adds the current FlaUI full-application UI suite.
-- `make verify-release GORILLA_RELEASE_EXE=<path>`
-  - Windows only.
-  - Runs the lower validation levels and the current released-binary integration against the supplied produced `gorilla.exe` artifact.
-  - The release-level contract is intentionally stable; installed MSI + service + MSIX UI coverage will expand behind this command as that infrastructure is added.
+  - Proves source-built Gorilla service + unpackaged/source-built UI + deterministic fixtures + the critical FlaUI workflows.
+- `make verify-release GORILLA_RELEASE_EXE=<path> GORILLA_RELEASE_MSIX=<path>`
+  - Windows only and intended for a disposable machine.
+  - Runs all lower validation levels, released-binary installer fixture coverage, and installed-product validation against the supplied produced artifacts.
+  - Proves the produced MSIX contains the matching `gorilla.exe`, installs/registers the automatic `LocalSystem` service, communicates over the real named pipe, runs the same critical FlaUI workflows through the installed packaged UI, and removes package/service registration on uninstall.
 
 ### Reusable leaf targets
 
@@ -59,9 +61,10 @@ Use these for fast focused iteration or CI jobs that own one validation layer:
 - `make ui-test`
 - `make ui-windows-build`
 - `make windows-integration`
-- `make ui-e2e` (build and run the FlaUI suite)
-- `make ui-e2e-test` (run FlaUI against an existing Windows UI build)
+- `make ui-e2e` (build and run source-built FlaUI E2E)
+- `make ui-e2e-test` (run FlaUI against existing source builds)
 - `make release-integration GORILLA_RELEASE_EXE=<path>`
+- `make installed-product-integration GORILLA_RELEASE_MSIX=<path> GORILLA_RELEASE_EXE=<path>`
 
 `make lint` and `make test` remain supported compatibility aliases for Go linting and Go tests respectively. `make lint` includes `staticcheck`.
 
@@ -71,7 +74,8 @@ Use these for fast focused iteration or CI jobs that own one validation layer:
 - Portable UI Core/Client changes: iterate with `make ui-lint` / `make ui-test`; run `make verify` before pushing.
 - Windows service, installer, named-pipe, or Windows-specific behavior: require `make verify-windows` in Windows CI.
 - WinUI application behavior: require `make verify-e2e` in Windows CI in addition to portable validation.
-- Release/package interoperability changes: use `make verify-release GORILLA_RELEASE_EXE=<produced artifact>` where the released-binary validation applies; expand this same level rather than inventing a separate release-only validation path.
+- Release/package interoperability changes: use and expand `make verify-release GORILLA_RELEASE_EXE=<produced exe> GORILLA_RELEASE_MSIX=<produced msix>` rather than inventing a separate release-only framework.
+- Keep source-built E2E and installed-release validation distinct: source E2E proves source service/UI behavior quickly; installed-product validation proves produced package/service/UI interoperability.
 
 ## Build & Test Commands
 
@@ -81,7 +85,7 @@ Other useful make targets:
 - `make clean`
 - `make bootstrap`
 - `make bootstrap-run`
-- `make msi` (Windows + WiX)
+- `make msi` (legacy Windows + WiX package build; not an official release artifact)
 
 Run `make help` for the current command summary.
 
@@ -105,6 +109,8 @@ Run `make help` for the current command summary.
   - `integration/windows/`
   - `utils/manual-test/`
 - Keep CI-specific setup in workflow YAML only when necessary; the actual build/test/integration behavior should be invoked through repo-owned validation commands or scripts.
+- Installed-product validation deliberately refuses to run when an existing Gorilla MSIX, Gorilla service, or `%ProgramData%\gorilla\config.yaml` is present. Use a disposable Windows runner/VM rather than risking a real installation.
+- Reuse `prepare-release-integration.ps1` fixture semantics and the existing FlaUI critical workflows for installed-product tests so source and release validation do not drift.
 
 ## Config & Examples
 

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ go-format:
 	if [ -n "$$UNFORMATTED" ]; then \
 	  echo "Repo contains improperly formatted Go files:"; \
 	  echo "$$UNFORMATTED"; \
+	  gofmt -d -s $$UNFORMATTED; \
 	  exit 1; \
 	else \
 	  echo "All Go files formatted correctly"; \

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,6 @@ go-format:
 	if [ -n "$$UNFORMATTED" ]; then \
 	  echo "Repo contains improperly formatted Go files:"; \
 	  echo "$$UNFORMATTED"; \
-	  gofmt -d -s $$UNFORMATTED; \
 	  exit 1; \
 	else \
 	  echo "All Go files formatted correctly"; \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 .PHONY: build bootstrap bootstrap-run manual-test-server clean help \
 	go-format go-vet go-staticcheck go-test lint test \
 	ui-restore ui-lint ui-test ui-windows-build ui-e2e ui-e2e-test \
-	windows-integration release-integration \
+	windows-integration release-integration installed-product-integration \
 	verify verify-windows verify-e2e verify-release
 
 ifndef ($(GOPATH))
@@ -26,8 +26,10 @@ MANUAL_TEST_BASE_URL ?=
 WINDOWS_INTEGRATION_WORK_ROOT ?= $(CURDIR)/build/windows-integration
 UI_E2E_WORK_ROOT ?= $(WINDOWS_INTEGRATION_WORK_ROOT)
 RELEASE_INTEGRATION_WORK_ROOT ?= $(CURDIR)/build/release-integration
+INSTALLED_PRODUCT_WORK_ROOT ?= $(CURDIR)/build/installed-product-integration
 RELEASE_USE_PREBUILT_FIXTURES ?= 0
 GORILLA_RELEASE_EXE ?=
+GORILLA_RELEASE_MSIX ?=
 GO111MODULE = on
 
 ifneq ($(OS), Windows_NT)
@@ -61,14 +63,14 @@ define HELP_TEXT
 	make clean          - Delete all build artifacts
 
 	make build          - Build the code
-	make msi            - Build Windows MSI (requires WiX on Windows)
+	make msi            - Build legacy Windows MSI (not an official release artifact)
 	make bootstrap      - Build manual-test assets/server and generate VM scripts
 	make bootstrap-run  - Build manual-test assets/server and run local test server
 
 	make verify         - Run all portable validation expected before pushing
 	make verify-windows - Add Windows build and source integration validation
 	make verify-e2e     - Add source-built service/app integration and critical FlaUI workflows
-	make verify-release - Validate a supplied released gorilla.exe plus lower layers
+	make verify-release GORILLA_RELEASE_EXE=... GORILLA_RELEASE_MSIX=... - Validate produced release artifacts as an installed product plus lower layers
 
 	make go-format       - Check Go formatting
 	make go-vet          - Run Go vet for the Windows deployment target
@@ -81,7 +83,8 @@ define HELP_TEXT
 	make windows-integration - Run source-built Windows installer integration
 	make ui-e2e          - Build source service/UI and run critical FlaUI E2E workflows
 	make ui-e2e-test     - Run critical FlaUI E2E against existing source builds
-	make release-integration GORILLA_RELEASE_EXE=... - Test a supplied release binary
+	make release-integration GORILLA_RELEASE_EXE=... - Test a supplied release binary against installer fixtures
+	make installed-product-integration GORILLA_RELEASE_MSIX=... - Install the produced MSIX and validate service/UI/package interoperability
 
 	make lint           - Compatibility alias for Go format/vet/staticcheck
 	make test           - Compatibility alias for Go tests
@@ -250,6 +253,19 @@ else
 	@exit 1
 endif
 
+installed-product-integration:
+ifeq ($(OS), Windows_NT)
+ifeq ($(strip $(GORILLA_RELEASE_MSIX)),)
+	@echo "GORILLA_RELEASE_MSIX must point to the produced Gorilla MSIX release artifact"
+	@exit 1
+else
+	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-installed-product-integration.ps1 -WorkRoot "$(INSTALLED_PRODUCT_WORK_ROOT)" -GorillaMsixPath "$(GORILLA_RELEASE_MSIX)" -GorillaReleaseExePath "$(GORILLA_RELEASE_EXE)"
+endif
+else
+	@echo "installed-product-integration requires Windows"
+	@exit 1
+endif
+
 verify: go-format go-vet go-staticcheck go-test ui-lint ui-test
 
 verify-windows: verify
@@ -269,12 +285,14 @@ else
 	@exit 1
 endif
 
-# Stage 1 establishes the release-level contract using the released-binary
-# integration that exists today. Stage 7 expands this same target to installed
-# MSI + service + MSIX UI interoperability without changing the public command.
+# Release validation deliberately composes the same lower layers and fixtures as
+# source E2E, then proves the produced MSIX installs the matching gorilla.exe,
+# registers the LocalSystem service, communicates over the real named pipe, and
+# drives the same critical product workflows through the installed WinUI app.
 verify-release: verify-e2e
 ifeq ($(OS), Windows_NT)
 	$(MAKE) release-integration
+	$(MAKE) installed-product-integration
 else
 	@echo "verify-release requires Windows"
 	@exit 1

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://
 Information related to installing and configuring Gorilla can be found on the [Wiki](https://github.com/1dustindavis/gorilla/wiki).
 For quick manual-test setup helpers on a fresh Windows VM, see [utils/manual-test/README.md](utils/manual-test/README.md).
 
+The official Windows installer is `Gorilla.UI.App.msix` from the releases page. The MSIX requires Windows 10 version 2004 (build 19041) or newer and administrator approval at install time because it installs Gorilla's automatic `LocalSystem` Windows service alongside the WinUI application. The UI itself runs as the signed-in user and communicates with the service over Gorilla's named pipe.
+
+Deploy Gorilla's service configuration at `%ProgramData%\gorilla\config.yaml`. The service intentionally keeps mutable configuration outside the immutable MSIX package. Environments that need custom deployment behavior can use the separately published `gorilla.exe` binary instead of the packaged installer.
+
 ## Building
 
 If you just want the latest version, download it from the [releases page](https://github.com/1dustindavis/gorilla/releases).
@@ -34,13 +38,15 @@ make verify-windows
     Windows build and source integration validation.
 
 make verify-e2e
-    Windows validation plus the current FlaUI UI suite.
+    Source-built Gorilla service + unpackaged UI + deterministic fixtures + critical FlaUI workflows.
 
-make verify-release GORILLA_RELEASE_EXE=<path>
-    Current released-binary integration plus the lower validation layers.
+make verify-release GORILLA_RELEASE_EXE=<path> GORILLA_RELEASE_MSIX=<path>
+    Lower validation plus released-binary fixture coverage and full installed-product validation of the produced MSIX/service/UI artifacts.
 ```
 
-Use smaller targets such as `make go-test`, `make go-staticcheck`, `make ui-lint`, or `make ui-test` while iterating. See `AGENTS.md` and `make help` for the complete validation contract and guidance on which level applies to a change.
+`verify-release` requires a disposable Windows machine with no existing Gorilla package, service, or production configuration. Release CI uses the same deterministic fixture and FlaUI workflows as source E2E, then additionally proves package installation, service registration, named-pipe communication, packaged UI behavior, and uninstall cleanup.
+
+Use smaller targets such as `make go-test`, `make go-staticcheck`, `make ui-lint`, `make ui-test`, `make release-integration`, or `make installed-product-integration` while iterating. See `AGENTS.md` and `make help` for the complete validation contract and guidance on which level applies to a change.
 
 ## Repo Admin Mode
 Gorilla also supports local repo admin workflows:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://
 Information related to installing and configuring Gorilla can be found on the [Wiki](https://github.com/1dustindavis/gorilla/wiki).
 For quick manual-test setup helpers on a fresh Windows VM, see [utils/manual-test/README.md](utils/manual-test/README.md).
 
-The official Windows installer is published as `gorilla-<version>.msix` on each release (for example, `gorilla-2.30.0.msix`). The MSIX requires Windows 10 version 2004 (build 19041) or newer and administrator approval at install time because it installs Gorilla's automatic `LocalSystem` Windows service alongside the WinUI application. The UI itself runs as the signed-in user and communicates with the service over Gorilla's named pipe.
-
-Deploy Gorilla's service configuration at `%ProgramData%\gorilla\config.yaml`. The service intentionally keeps mutable configuration outside the immutable MSIX package. Environments that need custom deployment behavior can use the separately published `gorilla-<version>.exe` release binary instead of the packaged installer. The executable inside the MSIX remains `gorilla.exe`.
+Releases include `gorilla-<version>.msix` (Windows 10 2004 / build 19041+) and a standalone `gorilla-<version>.exe`.
+Service configuration lives at `%ProgramData%\gorilla\config.yaml`.
 
 ## Building
 
@@ -28,25 +27,16 @@ After cloning this repo, just run `go build -i ./cmd/gorilla`. A new binary will
 
 ## Contributing
 
-Pull requests are welcome. The Makefile provides the same validation entry points used by CI:
+Pull requests are welcome. Key validation targets:
 
 ```text
 make verify
-    Portable Go + .NET validation expected before pushing.
-
 make verify-windows
-    Windows build and source integration validation.
-
 make verify-e2e
-    Source-built Gorilla service + unpackaged UI + deterministic fixtures + critical FlaUI workflows.
-
 make verify-release GORILLA_RELEASE_EXE=<path> GORILLA_RELEASE_MSIX=<path>
-    Lower validation plus released-binary fixture coverage and full installed-product validation of the produced MSIX/service/UI artifacts.
 ```
 
-`verify-release` requires a disposable Windows machine with no existing Gorilla package, service, or production configuration. Release CI uses the same deterministic fixture and FlaUI workflows as source E2E, then additionally proves package installation, service registration, named-pipe communication, packaged UI behavior, and uninstall cleanup.
-
-Use smaller targets such as `make go-test`, `make go-staticcheck`, `make ui-lint`, `make ui-test`, `make release-integration`, or `make installed-product-integration` while iterating. See `AGENTS.md` and `make help` for the complete validation contract and guidance on which level applies to a change.
+See `AGENTS.md` and `make help` for details.
 
 ## Repo Admin Mode
 Gorilla also supports local repo admin workflows:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://
 Information related to installing and configuring Gorilla can be found on the [Wiki](https://github.com/1dustindavis/gorilla/wiki).
 For quick manual-test setup helpers on a fresh Windows VM, see [utils/manual-test/README.md](utils/manual-test/README.md).
 
-The official Windows installer is `Gorilla.UI.App.msix` from the releases page. The MSIX requires Windows 10 version 2004 (build 19041) or newer and administrator approval at install time because it installs Gorilla's automatic `LocalSystem` Windows service alongside the WinUI application. The UI itself runs as the signed-in user and communicates with the service over Gorilla's named pipe.
+The official Windows installer is `gorilla.msix` from the releases page. The MSIX requires Windows 10 version 2004 (build 19041) or newer and administrator approval at install time because it installs Gorilla's automatic `LocalSystem` Windows service alongside the WinUI application. The UI itself runs as the signed-in user and communicates with the service over Gorilla's named pipe.
 
 Deploy Gorilla's service configuration at `%ProgramData%\gorilla\config.yaml`. The service intentionally keeps mutable configuration outside the immutable MSIX package. Environments that need custom deployment behavior can use the separately published `gorilla.exe` binary instead of the packaged installer.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://
 Information related to installing and configuring Gorilla can be found on the [Wiki](https://github.com/1dustindavis/gorilla/wiki).
 For quick manual-test setup helpers on a fresh Windows VM, see [utils/manual-test/README.md](utils/manual-test/README.md).
 
-The official Windows installer is `gorilla.msix` from the releases page. The MSIX requires Windows 10 version 2004 (build 19041) or newer and administrator approval at install time because it installs Gorilla's automatic `LocalSystem` Windows service alongside the WinUI application. The UI itself runs as the signed-in user and communicates with the service over Gorilla's named pipe.
+The official Windows installer is published as `gorilla-<version>.msix` on each release (for example, `gorilla-2.30.0.msix`). The MSIX requires Windows 10 version 2004 (build 19041) or newer and administrator approval at install time because it installs Gorilla's automatic `LocalSystem` Windows service alongside the WinUI application. The UI itself runs as the signed-in user and communicates with the service over Gorilla's named pipe.
 
-Deploy Gorilla's service configuration at `%ProgramData%\gorilla\config.yaml`. The service intentionally keeps mutable configuration outside the immutable MSIX package. Environments that need custom deployment behavior can use the separately published `gorilla.exe` binary instead of the packaged installer.
+Deploy Gorilla's service configuration at `%ProgramData%\gorilla\config.yaml`. The service intentionally keeps mutable configuration outside the immutable MSIX package. Environments that need custom deployment behavior can use the separately published `gorilla-<version>.exe` release binary instead of the packaged installer. The executable inside the MSIX remains `gorilla.exe`.
 
 ## Building
 

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -6,6 +6,4 @@ catalogs:
 app_data_path: c:/cpe/gorilla/cache
 # auth_user: johnny
 # auth_pass: pizza
-# service_name: gorilla
 # service_interval: 1h
-# service_pipe_name: gorilla-service

--- a/gorilla-ui/src/Gorilla.UI.App/App.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/App.xaml.cs
@@ -10,7 +10,9 @@ namespace Gorilla.UI.App
 {
     public partial class App : Application
     {
-        private const string PipeNameOverrideVariable = "GORILLA_UI_PIPE_NAME";
+        // Source E2E tests use an isolated service identity. Production always
+        // uses NamedPipeClientOptions.Default (gorilla-service).
+        private const string E2EPipeNameVariable = "GORILLA_UI_E2E_PIPE_NAME";
         private const string CachePathOverrideVariable = "GORILLA_UI_CACHE_PATH";
         private Window? _window;
 
@@ -22,7 +24,7 @@ namespace Gorilla.UI.App
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
             var cacheFilePath = BuildCacheFilePath();
-            var pipeName = Environment.GetEnvironmentVariable(PipeNameOverrideVariable);
+            var pipeName = Environment.GetEnvironmentVariable(E2EPipeNameVariable);
             var services = GorillaUiServices.Create(cacheFilePath, pipeName);
             var operationTracker = new OperationTracker(services.Client);
             var homeViewModel = new HomeViewModel(services.Client, services.CacheCoordinator, operationTracker);

--- a/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
+++ b/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>Gorilla.UI.App</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
@@ -11,6 +11,7 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
+    <GorillaServiceExecutable Condition="'$(GorillaServiceExecutable)' == ''">$(MSBuildThisFileDirectory)..\..\..\..\build\gorilla.exe</GorillaServiceExecutable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +22,15 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <Content Include="$(GorillaServiceExecutable)" Link="gorilla.exe" Condition="Exists('$(GorillaServiceExecutable)')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
+
+  <Target Name="RequireGorillaServiceExecutableForMsix" BeforeTargets="_GenerateAppxPackageFile" Condition="'$(GenerateAppxPackageOnBuild)' == 'true' and !Exists('$(GorillaServiceExecutable)')">
+    <Error Text="Gorilla service executable was not found at '$(GorillaServiceExecutable)'. Build gorilla.exe before producing the MSIX or set GorillaServiceExecutable." />
+  </Target>
 
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />

--- a/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
+++ b/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
@@ -11,8 +11,8 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
-    <GorillaSourceBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\..\build\gorilla.exe</GorillaSourceBuildExecutable>
-    <GorillaReleaseBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\..\cmd\gorilla\gorilla.exe</GorillaReleaseBuildExecutable>
+    <GorillaSourceBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\build\gorilla.exe</GorillaSourceBuildExecutable>
+    <GorillaReleaseBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\cmd\gorilla\gorilla.exe</GorillaReleaseBuildExecutable>
     <GorillaServiceExecutable Condition="'$(GorillaServiceExecutable)' == '' and Exists('$(GorillaSourceBuildExecutable)')">$(GorillaSourceBuildExecutable)</GorillaServiceExecutable>
     <GorillaServiceExecutable Condition="'$(GorillaServiceExecutable)' == '' and Exists('$(GorillaReleaseBuildExecutable)')">$(GorillaReleaseBuildExecutable)</GorillaServiceExecutable>
   </PropertyGroup>

--- a/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
+++ b/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
@@ -11,7 +11,10 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
-    <GorillaServiceExecutable Condition="'$(GorillaServiceExecutable)' == ''">$(MSBuildThisFileDirectory)..\..\..\..\build\gorilla.exe</GorillaServiceExecutable>
+    <GorillaSourceBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\..\build\gorilla.exe</GorillaSourceBuildExecutable>
+    <GorillaReleaseBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\..\cmd\gorilla\gorilla.exe</GorillaReleaseBuildExecutable>
+    <GorillaServiceExecutable Condition="'$(GorillaServiceExecutable)' == '' and Exists('$(GorillaSourceBuildExecutable)')">$(GorillaSourceBuildExecutable)</GorillaServiceExecutable>
+    <GorillaServiceExecutable Condition="'$(GorillaServiceExecutable)' == '' and Exists('$(GorillaReleaseBuildExecutable)')">$(GorillaReleaseBuildExecutable)</GorillaServiceExecutable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,7 +32,7 @@
   </ItemGroup>
 
   <Target Name="RequireGorillaServiceExecutableForMsix" BeforeTargets="_GenerateAppxPackageFile" Condition="'$(GenerateAppxPackageOnBuild)' == 'true' and !Exists('$(GorillaServiceExecutable)')">
-    <Error Text="Gorilla service executable was not found at '$(GorillaServiceExecutable)'. Build gorilla.exe before producing the MSIX or set GorillaServiceExecutable." />
+    <Error Text="Gorilla service executable was not found. Build gorilla.exe before producing the MSIX or set GorillaServiceExecutable." />
   </Target>
 
   <ItemGroup>

--- a/gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest
+++ b/gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest
@@ -4,8 +4,9 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  IgnorableNamespaces="uap desktop6 rescap">
 
   <Identity
     Name="133b2116-358b-42fb-8bc8-35009cc5d5af"
@@ -21,8 +22,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.19041.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.19041.0" />
   </Dependencies>
 
   <Resources>
@@ -42,10 +43,24 @@
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <desktop6:Extension
+          Category="windows.service"
+          Executable="gorilla.exe"
+          EntryPoint="Windows.FullTrustApplication">
+          <desktop6:Service
+            Name="gorilla"
+            StartupType="auto"
+            StartAccount="localSystem"
+            Arguments="-service" />
+        </desktop6:Extension>
+      </Extensions>
     </Application>
   </Applications>
 
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
+    <rescap:Capability Name="packagedServices" />
+    <rescap:Capability Name="localSystemServices" />
   </Capabilities>
 </Package>

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/GorillaAppSession.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/GorillaAppSession.cs
@@ -26,12 +26,13 @@ internal sealed class GorillaAppSession : IDisposable
 
     public static GorillaAppSession Launch()
     {
+        var appUserModelId = Environment.GetEnvironmentVariable("GORILLA_UI_APP_ID");
         var appExePath = Environment.GetEnvironmentVariable("GORILLA_UI_APP_EXE");
-        if (string.IsNullOrWhiteSpace(appExePath))
+        if (string.IsNullOrWhiteSpace(appUserModelId) && string.IsNullOrWhiteSpace(appExePath))
         {
-            throw new InvalidOperationException("GORILLA_UI_APP_EXE must be set to the built Gorilla.UI.App.exe path.");
+            throw new InvalidOperationException("Set GORILLA_UI_APP_EXE for source-built UI tests or GORILLA_UI_APP_ID for installed-package UI tests.");
         }
-        if (!File.Exists(appExePath))
+        if (string.IsNullOrWhiteSpace(appUserModelId) && !File.Exists(appExePath))
         {
             throw new FileNotFoundException($"GORILLA_UI_APP_EXE path does not exist: {appExePath}", appExePath);
         }
@@ -43,7 +44,9 @@ internal sealed class GorillaAppSession : IDisposable
         }
         Directory.CreateDirectory(artifactsDirectory);
 
-        var application = Application.Launch(appExePath);
+        var application = !string.IsNullOrWhiteSpace(appUserModelId)
+            ? Application.LaunchStoreApp(appUserModelId)
+            : Application.Launch(appExePath!);
         var process = Process.GetProcessById(application.ProcessId);
         var automation = new UIA3Automation();
         var session = new GorillaAppSession(application, process, automation, artifactsDirectory);

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/run-tests.ps1
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/run-tests.ps1
@@ -3,6 +3,7 @@ param(
     [string]$ArtifactsDirectory = "$PSScriptRoot\artifacts",
     [string]$TestFilter = "",
     [string]$ResultPrefix = "windows-ui-test",
+    [string]$AppUserModelId = "",
     [switch]$SkipBuild
 )
 
@@ -42,15 +43,23 @@ if (-not $SkipBuild) {
     Invoke-DotNet @("build", $testProject, "-c", "Release", "--no-restore")
 }
 
-if (-not (Test-Path -LiteralPath $appExe)) {
-    if ($SkipBuild) {
-        throw "Expected Release x64 Gorilla.UI.App.exe was not found at $appExe. Run the Windows UI build before test execution."
+if ([string]::IsNullOrWhiteSpace($AppUserModelId)) {
+    if (-not (Test-Path -LiteralPath $appExe)) {
+        if ($SkipBuild) {
+            throw "Expected Release x64 Gorilla.UI.App.exe was not found at $appExe. Run the Windows UI build before test execution."
+        }
+        throw "Expected Release x64 Gorilla.UI.App.exe was not found after build: $appExe"
     }
-    throw "Expected Release x64 Gorilla.UI.App.exe was not found after build: $appExe"
+
+    Write-Host "Using Windows UI executable: $appExe"
+    $env:GORILLA_UI_APP_EXE = $appExe
+    Remove-Item Env:GORILLA_UI_APP_ID -ErrorAction SilentlyContinue
+} else {
+    Write-Host "Using installed Windows UI package application: $AppUserModelId"
+    $env:GORILLA_UI_APP_ID = $AppUserModelId
+    Remove-Item Env:GORILLA_UI_APP_EXE -ErrorAction SilentlyContinue
 }
 
-Write-Host "Using Windows UI executable: $appExe"
-$env:GORILLA_UI_APP_EXE = $appExe
 $env:WINDOWS_UI_TEST_RESULTS_DIR = $ResultsDirectory
 $env:WINDOWS_UI_TEST_ARTIFACTS_DIR = $ArtifactsDirectory
 

--- a/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
@@ -8,6 +8,12 @@ namespace Gorilla.UI.Client.Tests;
 public class ContractsSmokeTests
 {
     [Fact]
+    public void NamedPipeClientOptions_DefaultUsesCanonicalProductPipe()
+    {
+        Assert.Equal("gorilla-service", NamedPipeClientOptions.Default.PipeName);
+    }
+
+    [Fact]
     public void OperationState_HasTerminalValues()
     {
         Assert.Contains(OperationState.Succeeded, Enum.GetValues<OperationState>());

--- a/integration/windows/run-installed-product-integration.ps1
+++ b/integration/windows/run-installed-product-integration.ps1
@@ -30,6 +30,9 @@ $markerPath = Join-Path $appDataPath "ps1.txt"
 $serviceLogPath = Join-Path $appDataPath "gorilla.log"
 $evidenceRoot = Join-Path $root "installed-product-evidence"
 $installedByHarness = $false
+$configCreatedByHarness = $false
+$configDirectoryCreatedByHarness = $false
+$appDataCreatedByHarness = $false
 
 function Wait-ServiceState {
     param(
@@ -76,6 +79,9 @@ function Assert-CleanMachine {
     }
     if (Test-Path -LiteralPath $configPath) {
         throw "Installed-product validation will not overwrite existing Gorilla configuration: $configPath"
+    }
+    if (Test-Path -LiteralPath $appDataPath) {
+        throw "Installed-product validation will not overwrite existing Gorilla integration data: $appDataPath"
     }
 }
 
@@ -140,7 +146,6 @@ $serverProc = $null
 try {
     Assert-CleanMachine
     Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Path $root, $evidenceRoot -Force | Out-Null
 
     Write-Host "[INFO] Reusing Windows integration fixture preparation for installed-product validation"
@@ -164,7 +169,13 @@ optional_installs:
         throw "Fixture HTTP server exited during startup"
     }
 
-    New-Item -ItemType Directory -Path $configDirectory -Force | Out-Null
+    if (-not (Test-Path -LiteralPath $configDirectory)) {
+        New-Item -ItemType Directory -Path $configDirectory -Force | Out-Null
+        $configDirectoryCreatedByHarness = $true
+    }
+    New-Item -ItemType Directory -Path $appDataPath -Force | Out-Null
+    $appDataCreatedByHarness = $true
+
     $fileUrl = "http://127.0.0.1:$serverPort/"
     @"
 url: $fileUrl
@@ -175,6 +186,7 @@ app_data_path: C:/ProgramData/gorilla-it
 service_interval: 24h
 debug: true
 "@ | Set-Content -LiteralPath $configPath -NoNewline
+    $configCreatedByHarness = $true
 
     Write-Host "[INFO] Installing produced Gorilla MSIX: $msixPath"
     Add-AppxPackage -Path $msixPath -ErrorAction Stop
@@ -256,9 +268,13 @@ debug: true
     if ($serverProc -and -not $serverProc.HasExited) {
         Stop-Process -Id $serverProc.Id -Force -ErrorAction SilentlyContinue
     }
-    Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath $configPath -Force -ErrorAction SilentlyContinue
-    if ((Test-Path -LiteralPath $configDirectory) -and -not (Get-ChildItem -LiteralPath $configDirectory -Force)) {
+    if ($appDataCreatedByHarness) {
+        Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if ($configCreatedByHarness) {
+        Remove-Item -LiteralPath $configPath -Force -ErrorAction SilentlyContinue
+    }
+    if ($configDirectoryCreatedByHarness -and (Test-Path -LiteralPath $configDirectory) -and -not (Get-ChildItem -LiteralPath $configDirectory -Force)) {
         Remove-Item -LiteralPath $configDirectory -Force -ErrorAction SilentlyContinue
     }
 }

--- a/integration/windows/run-installed-product-integration.ps1
+++ b/integration/windows/run-installed-product-integration.ps1
@@ -1,0 +1,248 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$GorillaMsixPath,
+    [string]$GorillaReleaseExePath = "",
+    [string]$WorkRoot = "$env:RUNNER_TEMP\gorilla-installed-product"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$prepareScript = Join-Path $PSScriptRoot "prepare-release-integration.ps1"
+$uiTestScript = Join-Path $repoRoot "gorilla-ui\tests\Gorilla.UI.App.WindowsUiTests\run-tests.ps1"
+$packageIdentityName = "133b2116-358b-42fb-8bc8-35009cc5d5af"
+$serviceName = "gorilla"
+$servicePipeName = "gorilla-service"
+$root = [System.IO.Path]::GetFullPath($WorkRoot)
+$msixPath = [System.IO.Path]::GetFullPath($GorillaMsixPath)
+if (-not (Test-Path -LiteralPath $msixPath)) {
+    throw "Produced Gorilla MSIX not found: $msixPath"
+}
+
+$fixtureRoot = Join-Path $root "fixture"
+$repoFixtureRoot = Join-Path $fixtureRoot "repo"
+$serverExe = Join-Path $fixtureRoot "tools\fixture-server.exe"
+$catalogPath = Join-Path $repoFixtureRoot "catalogs\integration.yaml"
+$manifestPath = Join-Path $repoFixtureRoot "manifests\ui-e2e.yaml"
+$configPath = "C:\ProgramData\gorilla\config.yaml"
+$appDataPath = "C:\ProgramData\gorilla-it"
+$markerPath = Join-Path $appDataPath "ps1.txt"
+$serviceLogPath = Join-Path $appDataPath "gorilla.log"
+$evidenceRoot = Join-Path $root "installed-product-evidence"
+
+function Wait-ServiceState {
+    param(
+        [Parameter(Mandatory = $true)][string]$Expected,
+        [int]$TimeoutSeconds = 30
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+        if ($Expected -eq "Absent" -and -not $service) {
+            return
+        }
+        if ($service -and $service.Status.ToString() -eq $Expected) {
+            return
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+
+    $actual = (Get-Service -Name $serviceName -ErrorAction SilentlyContinue)?.Status
+    throw "Timed out waiting for service '$serviceName' state '$Expected'. Actual: $actual"
+}
+
+function Remove-InstalledPackage {
+    $packages = @(Get-AppxPackage -Name $packageIdentityName -ErrorAction SilentlyContinue)
+    foreach ($package in $packages) {
+        Write-Host "[INFO] Removing leftover Gorilla package $($package.PackageFullName)"
+        Remove-AppxPackage -Package $package.PackageFullName -ErrorAction Stop
+    }
+    if ($packages.Count -gt 0) {
+        Wait-ServiceState -Expected "Absent"
+    }
+}
+
+function Copy-InstalledProductEvidence {
+    param([Parameter(Mandatory = $true)][string]$PhaseDirectory)
+
+    New-Item -ItemType Directory -Path $PhaseDirectory -Force | Out-Null
+    try {
+        if (Test-Path -LiteralPath $serviceLogPath) {
+            Copy-Item -LiteralPath $serviceLogPath -Destination (Join-Path $PhaseDirectory "gorilla.log") -Force
+        }
+    } catch {
+        Write-Warning "Unable to copy Gorilla service log: $_"
+    }
+
+    try {
+        $service = Get-CimInstance Win32_Service -Filter "Name='$serviceName'" -ErrorAction SilentlyContinue
+        if ($service) {
+            $service | Format-List * | Out-String | Set-Content -LiteralPath (Join-Path $PhaseDirectory "service-info.txt")
+        }
+    } catch {
+        Write-Warning "Unable to capture service information: $_"
+    }
+
+    try {
+        Get-AppxPackage -Name $packageIdentityName -ErrorAction SilentlyContinue |
+            Format-List * | Out-String | Set-Content -LiteralPath (Join-Path $PhaseDirectory "package-info.txt")
+    } catch {
+        Write-Warning "Unable to capture package information: $_"
+    }
+}
+
+function Invoke-TestPhase {
+    param(
+        [Parameter(Mandatory = $true)][string]$Phase,
+        [Parameter(Mandatory = $true)][string]$Filter,
+        [Parameter(Mandatory = $true)][string]$AppUserModelId
+    )
+
+    $phaseDirectory = Join-Path $evidenceRoot $Phase
+    New-Item -ItemType Directory -Path $phaseDirectory -Force | Out-Null
+    $env:GORILLA_UI_DEBUG = "1"
+    $env:GORILLA_UI_LOG_PATH = Join-Path $phaseDirectory "ui-client.log"
+    try {
+        & $uiTestScript `
+            -ResultsDirectory $phaseDirectory `
+            -ArtifactsDirectory $phaseDirectory `
+            -TestFilter $Filter `
+            -ResultPrefix "tests" `
+            -AppUserModelId $AppUserModelId `
+            -SkipBuild
+        if ($LASTEXITCODE -ne 0) {
+            throw "Installed-package FlaUI phase '$Phase' failed with exit code $LASTEXITCODE"
+        }
+    } finally {
+        Copy-InstalledProductEvidence -PhaseDirectory $phaseDirectory
+        Remove-Item Env:GORILLA_UI_LOG_PATH -ErrorAction SilentlyContinue
+    }
+}
+
+$serverProc = $null
+$installedPackage = $null
+try {
+    Remove-InstalledPackage
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Split-Path -Parent $configPath) -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $root, $evidenceRoot -Force | Out-Null
+
+    Write-Host "[INFO] Reusing Windows integration fixture preparation for installed-product validation"
+    & $prepareScript -WorkRoot $root
+    if ($LASTEXITCODE -ne 0) {
+        throw "prepare-release-integration.ps1 failed with exit code $LASTEXITCODE"
+    }
+
+    @'
+name: ui-e2e
+optional_installs:
+  - Ps1V1
+'@ | Set-Content -LiteralPath $manifestPath -NoNewline
+
+    $serverPort = Get-Random -Minimum 19000 -Maximum 19999
+    $serverProc = Start-Process -FilePath $serverExe `
+        -ArgumentList @("-addr", "127.0.0.1:$serverPort", "-root", $repoFixtureRoot) `
+        -PassThru -WindowStyle Hidden
+    Start-Sleep -Seconds 1
+    if ($serverProc.HasExited) {
+        throw "Fixture HTTP server exited during startup"
+    }
+
+    New-Item -ItemType Directory -Path (Split-Path -Parent $configPath) -Force | Out-Null
+    $fileUrl = "http://127.0.0.1:$serverPort/"
+    @"
+url: $fileUrl
+manifest: ui-e2e
+catalogs:
+  - integration
+app_data_path: C:/ProgramData/gorilla-it
+service_interval: 24h
+debug: true
+"@ | Set-Content -LiteralPath $configPath -NoNewline
+
+    Write-Host "[INFO] Installing produced Gorilla MSIX: $msixPath"
+    Add-AppxPackage -Path $msixPath -ErrorAction Stop
+    $installedPackage = Get-AppxPackage -Name $packageIdentityName -ErrorAction Stop
+    if ($null -eq $installedPackage) {
+        throw "Gorilla MSIX installation did not register package identity '$packageIdentityName'"
+    }
+
+    $installedGorilla = Join-Path $installedPackage.InstallLocation "gorilla.exe"
+    if (-not (Test-Path -LiteralPath $installedGorilla)) {
+        throw "Installed Gorilla package does not contain gorilla.exe at $installedGorilla"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($GorillaReleaseExePath)) {
+        $releaseExe = [System.IO.Path]::GetFullPath($GorillaReleaseExePath)
+        if (-not (Test-Path -LiteralPath $releaseExe)) {
+            throw "Produced standalone gorilla.exe not found: $releaseExe"
+        }
+        $packagedHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $installedGorilla).Hash
+        $releaseHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $releaseExe).Hash
+        if ($packagedHash -cne $releaseHash) {
+            throw "The gorilla.exe inside the produced MSIX does not match the produced standalone gorilla.exe"
+        }
+    }
+
+    $service = Get-CimInstance Win32_Service -Filter "Name='$serviceName'" -ErrorAction Stop
+    if ($null -eq $service) {
+        throw "Installing the Gorilla MSIX did not register the '$serviceName' service"
+    }
+    if ($service.StartName -notin @("LocalSystem", "LocalSystem")) {
+        throw "Gorilla service account is '$($service.StartName)'; expected LocalSystem"
+    }
+    if ($service.StartMode -ne "Auto") {
+        throw "Gorilla service startup mode is '$($service.StartMode)'; expected Auto"
+    }
+    if ($service.PathName -notlike "*$installedGorilla*") {
+        throw "Gorilla service is not registered to the packaged executable. PathName: $($service.PathName)"
+    }
+
+    $serviceState = Get-Service -Name $serviceName
+    if ($serviceState.Status -ne "Running") {
+        Start-Service -Name $serviceName
+    }
+    Wait-ServiceState -Expected "Running"
+
+    & $installedGorilla -config $configPath -servicecmd ListOptionalInstalls | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Packaged gorilla.exe could not communicate with the installed Gorilla service over the real named pipe"
+    }
+
+    $appUserModelId = "$($installedPackage.PackageFamilyName)!App"
+    $uiCachePath = Join-Path $env:LOCALAPPDATA "Packages\$($installedPackage.PackageFamilyName)\LocalCache\Local\Gorilla\ui\optional-installs-cache.json"
+    $env:GORILLA_UI_E2E_MARKER_PATH = $markerPath
+    $env:GORILLA_UI_E2E_CACHE_PATH = $uiCachePath
+
+    Invoke-TestPhase -Phase "healthy" -Filter "E2EPhase=Healthy|FullyQualifiedName~AppLaunchSmokeTests" -AppUserModelId $appUserModelId
+
+    Stop-Service -Name $serviceName -Force -ErrorAction Stop
+    Wait-ServiceState -Expected "Stopped"
+    Invoke-TestPhase -Phase "service-unavailable" -Filter "E2EPhase=ServiceUnavailable" -AppUserModelId $appUserModelId
+
+    Write-Host "Installed-product integration passed"
+} catch {
+    $originalError = $_
+    try {
+        New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
+        $originalError | Out-String | Set-Content -LiteralPath (Join-Path $evidenceRoot "harness-failure.txt")
+        Copy-InstalledProductEvidence -PhaseDirectory $evidenceRoot
+    } catch {
+        Write-Warning "Unable to capture installed-product failure evidence: $_"
+    }
+    throw $originalError
+} finally {
+    try {
+        Remove-InstalledPackage
+    } catch {
+        Write-Warning "Unable to remove installed Gorilla package during cleanup: $_"
+    }
+    if ($serverProc -and -not $serverProc.HasExited) {
+        Stop-Process -Id $serverProc.Id -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Split-Path -Parent $configPath) -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/integration/windows/run-installed-product-integration.ps1
+++ b/integration/windows/run-installed-product-integration.ps1
@@ -143,6 +143,8 @@ function Invoke-TestPhase {
 }
 
 $serverProc = $null
+$primaryError = $null
+$cleanupError = $null
 try {
     Assert-CleanMachine
     Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
@@ -247,23 +249,27 @@ debug: true
     Stop-Service -Name $serviceName -Force -ErrorAction Stop
     Wait-ServiceState -Expected "Stopped"
     Invoke-TestPhase -Phase "service-unavailable" -Filter "E2EPhase=ServiceUnavailable" -AppUserModelId $appUserModelId
-
-    Write-Host "Installed-product integration passed"
 } catch {
-    $originalError = $_
+    $primaryError = $_
     try {
         New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
-        $originalError | Out-String | Set-Content -LiteralPath (Join-Path $evidenceRoot "harness-failure.txt")
+        $primaryError | Out-String | Set-Content -LiteralPath (Join-Path $evidenceRoot "harness-failure.txt")
         Copy-InstalledProductEvidence -PhaseDirectory $evidenceRoot
     } catch {
         Write-Warning "Unable to capture installed-product failure evidence: $_"
     }
-    throw $originalError
 } finally {
     try {
         Remove-TestPackage
     } catch {
-        Write-Warning "Unable to remove test-installed Gorilla package during cleanup: $_"
+        $cleanupError = $_
+        try {
+            New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
+            $cleanupError | Out-String | Set-Content -LiteralPath (Join-Path $evidenceRoot "cleanup-failure.txt")
+            Copy-InstalledProductEvidence -PhaseDirectory $evidenceRoot
+        } catch {
+            Write-Warning "Unable to capture installed-product cleanup failure evidence: $_"
+        }
     }
     if ($serverProc -and -not $serverProc.HasExited) {
         Stop-Process -Id $serverProc.Id -Force -ErrorAction SilentlyContinue
@@ -278,3 +284,15 @@ debug: true
         Remove-Item -LiteralPath $configDirectory -Force -ErrorAction SilentlyContinue
     }
 }
+
+if ($null -ne $primaryError) {
+    if ($null -ne $cleanupError) {
+        Write-Warning "Installed-product cleanup also failed: $cleanupError"
+    }
+    throw $primaryError
+}
+if ($null -ne $cleanupError) {
+    throw $cleanupError
+}
+
+Write-Host "Installed-product integration passed"

--- a/integration/windows/run-installed-product-integration.ps1
+++ b/integration/windows/run-installed-product-integration.ps1
@@ -13,7 +13,6 @@ $prepareScript = Join-Path $PSScriptRoot "prepare-release-integration.ps1"
 $uiTestScript = Join-Path $repoRoot "gorilla-ui\tests\Gorilla.UI.App.WindowsUiTests\run-tests.ps1"
 $packageIdentityName = "133b2116-358b-42fb-8bc8-35009cc5d5af"
 $serviceName = "gorilla"
-$servicePipeName = "gorilla-service"
 $root = [System.IO.Path]::GetFullPath($WorkRoot)
 $msixPath = [System.IO.Path]::GetFullPath($GorillaMsixPath)
 if (-not (Test-Path -LiteralPath $msixPath)) {
@@ -23,13 +22,14 @@ if (-not (Test-Path -LiteralPath $msixPath)) {
 $fixtureRoot = Join-Path $root "fixture"
 $repoFixtureRoot = Join-Path $fixtureRoot "repo"
 $serverExe = Join-Path $fixtureRoot "tools\fixture-server.exe"
-$catalogPath = Join-Path $repoFixtureRoot "catalogs\integration.yaml"
 $manifestPath = Join-Path $repoFixtureRoot "manifests\ui-e2e.yaml"
 $configPath = "C:\ProgramData\gorilla\config.yaml"
+$configDirectory = Split-Path -Parent $configPath
 $appDataPath = "C:\ProgramData\gorilla-it"
 $markerPath = Join-Path $appDataPath "ps1.txt"
 $serviceLogPath = Join-Path $appDataPath "gorilla.log"
 $evidenceRoot = Join-Path $root "installed-product-evidence"
+$installedByHarness = $false
 
 function Wait-ServiceState {
     param(
@@ -53,14 +53,29 @@ function Wait-ServiceState {
     throw "Timed out waiting for service '$serviceName' state '$Expected'. Actual: $actual"
 }
 
-function Remove-InstalledPackage {
+function Remove-TestPackage {
+    if (-not $script:installedByHarness) {
+        return
+    }
+
     $packages = @(Get-AppxPackage -Name $packageIdentityName -ErrorAction SilentlyContinue)
     foreach ($package in $packages) {
-        Write-Host "[INFO] Removing leftover Gorilla package $($package.PackageFullName)"
+        Write-Host "[INFO] Removing test-installed Gorilla package $($package.PackageFullName)"
         Remove-AppxPackage -Package $package.PackageFullName -ErrorAction Stop
     }
-    if ($packages.Count -gt 0) {
-        Wait-ServiceState -Expected "Absent"
+    Wait-ServiceState -Expected "Absent"
+    $script:installedByHarness = $false
+}
+
+function Assert-CleanMachine {
+    if (Get-AppxPackage -Name $packageIdentityName -ErrorAction SilentlyContinue) {
+        throw "Installed-product validation requires a disposable machine with no existing Gorilla MSIX installation."
+    }
+    if (Get-Service -Name $serviceName -ErrorAction SilentlyContinue) {
+        throw "Installed-product validation requires a disposable machine with no existing '$serviceName' service."
+    }
+    if (Test-Path -LiteralPath $configPath) {
+        throw "Installed-product validation will not overwrite existing Gorilla configuration: $configPath"
     }
 }
 
@@ -122,12 +137,10 @@ function Invoke-TestPhase {
 }
 
 $serverProc = $null
-$installedPackage = $null
 try {
-    Remove-InstalledPackage
+    Assert-CleanMachine
     Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath (Split-Path -Parent $configPath) -Recurse -Force -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Path $root, $evidenceRoot -Force | Out-Null
 
     Write-Host "[INFO] Reusing Windows integration fixture preparation for installed-product validation"
@@ -151,7 +164,7 @@ optional_installs:
         throw "Fixture HTTP server exited during startup"
     }
 
-    New-Item -ItemType Directory -Path (Split-Path -Parent $configPath) -Force | Out-Null
+    New-Item -ItemType Directory -Path $configDirectory -Force | Out-Null
     $fileUrl = "http://127.0.0.1:$serverPort/"
     @"
 url: $fileUrl
@@ -165,6 +178,7 @@ debug: true
 
     Write-Host "[INFO] Installing produced Gorilla MSIX: $msixPath"
     Add-AppxPackage -Path $msixPath -ErrorAction Stop
+    $installedByHarness = $true
     $installedPackage = Get-AppxPackage -Name $packageIdentityName -ErrorAction Stop
     if ($null -eq $installedPackage) {
         throw "Gorilla MSIX installation did not register package identity '$packageIdentityName'"
@@ -191,7 +205,7 @@ debug: true
     if ($null -eq $service) {
         throw "Installing the Gorilla MSIX did not register the '$serviceName' service"
     }
-    if ($service.StartName -notin @("LocalSystem", "LocalSystem")) {
+    if ($service.StartName -ne "LocalSystem") {
         throw "Gorilla service account is '$($service.StartName)'; expected LocalSystem"
     }
     if ($service.StartMode -ne "Auto") {
@@ -201,8 +215,7 @@ debug: true
         throw "Gorilla service is not registered to the packaged executable. PathName: $($service.PathName)"
     }
 
-    $serviceState = Get-Service -Name $serviceName
-    if ($serviceState.Status -ne "Running") {
+    if ((Get-Service -Name $serviceName).Status -ne "Running") {
         Start-Service -Name $serviceName
     }
     Wait-ServiceState -Expected "Running"
@@ -236,13 +249,16 @@ debug: true
     throw $originalError
 } finally {
     try {
-        Remove-InstalledPackage
+        Remove-TestPackage
     } catch {
-        Write-Warning "Unable to remove installed Gorilla package during cleanup: $_"
+        Write-Warning "Unable to remove test-installed Gorilla package during cleanup: $_"
     }
     if ($serverProc -and -not $serverProc.HasExited) {
         Stop-Process -Id $serverProc.Id -Force -ErrorAction SilentlyContinue
     }
     Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath (Split-Path -Parent $configPath) -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $configPath -Force -ErrorAction SilentlyContinue
+    if ((Test-Path -LiteralPath $configDirectory) -and -not (Get-ChildItem -LiteralPath $configDirectory -Force)) {
+        Remove-Item -LiteralPath $configDirectory -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/integration/windows/run-installed-product-integration.ps1
+++ b/integration/windows/run-installed-product-integration.ps1
@@ -66,6 +66,9 @@ function Remove-TestPackage {
         Write-Host "[INFO] Removing test-installed Gorilla package $($package.PackageFullName)"
         Remove-AppxPackage -Package $package.PackageFullName -ErrorAction Stop
     }
+    if (Get-AppxPackage -Name $packageIdentityName -ErrorAction SilentlyContinue) {
+        throw "Gorilla MSIX package is still registered after uninstall"
+    }
     Wait-ServiceState -Expected "Absent"
     $script:installedByHarness = $false
 }

--- a/integration/windows/run-ui-e2e.ps1
+++ b/integration/windows/run-ui-e2e.ps1
@@ -177,20 +177,18 @@ manifest: ui-e2e
 catalogs:
   - integration
 app_data_path: C:/ProgramData/gorilla-ui-e2e
-service_name: $serviceName
-service_pipe_name: $servicePipeName
 service_interval: 24h
 debug: true
 "@ | Set-Content -LiteralPath $configPath -NoNewline
 
-    $env:GORILLA_UI_PIPE_NAME = $servicePipeName
+    $env:GORILLA_UI_E2E_PIPE_NAME = $servicePipeName
     $env:GORILLA_UI_CACHE_PATH = $uiCachePath
     $env:GORILLA_UI_E2E_MARKER_PATH = $markerPath
     $env:GORILLA_UI_E2E_CACHE_PATH = $uiCachePath
 
-    & $GorillaExePath -config $configPath -serviceinstall | Out-Host
+    & $GorillaExePath -config $configPath -integration-test-service-identity $serviceName -serviceinstall | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Failed to install source-built Gorilla service" }
-    & $GorillaExePath -config $configPath -servicestart | Out-Host
+    & $GorillaExePath -config $configPath -integration-test-service-identity $serviceName -servicestart | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Failed to start source-built Gorilla service" }
     Wait-ServiceState -Expected "Running"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,9 +41,9 @@ var (
 	serviceStartArg   bool
 	serviceStopArg    bool
 	serviceStatusArg  bool
-	// integrationTestServiceIdentityArg is an internal test seam used by the
+	// e2eIdentityArg is an internal test seam used by the
 	// source-built Windows E2E harness. It is intentionally omitted from usage.
-	integrationTestServiceIdentityArg string
+	e2eIdentityArg    string
 
 	// Use a fake function so we can override when testing
 	osExit = os.Exit
@@ -113,10 +113,10 @@ type Configuration struct {
 	ServiceName     string `yaml:"-"`
 	ServiceInterval string `yaml:"service_interval,omitempty"`
 	ServicePipeName string `yaml:"-"`
-	// IntegrationTestServiceIdentity carries the source E2E identity into the
+	// E2EIdentity carries the source E2E identity into the
 	// installed service command line. It is never read from YAML.
-	IntegrationTestServiceIdentity string `yaml:"-"`
-	ConfigPath                     string
+	E2EIdentity    string `yaml:"-"`
+	ConfigPath     string
 }
 
 func init() {
@@ -161,7 +161,7 @@ func init() {
 	flag.BoolVar(&serviceStartArg, "servicestart", false, "")
 	flag.BoolVar(&serviceStopArg, "servicestop", false, "")
 	flag.BoolVar(&serviceStatusArg, "servicestatus", false, "")
-	flag.StringVar(&integrationTestServiceIdentityArg, "integration-test-service-identity", "", "")
+	flag.StringVar(&e2eIdentityArg, "integration-test-service-identity", "", "")
 }
 
 func parseArguments() (string, bool, bool, bool, bool, string) {
@@ -290,10 +290,10 @@ func Get() Configuration {
 	// an internal command-line seam for the source-built Windows E2E harness.
 	cfg.ServiceName = CanonicalServiceName
 	cfg.ServicePipeName = CanonicalServicePipeName
-	if integrationTestServiceIdentityArg != "" {
-		cfg.ServiceName = integrationTestServiceIdentityArg
-		cfg.ServicePipeName = integrationTestServiceIdentityArg
-		cfg.IntegrationTestServiceIdentity = integrationTestServiceIdentityArg
+	if e2eIdentityArg != "" {
+		cfg.ServiceName = e2eIdentityArg
+		cfg.ServicePipeName = e2eIdentityArg
+		cfg.E2EIdentity = e2eIdentityArg
 	}
 	if cfg.ServiceInterval == "" {
 		cfg.ServiceInterval = "1h"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,32 +83,32 @@ Options:
 
 // Configuration stores all of the possible parameters a config file could contain
 type Configuration struct {
-	URL             string   `yaml:"url"`
-	URLPackages     string   `yaml:"url_packages"`
-	Manifest        string   `yaml:"manifest"`
-	LocalManifests  []string `yaml:"local_manifests,omitempty"`
-	Catalogs        []string `yaml:"catalogs"`
-	AppDataPath     string   `yaml:"app_data_path"`
-	Verbose         bool     `yaml:"verbose,omitempty"`
-	Debug           bool     `yaml:"debug,omitempty"`
-	CheckOnly       bool     `yaml:"checkonly,omitempty"`
-	BuildArg        bool
-	ImportArg       string
-	RepoPath        string `yaml:"repo_path,omitempty"`
-	AuthUser        string `yaml:"auth_user,omitempty"`
-	AuthPass        string `yaml:"auth_pass,omitempty"`
-	TLSAuth         bool   `yaml:"tls_auth,omitempty"`
-	TLSClientCert   string `yaml:"tls_client_cert,omitempty"`
-	TLSClientKey    string `yaml:"tls_client_key,omitempty"`
-	TLSServerCert   string `yaml:"tls_server_cert,omitempty"`
-	CachePath       string
-	ServiceMode     bool `yaml:"service_mode,omitempty"`
-	ServiceCommand  string
-	ServiceInstall  bool
-	ServiceRemove   bool
-	ServiceStart    bool
-	ServiceStop     bool
-	ServiceStatus   bool
+	URL            string   `yaml:"url"`
+	URLPackages    string   `yaml:"url_packages"`
+	Manifest       string   `yaml:"manifest"`
+	LocalManifests []string `yaml:"local_manifests,omitempty"`
+	Catalogs       []string `yaml:"catalogs"`
+	AppDataPath    string   `yaml:"app_data_path"`
+	Verbose        bool     `yaml:"verbose,omitempty"`
+	Debug          bool     `yaml:"debug,omitempty"`
+	CheckOnly      bool     `yaml:"checkonly,omitempty"`
+	BuildArg       bool
+	ImportArg      string
+	RepoPath       string `yaml:"repo_path,omitempty"`
+	AuthUser       string `yaml:"auth_user,omitempty"`
+	AuthPass       string `yaml:"auth_pass,omitempty"`
+	TLSAuth        bool   `yaml:"tls_auth,omitempty"`
+	TLSClientCert  string `yaml:"tls_client_cert,omitempty"`
+	TLSClientKey   string `yaml:"tls_client_key,omitempty"`
+	TLSServerCert  string `yaml:"tls_server_cert,omitempty"`
+	CachePath      string
+	ServiceMode    bool `yaml:"service_mode,omitempty"`
+	ServiceCommand string
+	ServiceInstall bool
+	ServiceRemove  bool
+	ServiceStart   bool
+	ServiceStop    bool
+	ServiceStatus  bool
 	// ServiceName and ServicePipeName are product identities, not supported
 	// configuration. Tests may still construct Configuration values directly.
 	ServiceName     string `yaml:"-"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,8 +115,8 @@ type Configuration struct {
 	ServicePipeName string `yaml:"-"`
 	// E2EIdentity carries the source E2E identity into the
 	// installed service command line. It is never read from YAML.
-	E2EIdentity    string `yaml:"-"`
-	ConfigPath     string
+	E2EIdentity     string `yaml:"-"`
+	ConfigPath      string
 }
 
 func init() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,9 +41,17 @@ var (
 	serviceStartArg   bool
 	serviceStopArg    bool
 	serviceStatusArg  bool
+	// integrationTestServiceIdentityArg is an internal test seam used by the
+	// source-built Windows E2E harness. It is intentionally omitted from usage.
+	integrationTestServiceIdentityArg string
 
 	// Use a fake function so we can override when testing
 	osExit = os.Exit
+)
+
+const (
+	CanonicalServiceName     = "gorilla"
+	CanonicalServicePipeName = "gorilla-service"
 )
 
 const usage = `
@@ -100,10 +108,15 @@ type Configuration struct {
 	ServiceStart    bool
 	ServiceStop     bool
 	ServiceStatus   bool
-	ServiceName     string `yaml:"service_name,omitempty"`
+	// ServiceName and ServicePipeName are product identities, not supported
+	// configuration. Tests may still construct Configuration values directly.
+	ServiceName     string `yaml:"-"`
 	ServiceInterval string `yaml:"service_interval,omitempty"`
-	ServicePipeName string `yaml:"service_pipe_name,omitempty"`
-	ConfigPath      string
+	ServicePipeName string `yaml:"-"`
+	// IntegrationTestServiceIdentity carries the source E2E identity into the
+	// installed service command line. It is never read from YAML.
+	IntegrationTestServiceIdentity string `yaml:"-"`
+	ConfigPath                     string
 }
 
 func init() {
@@ -148,6 +161,7 @@ func init() {
 	flag.BoolVar(&serviceStartArg, "servicestart", false, "")
 	flag.BoolVar(&serviceStopArg, "servicestop", false, "")
 	flag.BoolVar(&serviceStatusArg, "servicestatus", false, "")
+	flag.StringVar(&integrationTestServiceIdentityArg, "integration-test-service-identity", "", "")
 }
 
 func parseArguments() (string, bool, bool, bool, bool, string) {
@@ -272,15 +286,17 @@ func Get() Configuration {
 	report.Items["Manifest"] = cfg.Manifest
 	report.Items["Catalog"] = cfg.Catalogs
 
-	// Configure service defaults.
-	if cfg.ServiceName == "" {
-		cfg.ServiceName = "gorilla"
+	// Service and pipe names are fixed product identities. The only override is
+	// an internal command-line seam for the source-built Windows E2E harness.
+	cfg.ServiceName = CanonicalServiceName
+	cfg.ServicePipeName = CanonicalServicePipeName
+	if integrationTestServiceIdentityArg != "" {
+		cfg.ServiceName = integrationTestServiceIdentityArg
+		cfg.ServicePipeName = integrationTestServiceIdentityArg
+		cfg.IntegrationTestServiceIdentity = integrationTestServiceIdentityArg
 	}
 	if cfg.ServiceInterval == "" {
 		cfg.ServiceInterval = "1h"
-	}
-	if cfg.ServicePipeName == "" {
-		cfg.ServicePipeName = "gorilla-service"
 	}
 
 	return cfg

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,9 +41,10 @@ var (
 	serviceStartArg   bool
 	serviceStopArg    bool
 	serviceStatusArg  bool
+
 	// e2eIdentityArg is an internal test seam used by the
 	// source-built Windows E2E harness. It is intentionally omitted from usage.
-	e2eIdentityArg    string
+	e2eIdentityArg string
 
 	// Use a fake function so we can override when testing
 	osExit = os.Exit
@@ -113,10 +114,12 @@ type Configuration struct {
 	ServiceName     string `yaml:"-"`
 	ServiceInterval string `yaml:"service_interval,omitempty"`
 	ServicePipeName string `yaml:"-"`
+
 	// E2EIdentity carries the source E2E identity into the
 	// installed service command line. It is never read from YAML.
-	E2EIdentity     string `yaml:"-"`
-	ConfigPath      string
+	E2EIdentity string `yaml:"-"`
+
+	ConfigPath string
 }
 
 func init() {

--- a/pkg/config/testdata/test_config.yaml
+++ b/pkg/config/testdata/test_config.yaml
@@ -12,3 +12,7 @@ auth_pass: pizza
 verbose: true
 debug: true
 checkonly: true
+# Service and pipe names are fixed product identities; these legacy keys must
+# not change them.
+service_name: legacy-service-name
+service_pipe_name: legacy-pipe-name

--- a/pkg/service/common.go
+++ b/pkg/service/common.go
@@ -117,8 +117,12 @@ func SendCommand(cfg config.Configuration, spec string) (CommandResponse, error)
 	return sendCommand(cfg, cmd)
 }
 
-func serviceInstallArgs(configPath string) []string {
-	return []string{"-c", configPath, "-service"}
+func serviceInstallArgs(configPath string, integrationTestServiceIdentity string) []string {
+	args := []string{"-c", configPath, "-service"}
+	if integrationTestServiceIdentity != "" {
+		args = append(args, "-integration-test-service-identity", integrationTestServiceIdentity)
+	}
+	return args
 }
 
 func executeCommand(cfg config.Configuration, cmd Command, managedRun func(config.Configuration) error) (CommandResponse, error) {

--- a/pkg/service/common_test.go
+++ b/pkg/service/common_test.go
@@ -96,7 +96,7 @@ func TestValidateCommandInstallItemRequiresOneArgument(t *testing.T) {
 
 func TestServiceInstallArgs(t *testing.T) {
 	configPath := `C:\ProgramData\gorilla\config.yaml`
-	got := serviceInstallArgs(configPath)
+	got := serviceInstallArgs(configPath, "")
 	if len(got) != 3 {
 		t.Fatalf("expected 3 args, got %d: %#v", len(got), got)
 	}
@@ -108,6 +108,18 @@ func TestServiceInstallArgs(t *testing.T) {
 	}
 	if got[2] != "-service" {
 		t.Fatalf("expected final arg -service, got %q", got[2])
+	}
+}
+
+func TestServiceInstallArgsPreservesIntegrationTestIdentity(t *testing.T) {
+	configPath := `C:\ProgramData\gorilla-ui-e2e\config.yaml`
+	got := serviceInstallArgs(configPath, "gorilla-ui-e2e")
+	want := []string{
+		"-c", configPath, "-service",
+		"-integration-test-service-identity", "gorilla-ui-e2e",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %#v, got %#v", want, got)
 	}
 }
 

--- a/pkg/service/manage_windows.go
+++ b/pkg/service/manage_windows.go
@@ -155,7 +155,7 @@ func installWindowsService(m *mgr.Mgr, cfg config.Configuration) error {
 		return fmt.Errorf("failed to resolve executable path: %w", err)
 	}
 	exePath = filepath.Clean(exePath)
-	startArgs := serviceInstallArgs(configPath)
+	startArgs := serviceInstallArgs(configPath, cfg.IntegrationTestServiceIdentity)
 	serviceVerbose(cfg, "install config: exe=%q config=%q args=%q start_type=automatic account=%q", exePath, configPath, startArgs, "LocalSystem")
 
 	if existing, err := m.OpenService(cfg.ServiceName); err == nil {

--- a/pkg/service/manage_windows.go
+++ b/pkg/service/manage_windows.go
@@ -155,7 +155,7 @@ func installWindowsService(m *mgr.Mgr, cfg config.Configuration) error {
 		return fmt.Errorf("failed to resolve executable path: %w", err)
 	}
 	exePath = filepath.Clean(exePath)
-	startArgs := serviceInstallArgs(configPath, cfg.IntegrationTestServiceIdentity)
+	startArgs := serviceInstallArgs(configPath, cfg.E2EIdentity)
 	serviceVerbose(cfg, "install config: exe=%q config=%q args=%q start_type=automatic account=%q", exePath, configPath, startArgs, "LocalSystem")
 
 	if existing, err := m.OpenService(cfg.ServiceName); err == nil {

--- a/utils/manual-test/bootstrap-vm.ps1
+++ b/utils/manual-test/bootstrap-vm.ps1
@@ -62,9 +62,7 @@ manifest: $ManifestValue
 catalogs:
 $yamlCatalogs
 app_data_path: $yamlAppDataPath
-# service_name: gorilla
 # service_interval: 1h
-# service_pipe_name: gorilla-service
 "@
 
     Set-Content -Path $ConfigFilePath -Value $content -Encoding ASCII

--- a/wix/WIX_README.md
+++ b/wix/WIX_README.md
@@ -1,8 +1,10 @@
-# Building an MSI with Wix
-To build an MSI, run `make msi` from the repo root (Windows), or run the included Batch script `make-msi.bat` from the `wix` directory.
-An MSI should be created in the same directory.
+# Building the legacy MSI with WiX
+
+The WiX package is retained for compatibility and development use. `Gorilla.UI.App.msix` is the official Gorilla installer and packages both the WinUI application and Gorilla Windows service.
+
+To build the legacy MSI, run `make msi` from the repo root on Windows, or run the included `make-msi.bat` from the `wix` directory. An MSI should be created in the same directory.
 
 `ProductVersion` is passed to WiX from Makefile (`MSI_VERSION`) via `PRODUCT_VERSION`.
 
 ## Requirements
-* [Wix Toolset](http://wixtoolset.org)
+* [WiX Toolset](http://wixtoolset.org)

--- a/wix/WIX_README.md
+++ b/wix/WIX_README.md
@@ -1,6 +1,6 @@
 # Building the legacy MSI with WiX
 
-The WiX package is retained for compatibility and development use. `Gorilla.UI.App.msix` is the official Gorilla installer and packages both the WinUI application and Gorilla Windows service.
+The WiX package is retained for compatibility and development use. `gorilla-<version>.msix` is the official Gorilla installer and packages both the WinUI application and Gorilla Windows service.
 
 To build the legacy MSI, run `make msi` from the repo root on Windows, or run the included `make-msi.bat` from the `wix` directory. An MSI should be created in the same directory.
 


### PR DESCRIPTION
## Summary

Implements Stage 7 of #171 by composing Gorilla's existing Windows fixture and FlaUI infrastructure into a full installed-product release validation path.

- makes the versioned `gorilla-<version>.msix` the unified official installer by packaging `gorilla.exe` and registering the automatic LocalSystem Gorilla service
- publishes the standalone custom-deployment binary as `gorilla-<version>.exe`; both release assets are self-identifying after download while the internal executable remains `gorilla.exe`
- raises the packaged-product minimum to Windows 10 2004 / build 19041, required for packaged services
- keeps mutable operational configuration at `%ProgramData%\gorilla\config.yaml` while fixing the product identities to service `gorilla` and pipe `gorilla-service`; legacy YAML name overrides are ignored
- retains isolated source E2E coverage through an explicitly test-only service identity seam that is not exposed in YAML or command help
- adds a packaged-app launch mode to the existing FlaUI harness without duplicating critical workflows
- adds `installed-product-integration`, which installs a produced MSIX on a clean disposable Windows host and verifies package/service registration, packaged binary identity, real named-pipe communication, deterministic fixture install/remove behavior, service-unavailable cached startup, and uninstall cleanup
- expands the stable `verify-release` contract to compose released-binary fixture coverage and installed-product validation while preserving source-built `verify-e2e`
- gates both prerelease and stable publication in Build Release: the exact signed, versioned EXE/MSIX artifacts must pass `verify-release` before GitHub Release publication
- keeps Released-Binary Integration for the lightweight PR check and, after merge, manual test-signed installed-product bootstrap validation
- preserves release ordering after a gated failure: only a predecessor that demonstrably failed the pre-publication release gate may be skipped; ordinary out-of-order/build/signing failures still require rerun
- updates contributor/agent documentation to distinguish source-built E2E from installed-release validation and to document the unified MSIX deployment model

## Validation design

`verify-e2e` remains:

> source-built service + unpackaged/source-built UI + deterministic fixtures + critical FlaUI

`verify-release` is now:

> all lower validation + produced standalone binary fixture coverage + produced MSIX installation + packaged LocalSystem service + real named pipe + same deterministic fixtures + same critical FlaUI + uninstall cleanup

The installed-product harness refuses to run if it detects an existing Gorilla MSIX, Gorilla service, production config, or integration data, and cleanup only removes resources created by that harness invocation. Uninstall/service-removal failures fail an otherwise successful validation run.

### Pre-merge limitation

GitHub only enables `workflow_dispatch` after that trigger exists on the default branch, so this PR's manual test-signed installed-product workflow cannot be dispatched before merge. The automatic PR checks validate the lower layers; after merge, Build Release runs `verify-release` against the exact signed artifacts before publication, and the manual test-signed workflow becomes available.

## Release behavior

Release assets are named `gorilla-<version>.exe` and `gorilla-<version>.msix` (for example, `gorilla-2.30.0.exe` and `gorilla-2.30.0.msix`). The MSIX is the official installer; the EXE remains available for custom deployment. The legacy WiX/MSI build remains available as a compatibility/development target but is not treated as an official release artifact.

Closes the Stage 7 scope of #171.