### PR TITLE
Move wiki documentation into repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Run `make help` for the current command summary.
   - `examples/example_catalog.yaml`
   - `examples/example_manifest.yaml`
   - `examples/example_package-info.yaml`
+- Keep user-facing behavior documented under `docs/`; update the relevant page when installation, configuration, manifest, catalog, service, or App Catalog behavior changes.
 - For UI protocol/data shape changes, keep the JSON contract aligned with the YAML model represented in:
   - `examples/example_manifest.yaml`
   - `examples/example_package-info.yaml`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gorilla is intended to provide application management on Windows using [Munki](h
 Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://github.com/chocolatey/choco).
 
 ## Getting Started
-Information related to installing and configuring Gorilla can be found on the [Wiki](https://github.com/1dustindavis/gorilla/wiki).
+See the [Gorilla documentation](docs/README.md) for installation, configuration, catalogs, manifests, the Windows service, and App Catalog.
 For quick manual-test setup helpers on a fresh Windows VM, see [utils/manual-test/README.md](utils/manual-test/README.md).
 
 Releases include `gorilla-<version>.msix` (Windows 10 2004 / build 19041+) and a standalone `gorilla-<version>.exe`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ See the [Gorilla documentation](docs/README.md).
 
 The versioned `gorilla-<version>.msix` is the recommended installation method.
 Config lives at `%ProgramData%\gorilla\config.yaml`.
+A UI for Gorilla called [App Catalog](docs/app-catalog.md) is still in development and is included with the MSIX.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://
 ## Getting Started
 See the [Gorilla documentation](docs/README.md).
 
-The versioned `gorilla-<version>.msix` is the recommended installation method.
-Config lives at `%ProgramData%\gorilla\config.yaml`.
+Download the latest version from the [releases page](https://github.com/1dustindavis/gorilla/releases). MSIX is the recommended installation method.
 
 A UI for Gorilla called [App Catalog](docs/app-catalog.md) is still in development and is included with the MSIX.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Munki-like Application Management for Windows
 
-Gorilla is intended to provide application management on Windows using [Munki](https://github.com/munki/munki) as inspiration.
 Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://github.com/chocolatey/choco).
 
 ## Getting Started
@@ -12,6 +11,7 @@ See the [Gorilla documentation](docs/README.md).
 
 The versioned `gorilla-<version>.msix` is the recommended installation method.
 Config lives at `%ProgramData%\gorilla\config.yaml`.
+
 A UI for Gorilla called [App Catalog](docs/app-catalog.md) is still in development and is included with the MSIX.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Gorilla logo](gorilla.png)
-# Gorilla [![Build status](https://github.com/1dustindavis/gorilla/actions/workflows/go-test.yml/badge.svg?branch=main)](https://github.com/1dustindavis/gorilla/actions/workflows/go-test.yml)
+[![Build status](https://github.com/1dustindavis/gorilla/actions/workflows/go-test.yml/badge.svg?branch=main)](https://github.com/1dustindavis/gorilla/actions/workflows/go-test.yml)
+# Gorilla
 
 Munki-like Application Management for Windows
 
@@ -7,11 +8,10 @@ Gorilla is intended to provide application management on Windows using [Munki](h
 Gorilla supports `.msi`, `.ps1`, `.exe`, or `.nupkg` [(via chocolatey)](https://github.com/chocolatey/choco).
 
 ## Getting Started
-See the [Gorilla documentation](docs/README.md) for installation, configuration, catalogs, manifests, the Windows service, and App Catalog.
-For quick manual-test setup helpers on a fresh Windows VM, see [utils/manual-test/README.md](utils/manual-test/README.md).
+See the [Gorilla documentation](docs/README.md).
 
-Releases include `gorilla-<version>.msix` (Windows 10 2004 / build 19041+) and a standalone `gorilla-<version>.exe`.
-Service configuration lives at `%ProgramData%\gorilla\config.yaml`.
+The versioned `gorilla-<version>.msix` is the recommended installation method.
+Config lives at `%ProgramData%\gorilla\config.yaml`.
 
 ## Building
 
@@ -27,16 +27,11 @@ After cloning this repo, just run `go build -i ./cmd/gorilla`. A new binary will
 
 ## Contributing
 
-Pull requests are welcome. Key validation targets:
+Pull requests are welcome. Validate changes with:
 
 ```text
 make verify
-make verify-windows
-make verify-e2e
-make verify-release GORILLA_RELEASE_EXE=<path> GORILLA_RELEASE_MSIX=<path>
 ```
-
-See `AGENTS.md` and `make help` for details.
 
 ## Repo Admin Mode
 Gorilla also supports local repo admin workflows:

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,9 +14,9 @@ Gorilla manages application installation, updates, and removal on Windows using 
    ```
 
 2. Create `%ProgramData%\gorilla\config.yaml` with at least `url` and `manifest`. See [Client configuration](client-configuration.md).
-3. Install the versioned `gorilla-<version>.msix` from [Gorilla releases](https://github.com/1dustindavis/gorilla/releases).
+3. Install the latest MSIX from [Gorilla releases](https://github.com/1dustindavis/gorilla/releases).
 
-The MSIX requires Windows 10 2004 / build 19041 or newer. It installs App Catalog and registers Gorilla as an automatic `LocalSystem` service. The standalone `gorilla-<version>.exe` remains available for custom deployments.
+The MSIX requires Windows 10 2004 / build 19041 or newer. It installs the App Catalog UI and registers Gorilla as an automatic `LocalSystem` service. The standalone `gorilla-<version>.exe` remains available for custom deployments.
 
 By default, logs are written to `%ProgramData%\gorilla\gorilla.log` and the run report to `%ProgramData%\gorilla\GorillaReport.json`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Gorilla manages application installation, updates, and removal on Windows using 
 2. Create `%ProgramData%\gorilla\config.yaml` with at least `url` and `manifest`. See [Client configuration](client-configuration.md).
 3. Install the latest MSIX from [Gorilla releases](https://github.com/1dustindavis/gorilla/releases).
 
-The MSIX requires Windows 10 2004 / build 19041 or newer. It installs the App Catalog UI and registers Gorilla as an automatic `LocalSystem` service. The standalone `gorilla-<version>.exe` remains available for custom deployments.
+The MSIX requires Windows 10 2004 / build 19041 or newer. It installs the App Catalog UI and registers Gorilla as an automatic `LocalSystem` service. The standalone EXE is available for custom deployments.
 
 By default, logs are written to `%ProgramData%\gorilla\gorilla.log` and the run report to `%ProgramData%\gorilla\GorillaReport.json`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Gorilla documentation
+
+Gorilla manages application installation, updates, and removal on Windows using manifests and catalogs hosted on a web server.
+
+## Getting started
+
+1. Host `manifests/`, `catalogs/`, and `packages/` directories on an HTTPS server:
+
+   ```text
+   web-root/
+   ├── manifests/*.yaml
+   ├── catalogs/*.yaml
+   └── packages/*.{nupkg,msi,exe,ps1,msix}
+   ```
+
+2. Create `%ProgramData%\gorilla\config.yaml` with at least `url` and `manifest`. See [Client configuration](client-configuration.md).
+3. Install the versioned `gorilla-<version>.msix` from [Gorilla releases](https://github.com/1dustindavis/gorilla/releases).
+
+The MSIX requires Windows 10 2004 / build 19041 or newer. It installs App Catalog and registers Gorilla as an automatic `LocalSystem` service. The standalone `gorilla-<version>.exe` remains available for custom deployments.
+
+By default, logs are written to `%ProgramData%\gorilla\gorilla.log` and the run report to `%ProgramData%\gorilla\GorillaReport.json`.
+
+## Reference
+
+- [Client configuration](client-configuration.md)
+- [Windows service](windows-service.md)
+- [Catalogs](catalogs.md)
+- [Manifests](manifests.md)
+- [App Catalog](app-catalog.md)
+- [Repository administration](repo-admin-tools.md)
+- [Installing Chocolatey with Gorilla](installing-chocolatey.md)
+- [Community](community.md)

--- a/docs/app-catalog.md
+++ b/docs/app-catalog.md
@@ -1,0 +1,20 @@
+# App Catalog
+
+![Gorilla App Catalog](https://github.com/user-attachments/assets/5defc532-6d4e-4961-8c90-3b4648e3c650)
+
+App Catalog is Gorilla's pre-release Windows UI for on-demand software actions. It:
+
+- Lists items assigned through `optional_installs`.
+- Installs and removes optional items through the Gorilla service.
+- Streams operation status updates.
+- Loads cached data at startup, then refreshes it from the service.
+
+Install the versioned `gorilla-<version>.msix` from [Gorilla releases](https://github.com/1dustindavis/gorilla/releases):
+
+```powershell
+Add-AppxPackage -Path .\gorilla-2.30.0.msix -ForceUpdateFromAnyVersion
+```
+
+The MSIX installs App Catalog and registers the automatic Gorilla service. App Catalog requires a configured manifest containing `optional_installs` items.
+
+The UI and its protocol remain pre-release and may change.

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -1,0 +1,93 @@
+# Catalogs
+
+A catalog maps unique item names to installation, removal, and status-check metadata. Catalogs are loaded in the order configured; each catalog should contain only one entry for a given item name.
+
+```yaml
+ExampleApp:
+  display_name: Example App
+  version: 1.2.3
+  dependencies:
+    - ExampleDependency
+  check:
+    registry:
+      name: Example App
+      version: 1.2.3
+  installer:
+    type: msi
+    location: packages/example-app-1.2.3.msi
+    hash: <sha256>
+    arguments:
+      - /L=1033
+```
+
+See [the complete example catalog](../examples/example_catalog.yaml).
+
+## Item keys
+
+- `display_name`: Human-readable item name.
+- `version`: Desired application version.
+- `dependencies`: Item names that must be processed first.
+- `check`: One status-check definition.
+- `installer`: Installation metadata.
+- `uninstaller`: Removal metadata for `managed_uninstalls` and optional removals.
+- `preinstall_script`: PowerShell run before installation; a nonzero exit stops the install.
+- `postinstall_script`: PowerShell run after the installation attempt; a nonzero exit is reported as an error.
+
+## Status checks
+
+Gorilla selects the first configured check in this order: `script`, `file`, `registry`, then `appx`.
+
+### File
+
+```yaml
+check:
+  file:
+    - path: C:\Program Files\Example\example.exe
+      version: 1.2.3
+      hash: <sha256>
+```
+
+`path` is required. `version` and `hash` are optional checks against the file's Windows metadata or content. Multiple file entries may be supplied.
+
+### Script
+
+```yaml
+check:
+  script: |
+    if (Test-Path 'C:\Program Files\Example\example.exe') { exit 1 }
+    exit 0
+```
+
+For installs and updates, exit `0` means action is needed and a nonzero exit means no action. Removal uses the inverse interpretation.
+
+### Registry
+
+```yaml
+check:
+  registry:
+    name: Example App
+    version: 1.2.3
+```
+
+`name` is matched against `DisplayName` entries under the Windows uninstall registry keys. `version` is compared with `DisplayVersion`.
+
+### AppX/MSIX
+
+```yaml
+check:
+  appx:
+    name: Example.Package.Name
+    version: 1.2.3.0
+```
+
+`name` is the package `DisplayName` returned by `Get-AppxProvisionedPackage -Online`; `version` is the minimum acceptable version.
+
+## Installer and uninstaller keys
+
+- `type`: `nupkg`, `msi`, `exe`, `ps1`, or `msix`.
+- `location`: Package path relative to `url_packages` or `url`.
+- `hash`: Required SHA-256 of the package.
+- `arguments`: Optional arguments for MSI, EXE, or MSIX installation and EXE removal.
+- `package_id`: Optional Chocolatey package ID for `nupkg`; setting it avoids ambiguous automatic detection.
+
+For MSIX removal, set `uninstaller.type: msix`. No uninstaller `location` or `hash` is needed; Gorilla uses `check.appx.name` to remove the provisioned package and per-user registrations.

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -1,0 +1,37 @@
+# Client configuration
+
+Gorilla reads YAML configuration from `%ProgramData%\gorilla\config.yaml` by default. To use another file:
+
+```powershell
+gorilla.exe -config C:\path\to\config.yaml
+```
+
+## Example
+
+```yaml
+url: https://example.com/gorilla/
+manifest: example
+catalogs:
+  - production
+app_data_path: C:/ProgramData/gorilla
+service_interval: 1h
+```
+
+`url` and `manifest` are required for normal managed runs. Repository URLs must include a trailing slash because Gorilla appends paths such as `manifests/example.yaml`.
+
+## Keys
+
+- `url`: Base URL containing the `manifests/` and `catalogs/` directories. A local repository may use a URL such as `file://C:/example/gorilla/`.
+- `manifest`: Primary manifest assigned to the computer.
+- `catalogs`: Optional ordered list of catalogs. Catalogs may instead be supplied by manifests.
+- `url_packages`: Optional alternate base URL for package downloads. Defaults to `url`.
+- `local_manifests`: Optional list of local manifest paths processed after remote manifests.
+- `app_data_path`: Working directory for cache, logs, reports, and the service manifest. Defaults to `%ProgramData%\gorilla`.
+- `service_interval`: Interval between service runs in Go duration format, such as `30m`, `1h`, or `2h`. Defaults to `1h`.
+- `repo_path`: Local repository root used by [repository administration](repo-admin-tools.md). Defaults to the current directory.
+- `auth_user` and `auth_pass`: Optional HTTP Basic Authentication credentials.
+- `tls_auth`: Enables mutual TLS when `true`.
+- `tls_client_cert`, `tls_client_key`, and `tls_server_cert`: PEM paths used for mutual TLS.
+- `verbose`, `debug`, and `checkonly`: Optional runtime behavior flags.
+
+The Windows service name is `gorilla` and its named pipe is `gorilla-service`. These product identities are fixed rather than YAML settings.

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -33,5 +33,3 @@ service_interval: 1h
 - `tls_auth`: Enables mutual TLS when `true`.
 - `tls_client_cert`, `tls_client_key`, and `tls_server_cert`: PEM paths used for mutual TLS.
 - `verbose`, `debug`, and `checkonly`: Optional runtime behavior flags.
-
-The Windows service name is `gorilla` and its named pipe is `gorilla-service`. These product identities are fixed rather than YAML settings.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,3 @@
+# Community
+
+Gorilla discussion happens in the `#gorilla` channel on the [Mac Admins Slack](https://www.macadmins.org/).

--- a/docs/installing-chocolatey.md
+++ b/docs/installing-chocolatey.md
@@ -1,0 +1,20 @@
+# Installing Chocolatey with Gorilla
+
+Gorilla uses Chocolatey to install and remove `nupkg` items. Chocolatey itself can be bootstrapped as a PowerShell catalog item before any dependent packages:
+
+```yaml
+Chocolatey:
+  display_name: Chocolatey
+  check:
+    file:
+      - path: C:\ProgramData\chocolatey\bin\choco.exe
+  installer:
+    type: ps1
+    location: packages/chocolatey/install.ps1
+    hash: <sha256>
+  version: 1.0
+```
+
+Download the current installation script from [Chocolatey's installation documentation](https://chocolatey.org/install), store it in your repository, and replace `<sha256>` with the hash of that exact file. Other `nupkg` items can then declare `Chocolatey` as a dependency.
+
+Chocolatey extensions can be managed the same way as ordinary `nupkg` items. Use a stable file, version, or hash status check and declare `Chocolatey` as a dependency.

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -1,0 +1,29 @@
+# Manifests
+
+A manifest assigns catalog items to a computer and may include other manifests or catalogs.
+
+```yaml
+name: example
+managed_installs:
+  - GoogleChrome
+managed_uninstalls:
+  - Firefox
+managed_updates:
+  - Jre8
+optional_installs:
+  - VLC
+included_manifests:
+  - printers
+catalogs:
+  - production
+```
+
+- `name`: Manifest name.
+- `managed_installs`: Items installed when missing or older than the catalog version.
+- `managed_uninstalls`: Items removed when installed.
+- `managed_updates`: Items updated only when already installed and older than the catalog version.
+- `optional_installs`: Items exposed for on-demand installation or removal through service commands and App Catalog.
+- `included_manifests`: Additional manifests processed once in discovered order.
+- `catalogs`: Catalogs added after those listed in client configuration.
+
+Remote manifests are loaded from `<url>manifests/<name>.yaml`. Files listed in the configuration's `local_manifests` are processed afterward. See [the example manifest](../examples/example_manifest.yaml).

--- a/docs/repo-admin-tools.md
+++ b/docs/repo-admin-tools.md
@@ -1,0 +1,36 @@
+# Repository administration
+
+Gorilla can compile package metadata into catalogs:
+
+```powershell
+gorilla.exe -build -config C:\path\to\config.yaml
+```
+
+Use a normal client configuration containing `url` and `manifest`, and set `repo_path` to the local Gorilla content repository root. If `repo_path` is omitted, Gorilla uses the current working directory.
+
+```yaml
+repo_path: C:/path/to/gorilla-repo
+```
+
+Each YAML file under `packages-info/` should contain `catalog` and normal catalog-item fields:
+
+```yaml
+item_name: GoogleChrome
+catalog: base
+display_name: Google Chrome
+installer:
+  type: nupkg
+  location: packages/google-chrome/GoogleChrome.nupkg
+  hash: <sha256>
+check:
+  registry:
+    name: Google Chrome
+    version: 1.2.3.4
+version: 1.2.3.4
+```
+
+See [the package-info example](../examples/example_package-info.yaml).
+
+`-build` writes one file per catalog to `<repo_path>/catalogs/<catalog>.yaml`. Item keys are selected from `item_name`, then `display_name` without spaces, then the package-info filename. Entries without `catalog` or any usable item name are skipped.
+
+The `-import <path>` command is reserved but not yet implemented.

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -1,0 +1,51 @@
+# Windows service
+
+The Gorilla service runs managed application processing on a schedule and exposes a named-pipe endpoint for App Catalog and command-line requests.
+
+- Service name: `gorilla`
+- Named pipe: `\\.\pipe\gorilla-service`
+- Account: `LocalSystem` for the packaged service
+- Configuration: `%ProgramData%\gorilla\config.yaml`
+- Local service manifest: `<app_data_path>\service-manifest.yaml`
+- Default interval: `1h`
+
+Set another interval with Go duration syntax:
+
+```yaml
+service_interval: 30m
+```
+
+## Official installation
+
+The versioned `gorilla-<version>.msix` release artifact installs App Catalog and registers the automatic Gorilla service.
+
+## Standalone deployment
+
+The standalone `gorilla-<version>.exe` supports custom service deployment. Run these commands from an elevated PowerShell or Command Prompt:
+
+```powershell
+gorilla.exe -c C:\ProgramData\gorilla\config.yaml -serviceinstall
+gorilla.exe -c C:\ProgramData\gorilla\config.yaml -servicestart
+gorilla.exe -c C:\ProgramData\gorilla\config.yaml -servicestatus
+gorilla.exe -c C:\ProgramData\gorilla\config.yaml -servicestop
+gorilla.exe -c C:\ProgramData\gorilla\config.yaml -serviceremove
+```
+
+Run the service loop in the foreground for troubleshooting:
+
+```powershell
+gorilla.exe -c C:\ProgramData\gorilla\config.yaml -service
+```
+
+## Service commands
+
+Use `-S` or `-servicecmd` to communicate with the running service:
+
+```powershell
+gorilla.exe -S ListOptionalInstalls
+gorilla.exe -S InstallItem:VLC
+gorilla.exe -S RemoveItem:VLC
+gorilla.exe -S StreamOperationStatus:<operationId>
+```
+
+Process logs are written to `<app_data_path>\gorilla.log`, which defaults to `%ProgramData%\gorilla\gorilla.log`.

--- a/wix/config_template.yaml
+++ b/wix/config_template.yaml
@@ -2,7 +2,7 @@
 ##
 ## Gorilla configuration template
 ## Only `url` and `manifest` are required
-## More details at https://github.com/1dustindavis/gorilla/wiki/Client-Configuration
+## More details at https://github.com/1dustindavis/gorilla/blob/main/docs/client-configuration.md
 ##
 
 ## `url` is the path on your server that contains the directories for


### PR DESCRIPTION
## Summary

- moves the maintained wiki subjects into a canonical `docs/` directory
- replaces legacy service guidance with the fixed `gorilla` service and `gorilla-service` pipe behavior shipped by #190
- documents the versioned unified MSIX, standalone EXE, and current App Catalog install/remove behavior
- points the root README and WiX configuration template to the repository documentation
- adds contributor guidance to keep user-facing docs aligned with behavior changes

After this merges, the repository documentation can be treated as the source of truth and the GitHub wiki can be disabled instead of maintained as a second copy.

## Validation

- compared configuration, catalog, manifest, service, and App Catalog claims against the current implementation and examples
- confirmed all local Markdown links resolve
- confirmed no repository documentation still links to the GitHub wiki
- `git diff --check`