### PR TITLE
Keep Go source line endings stable on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+*.go text eol=lf
 pkg/download/testdata/hashtest.txt text eol=lf


### PR DESCRIPTION
## Summary

- keep tracked Go source files LF-normalized on every platform
- prevent Windows checkouts from making `gofmt -l` report the entire Go tree as unformatted
- unblock the pre-publication `make verify-release` gate

## Cause

The release workflow checks out the repository on `windows-latest` and then runs `make verify-release`. With Windows line-ending conversion enabled, all 44 tracked Go files were written as CRLF. Since `gofmt` emits LF, `gofmt -l` reported every file and stopped validation before the installed-product test.

This caused both post-merge release runs to fail:
- [PR #190 release run](https://github.com/1dustindavis/gorilla/actions/runs/33834290117)
- [PR #191 release run](https://github.com/1dustindavis/gorilla/actions/runs/33914961443)

## Validation

- reproduced the current behavior with `core.autocrlf=true`: 44 of 44 tracked Go files contained CRLF
- repeated the Windows-style checkout with this branch's attributes: 0 of 44 Go files contained CRLF
- `git diff --check`

The full Windows and installed-product checks remain delegated to CI.