### PR TITLE
Rebuild unpackaged UI before release validation

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -427,15 +427,27 @@ jobs:
           RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration" `
           INSTALLED_PRODUCT_WORK_ROOT="$env:RUNNER_TEMP\gorilla-installed-product"
 
+    - name: Stage release validation failure diagnostics
+      if: failure()
+      shell: pwsh
+      run: |
+        $diagnostics = "$env:RUNNER_TEMP\release-validation-diagnostics"
+        New-Item -Path $diagnostics -ItemType Directory -Force | Out-Null
+        $gorillaLog = "C:\ProgramData\gorilla-it\cache\gorilla.log"
+        if (Test-Path -LiteralPath $gorillaLog) {
+          Copy-Item -LiteralPath $gorillaLog -Destination $diagnostics -Force
+        }
+
     - name: Upload release validation failure diagnostics
       if: failure()
       uses: actions/upload-artifact@v6
       with:
         name: release-validation-failure-${{ github.run_id }}
         path: |
-          C:\ProgramData\gorilla-it\cache\gorilla.log
+          ${{ runner.temp }}/release-validation-diagnostics
           ${{ runner.temp }}/gorilla-release-integration/fixture/configs
           ${{ runner.temp }}/gorilla-installed-product/installed-product-evidence
+          ${{ github.workspace }}/build/windows-integration/ui-evidence
         if-no-files-found: warn
         retention-days: 90
 

--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -126,14 +126,26 @@ jobs:
             RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration" `
             INSTALLED_PRODUCT_WORK_ROOT="$env:RUNNER_TEMP\gorilla-installed-product"
 
+      - name: Stage integration failure diagnostics
+        if: failure()
+        shell: pwsh
+        run: |
+          $diagnostics = "$env:RUNNER_TEMP\released-binary-integration-diagnostics"
+          New-Item -Path $diagnostics -ItemType Directory -Force | Out-Null
+          $gorillaLog = "C:\ProgramData\gorilla-it\cache\gorilla.log"
+          if (Test-Path -LiteralPath $gorillaLog) {
+            Copy-Item -LiteralPath $gorillaLog -Destination $diagnostics -Force
+          }
+
       - name: Upload integration failure diagnostics
         if: failure()
         uses: actions/upload-artifact@v6
         with:
           name: released-binary-integration-failure-${{ github.run_id }}
           path: |
-            C:\ProgramData\gorilla-it\cache\gorilla.log
+            ${{ runner.temp }}/released-binary-integration-diagnostics
             ${{ runner.temp }}/gorilla-release-integration/fixture/configs
             ${{ runner.temp }}/gorilla-installed-product/installed-product-evidence
+            ${{ github.workspace }}/build/windows-integration/ui-evidence
           if-no-files-found: warn
           retention-days: 90

--- a/.github/workflows/windows-ui-test.yml
+++ b/.github/workflows/windows-ui-test.yml
@@ -82,16 +82,11 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: Run FlaUI Windows UI validation
-        if: steps.changes.outputs.run == 'true'
-        id: ui-e2e
-        shell: pwsh
-        run: make ui-e2e
-
       - name: Build and inspect unsigned packaged product
         if: steps.changes.outputs.run == 'true'
         shell: pwsh
         run: |
+          make build
           dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj `
             -c Release `
             -p:Platform=x64 `
@@ -154,6 +149,12 @@ jobs:
           }
 
           Write-Host "Validated packaged Gorilla service payload and manifest"
+
+      - name: Run FlaUI Windows UI validation
+        if: steps.changes.outputs.run == 'true'
+        id: ui-e2e
+        shell: pwsh
+        run: make ui-e2e
 
       - name: Summarize skipped Windows UI validation
         if: steps.changes.outputs.run != 'true'

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ ui-test: ui-lint
 
 ui-windows-build:
 ifeq ($(OS), Windows_NT)
-	dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj -c Release -p:Platform=x64 -p:WindowsPackageType=None -p:WindowsAppSDKSelfContained=true -p:PublishReadyToRun=false -p:PublishTrimmed=false
+	dotnet build gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj -t:Rebuild -c Release -p:Platform=x64 -p:WindowsPackageType=None -p:GenerateAppxPackageOnBuild=false -p:AppxPackageSigningEnabled=false -p:WindowsAppSDKSelfContained=true -p:PublishReadyToRun=false -p:PublishTrimmed=false
 	dotnet build gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/Gorilla.UI.App.WindowsUiTests.csproj -c Release
 else
 	@echo "ui-windows-build requires Windows"


### PR DESCRIPTION
## Summary

- force a clean unpackaged WinUI rebuild before source FlaUI validation
- make Windows UI CI exercise the same packaged-build → source-E2E order used by release validation
- stage failure diagnostics on the runner's temporary drive before artifact upload

## Cause

The release workflow first builds the MSIX and then `verify-release` builds the same WinUI project as an unpackaged app in the existing `bin`/`obj` trees. The build reported success, but all three source FlaUI tests observed the app launcher exiting immediately. Normal PR UI validation did not catch this because it ran source E2E before building the package.

`ui-windows-build` now uses `Rebuild` and explicitly disables package generation/signing for the unpackaged build. The Windows UI workflow builds and inspects the package first, so CI covers the release ordering that exposed the problem.

The failed release also could not upload diagnostics because `upload-artifact` was given paths on both `C:` and `D:`. Both release workflows now copy the ProgramData log under `RUNNER_TEMP` before upload.

## Validation

- `git diff --check`
- Windows UI CI now reproduces package-first → unpackaged source-E2E sequencing
- full release/product validation remains gated by the automatic post-merge Build Release workflow

Follow-up to the failure in [Build Release run 33916932124](https://github.com/1dustindavis/gorilla/actions/runs/33916932124).