### PR TITLE
Isolate MSIX fixtures across validation layers

### DIFF
--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -108,10 +108,12 @@ jobs:
           "GORILLA_EXE_PATH=$immutableExePath" >> $env:GITHUB_ENV
           "GORILLA_MSIX_PATH=$($msix.FullName)" >> $env:GITHUB_ENV
 
-      - name: Run PR released-binary integration
+      - name: Run PR composed released-binary integration
         if: github.event_name == 'pull_request'
         shell: pwsh
         run: |
+          make windows-integration `
+            WINDOWS_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-source-integration"
           make release-integration `
             GORILLA_RELEASE_EXE="$env:GORILLA_EXE_PATH" `
             RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration"

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ endif
 
 windows-integration: build
 ifeq ($(OS), Windows_NT)
-	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-source-integration.ps1 -WorkRoot "$(WINDOWS_INTEGRATION_WORK_ROOT)" -GorillaExePath "$(CURDIR)/build/gorilla.exe"
+	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-source-integration.ps1 -WorkRoot "$(WINDOWS_INTEGRATION_WORK_ROOT)" -GorillaExePath "$(CURDIR)/build/gorilla.exe" -FixtureNamespace Source
 else
 	@echo "windows-integration requires Windows"
 	@exit 1
@@ -243,9 +243,9 @@ ifeq ($(strip $(GORILLA_RELEASE_EXE)),)
 	@exit 1
 else
 ifeq ($(RELEASE_USE_PREBUILT_FIXTURES),1)
-	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-source-integration.ps1 -WorkRoot "$(RELEASE_INTEGRATION_WORK_ROOT)" -GorillaExePath "$(GORILLA_RELEASE_EXE)" -UsePrebuiltFixtures
+	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-source-integration.ps1 -WorkRoot "$(RELEASE_INTEGRATION_WORK_ROOT)" -GorillaExePath "$(GORILLA_RELEASE_EXE)" -FixtureNamespace Release -UsePrebuiltFixtures
 else
-	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-source-integration.ps1 -WorkRoot "$(RELEASE_INTEGRATION_WORK_ROOT)" -GorillaExePath "$(GORILLA_RELEASE_EXE)"
+	pwsh -NoProfile -ExecutionPolicy Bypass -File integration/windows/run-source-integration.ps1 -WorkRoot "$(RELEASE_INTEGRATION_WORK_ROOT)" -GorillaExePath "$(GORILLA_RELEASE_EXE)" -FixtureNamespace Release
 endif
 endif
 else

--- a/integration/windows/prepare-release-integration.ps1
+++ b/integration/windows/prepare-release-integration.ps1
@@ -1,6 +1,9 @@
 param(
     [string]$WorkRoot = "$env:RUNNER_TEMP\gorilla-release-integration",
-    [string]$MsixCertThumbprint = ""
+    [string]$MsixCertThumbprint = "",
+    [ValidateLength(1, 10)]
+    [ValidatePattern('^[A-Za-z][A-Za-z0-9]*$')]
+    [string]$FixtureNamespace = "Release"
 )
 
 Set-StrictMode -Version Latest
@@ -41,8 +44,8 @@ $exeMarker = Join-Path $markerRoot "exe.txt"
 $msiMarker = Join-Path $markerRoot "msi.txt"
 $nupkgMarker = Join-Path $markerRoot "nupkg.txt"
 $ps1Marker = Join-Path $markerRoot "ps1.txt"
-$msixPackageName = "GorillaIntegrationTest"
-$msixNoUninstallerPackageName = "GorillaIntegrationTestNoUninstaller"
+$msixPackageName = "GorillaIntegrationTest$FixtureNamespace"
+$msixNoUninstallerPackageName = "GorillaIntegrationTest${FixtureNamespace}NoUninstaller"
 
 $msixBuildRoot = Join-Path $fixtureRoot "msix"
 

--- a/integration/windows/run-release-integration.ps1
+++ b/integration/windows/run-release-integration.ps1
@@ -1,7 +1,10 @@
 param(
     [string]$WorkRoot = "$env:RUNNER_TEMP\gorilla-release-integration",
     [Parameter(Mandatory = $true)]
-    [string]$GorillaExePath
+    [string]$GorillaExePath,
+    [ValidateLength(1, 10)]
+    [ValidatePattern('^[A-Za-z][A-Za-z0-9]*$')]
+    [string]$FixtureNamespace = "Release"
 )
 
 Set-StrictMode -Version Latest
@@ -113,7 +116,7 @@ if ($missingPreparedPaths.Count -gt 0) {
     }
 
     Write-Host "[INFO] Missing integration preparation output; running prepare-release-integration.ps1"
-    & $prepareScriptPath -WorkRoot $root
+    & $prepareScriptPath -WorkRoot $root -FixtureNamespace $FixtureNamespace
     if ($LASTEXITCODE -ne 0) {
         throw "prepare-release-integration.ps1 failed with exit code $LASTEXITCODE"
     }
@@ -129,8 +132,8 @@ $exeMarker = Join-Path $markerRoot "exe.txt"
 $msiMarker = Join-Path $markerRoot "msi.txt"
 $nupkgMarker = Join-Path $markerRoot "nupkg.txt"
 $ps1Marker = Join-Path $markerRoot "ps1.txt"
-$msixPackageName = "GorillaIntegrationTest"
-$msixNoUninstallerPackageName = "GorillaIntegrationTestNoUninstaller"
+$msixPackageName = "GorillaIntegrationTest$FixtureNamespace"
+$msixNoUninstallerPackageName = "GorillaIntegrationTest${FixtureNamespace}NoUninstaller"
 
 Write-Host "::group::[TEST] Environment setup"
 Remove-Item -LiteralPath $markerRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/integration/windows/run-source-integration.ps1
+++ b/integration/windows/run-source-integration.ps1
@@ -1,6 +1,9 @@
 param(
     [string]$WorkRoot = "$env:TEMP\gorilla-source-integration",
     [string]$GorillaExePath = "",
+    [ValidateLength(1, 10)]
+    [ValidatePattern('^[A-Za-z][A-Za-z0-9]*$')]
+    [string]$FixtureNamespace = "Release",
     [switch]$UsePrebuiltFixtures
 )
 
@@ -78,9 +81,11 @@ if ($useValidPrebuiltFixtures) {
 
     & (Join-Path $PSScriptRoot "prepare-release-integration.ps1") `
         -WorkRoot $WorkRoot `
-        -MsixCertThumbprint $thumbprint
+        -MsixCertThumbprint $thumbprint `
+        -FixtureNamespace $FixtureNamespace
 }
 
 & (Join-Path $PSScriptRoot "run-release-integration.ps1") `
     -WorkRoot $WorkRoot `
-    -GorillaExePath $GorillaExePath
+    -GorillaExePath $GorillaExePath `
+    -FixtureNamespace $FixtureNamespace


### PR DESCRIPTION
## Summary

- give source and released-binary MSIX fixtures distinct package identities
- carry the fixture namespace through preparation, execution, and assertions
- make PR released-binary CI run source integration immediately before release integration

## Cause

`verify-release` composes source Windows integration and released-binary integration on one runner. Both layers previously used `GorillaIntegrationTest`, but independently generated and signed their fixtures. The source layer installed v1, upgraded to v2, and deprovisioned it; Windows retained enough deployment state that the released-binary layer could not install a newly signed v1 package with the same identity. Its independently named no-uninstaller fixture still installed successfully.

Source fixtures now use `GorillaIntegrationTestSource...`; released-binary fixtures use `GorillaIntegrationTestRelease...`. This preserves identical install/update/uninstall behavior without sharing Windows-global package state.

The PR workflow now runs those layers sequentially, matching the composition that exposed the failure.

## Validation

- `git diff --check`
- CI exercises source integration followed by released-binary integration on the same Windows runner
- full signed installed-product validation remains the automatic post-merge release gate

Follow-up to [Build Release run 33926814056](https://github.com/1dustindavis/gorilla/actions/runs/33926814056).