### PR TITLE
Clean released-binary integration data before installed-product validation

### DIFF
--- a/.github/workflows/windows-release-integration.yml
+++ b/.github/workflows/windows-release-integration.yml
@@ -118,6 +118,15 @@ jobs:
             GORILLA_RELEASE_EXE="$env:GORILLA_EXE_PATH" `
             RELEASE_INTEGRATION_WORK_ROOT="$env:RUNNER_TEMP\gorilla-release-integration"
 
+      - name: Verify released-binary integration cleanup
+        if: github.event_name == 'pull_request'
+        shell: pwsh
+        run: |
+          $integrationData = "C:\ProgramData\gorilla-it"
+          if (Test-Path -LiteralPath $integrationData) {
+            throw "Released-binary integration left test data behind: $integrationData"
+          }
+
       - name: Run manual installed-product validation
         if: github.event_name == 'workflow_dispatch'
         shell: pwsh

--- a/integration/windows/run-release-integration.ps1
+++ b/integration/windows/run-release-integration.ps1
@@ -201,6 +201,15 @@ try {
     Assert-Missing -Path $ps1Marker
     Assert-AppxMissing -Name $msixPackageName
     Assert-AppxMissing -Name $msixNoUninstallerPackageName
+
+    # This harness owns the marker root: it removes any prior contents and
+    # recreates the directory during environment setup. Remove it after a
+    # successful run so the next validation layer sees a clean machine. Keep
+    # it on failure so the workflow can upload Gorilla's logs as diagnostics.
+    Remove-Item -LiteralPath $markerRoot -Recurse -Force -ErrorAction Stop
+    Assert-Missing -Path $markerRoot
+    Write-Host "[INFO] Removed integration data directory: $markerRoot"
+
     $results += "[PASS] Uninstall"
 
     Write-Host "========== Integration Test Summary =========="


### PR DESCRIPTION
## Summary

- remove the released-binary integration data directory after a successful validation run
- preserve the directory on failure so workflow diagnostics remain available
- assert the cleanup in the PR composed integration workflow

## Why

Post-merge release run [#33928176741](https://github.com/1dustindavis/gorilla/actions/runs/33928176741) completed source and released-binary validation, then the installed-product guard correctly refused to overwrite the leftover `C:\ProgramData\gorilla-it` directory. The released-binary harness creates and owns that directory, so it should remove it after success before the installed-product layer starts.

## Validation

- `git diff --check`
- Windows integration and composed released-binary integration PR checks

Local `make verify` is unavailable in the current Linux workspace because Go and PowerShell are not installed.