### PR TITLE
Make release MSIX self-contained

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
+++ b/gorilla-ui/src/Gorilla.UI.App/Gorilla.UI.App.csproj
@@ -10,6 +10,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <Nullable>enable</Nullable>
     <GorillaSourceBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\build\gorilla.exe</GorillaSourceBuildExecutable>
     <GorillaReleaseBuildExecutable>$(MSBuildThisFileDirectory)..\..\..\cmd\gorilla\gorilla.exe</GorillaReleaseBuildExecutable>
@@ -33,6 +34,10 @@
 
   <Target Name="RequireGorillaServiceExecutableForMsix" BeforeTargets="_GenerateAppxPackageFile" Condition="'$(GenerateAppxPackageOnBuild)' == 'true' and !Exists('$(GorillaServiceExecutable)')">
     <Error Text="Gorilla service executable was not found. Build gorilla.exe before producing the MSIX or set GorillaServiceExecutable." />
+  </Target>
+
+  <Target Name="RequireSelfContainedWindowsAppSdkForMsix" BeforeTargets="_GenerateAppxPackageFile" Condition="'$(GenerateAppxPackageOnBuild)' == 'true'">
+    <Error Condition="'$(WindowsAppSDKSelfContained)' != 'true'" Text="Gorilla MSIX packages must include the Windows App SDK runtime. Keep WindowsAppSDKSelfContained=true so installation does not require a separately provisioned Windows App Runtime package." />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- make the Gorilla WinUI app use self-contained Windows App SDK deployment for packaged builds
- fail MSIX packaging if `WindowsAppSDKSelfContained` is overridden away from `true`

## Why
Post-merge release validation now installs the exact signed MSIX on a clean GitHub-hosted Windows runner. The current package is framework-dependent, so installation fails when Windows App Runtime 1.8 is not already provisioned. Microsoft documents `WindowsAppSDKSelfContained=true` as the supported way to include the Windows App SDK dependencies inside a packaged app.

Keeping this setting in the app project makes PR packaging and release packaging share the same deployment model instead of relying on a release-workflow-only flag. The MSBuild assertion protects that contract from accidental command-line or project-level overrides.

## Validation goal
The existing release installed-product gate remains the end-to-end proof: the exact signed MSIX must install and run successfully on the clean release runner without separately provisioning Windows App Runtime 1.8.