### PR TITLE
Expose gorilla.exe as an MSIX execution alias

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest
+++ b/gorilla-ui/src/Gorilla.UI.App/Package.appxmanifest
@@ -4,9 +4,11 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap desktop6 rescap">
+  IgnorableNamespaces="uap uap3 desktop desktop6 rescap">
 
   <Identity
     Name="133b2116-358b-42fb-8bc8-35009cc5d5af"
@@ -44,6 +46,14 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
+        <uap3:Extension
+          Category="windows.appExecutionAlias"
+          Executable="gorilla.exe"
+          EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="gorilla.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
         <desktop6:Extension
           Category="windows.service"
           Executable="gorilla.exe"

--- a/integration/windows/run-installed-product-integration.ps1
+++ b/integration/windows/run-installed-product-integration.ps1
@@ -13,6 +13,7 @@ $prepareScript = Join-Path $PSScriptRoot "prepare-release-integration.ps1"
 $uiTestScript = Join-Path $repoRoot "gorilla-ui\tests\Gorilla.UI.App.WindowsUiTests\run-tests.ps1"
 $packageIdentityName = "133b2116-358b-42fb-8bc8-35009cc5d5af"
 $serviceName = "gorilla"
+$executionAlias = "gorilla.exe"
 $root = [System.IO.Path]::GetFullPath($WorkRoot)
 $msixPath = [System.IO.Path]::GetFullPath($GorillaMsixPath)
 if (-not (Test-Path -LiteralPath $msixPath)) {
@@ -54,6 +55,21 @@ function Wait-ServiceState {
 
     $actual = (Get-Service -Name $serviceName -ErrorAction SilentlyContinue)?.Status
     throw "Timed out waiting for service '$serviceName' state '$Expected'. Actual: $actual"
+}
+
+function Wait-ExecutionAlias {
+    param([int]$TimeoutSeconds = 30)
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $command = Get-Command $executionAlias -CommandType Application -ErrorAction SilentlyContinue
+        if ($command) {
+            return $command
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Installing the Gorilla MSIX did not expose the expected execution alias '$executionAlias'"
 }
 
 function Remove-TestPackage {
@@ -237,9 +253,11 @@ debug: true
     }
     Wait-ServiceState -Expected "Running"
 
-    & $installedGorilla -config $configPath -servicecmd ListOptionalInstalls | Out-Host
+    $aliasCommand = Wait-ExecutionAlias
+    Write-Host "[INFO] Using installed Gorilla execution alias: $($aliasCommand.Source)"
+    & $executionAlias -config $configPath -servicecmd ListOptionalInstalls | Out-Host
     if ($LASTEXITCODE -ne 0) {
-        throw "Packaged gorilla.exe could not communicate with the installed Gorilla service over the real named pipe"
+        throw "Packaged gorilla.exe execution alias could not communicate with the installed Gorilla service over the real named pipe"
     }
 
     $appUserModelId = "$($installedPackage.PackageFamilyName)!App"

--- a/integration/windows/run-installed-product-integration.ps1
+++ b/integration/windows/run-installed-product-integration.ps1
@@ -14,6 +14,7 @@ $uiTestScript = Join-Path $repoRoot "gorilla-ui\tests\Gorilla.UI.App.WindowsUiTe
 $packageIdentityName = "133b2116-358b-42fb-8bc8-35009cc5d5af"
 $serviceName = "gorilla"
 $executionAlias = "gorilla.exe"
+$executionAliasPath = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\$executionAlias"
 $root = [System.IO.Path]::GetFullPath($WorkRoot)
 $msixPath = [System.IO.Path]::GetFullPath($GorillaMsixPath)
 if (-not (Test-Path -LiteralPath $msixPath)) {
@@ -60,16 +61,24 @@ function Wait-ServiceState {
 function Wait-ExecutionAlias {
     param([int]$TimeoutSeconds = 30)
 
+    $expectedPath = [System.IO.Path]::GetFullPath($executionAliasPath)
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {
         $command = Get-Command $executionAlias -CommandType Application -ErrorAction SilentlyContinue
         if ($command) {
-            return $command
+            $resolvedPath = [System.IO.Path]::GetFullPath($command.Source)
+            if ($resolvedPath -ieq $expectedPath) {
+                return $resolvedPath
+            }
         }
         Start-Sleep -Milliseconds 250
     } while ((Get-Date) -lt $deadline)
 
-    throw "Installing the Gorilla MSIX did not expose the expected execution alias '$executionAlias'"
+    $resolved = Get-Command $executionAlias -CommandType Application -ErrorAction SilentlyContinue
+    if ($resolved) {
+        throw "Expected Gorilla MSIX execution alias at '$expectedPath', but '$executionAlias' resolves to '$($resolved.Source)'"
+    }
+    throw "Installing the Gorilla MSIX did not expose the expected execution alias at '$expectedPath'"
 }
 
 function Remove-TestPackage {
@@ -253,9 +262,9 @@ debug: true
     }
     Wait-ServiceState -Expected "Running"
 
-    $aliasCommand = Wait-ExecutionAlias
-    Write-Host "[INFO] Using installed Gorilla execution alias: $($aliasCommand.Source)"
-    & $executionAlias -config $configPath -servicecmd ListOptionalInstalls | Out-Host
+    $aliasPath = Wait-ExecutionAlias
+    Write-Host "[INFO] Using installed Gorilla execution alias: $aliasPath"
+    & $aliasPath -config $configPath -servicecmd ListOptionalInstalls | Out-Host
     if ($LASTEXITCODE -ne 0) {
         throw "Packaged gorilla.exe execution alias could not communicate with the installed Gorilla service over the real named pipe"
     }


### PR DESCRIPTION
## Summary
- register `gorilla.exe` as a Windows app execution alias in the MSIX manifest
- update installed-product validation to invoke Gorilla through the registered alias instead of directly from the protected `WindowsApps` package directory
- wait briefly for alias registration after MSIX installation before exercising the real service named pipe

## Why
The Stage 7 release gate now installs the exact signed, self-contained MSIX successfully. It then fails because the harness directly executes `gorilla.exe` from `C:\Program Files\WindowsApps\...`, which Windows denies.

An app execution alias is the supported production-facing way to expose a packaged CLI executable. Microsoft documents `windows.appExecutionAlias` with `desktop:ExecutionAlias` for launching a packaged executable from a command prompt. This makes `gorilla.exe` a stable interface for administrators and automation instead of relying on a versioned protected install path.

## Validation
The existing package build still verifies that the MSIX contains the same `gorilla.exe` as the standalone release artifact and that the packaged service points to that executable. Stage 7 now additionally requires Windows to expose the `gorilla.exe` execution alias and uses that alias for the real named-pipe service command.

The definitive end-to-end proof remains the post-merge release gate: install the exact Azure-signed MSIX on a clean runner, invoke `gorilla.exe` through the alias, validate the installed service/UI, and only then publish the prerelease.