### PR TITLE
Fix Windows service shutdown

### DIFF
--- a/pkg/service/run_windows.go
+++ b/pkg/service/run_windows.go
@@ -497,7 +497,7 @@ func (sr *serviceRunner) writeSuccessEnvelope(file *os.File, req serviceEnvelope
 			RequestID:    req.RequestID,
 			OperationID:  "",
 			TimestampUTC: nowRFC3339UTC(),
-			Payload: listOptionalInstallsResponse{Items: items},
+			Payload:      listOptionalInstallsResponse{Items: items},
 		}); err != nil {
 			return err
 		}

--- a/pkg/service/run_windows.go
+++ b/pkg/service/run_windows.go
@@ -222,8 +222,9 @@ func (sr *serviceRunner) serveNamedPipe(ctx context.Context) error {
 
 		err = windows.ConnectNamedPipe(handle, nil)
 		if err != nil && !errors.Is(err, windows.ERROR_PIPE_CONNECTED) {
-			windows.CloseHandle(handle)
-			sr.clearListenerPipe(handle)
+			if sr.takeListenerPipe(handle) {
+				_ = windows.CloseHandle(handle)
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -233,7 +234,15 @@ func (sr *serviceRunner) serveNamedPipe(ctx context.Context) error {
 			return fmt.Errorf("connect pipe: %w", err)
 		}
 
-		sr.clearListenerPipe(handle)
+		// A successfully connected pipe stops being the listener and is handed to
+		// either the request handler or the shutdown path. If shutdown already took
+		// the registered listener handle, it also owns closing that raw handle.
+		if !sr.takeListenerPipe(handle) {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return errors.New("named pipe listener handle ownership was lost unexpectedly")
+		}
 		if ctx.Err() != nil {
 			_ = windows.CloseHandle(handle)
 			return ctx.Err()
@@ -488,7 +497,7 @@ func (sr *serviceRunner) writeSuccessEnvelope(file *os.File, req serviceEnvelope
 			RequestID:    req.RequestID,
 			OperationID:  "",
 			TimestampUTC: nowRFC3339UTC(),
-			Payload:      listOptionalInstallsResponse{Items: items},
+			Payload: listOptionalInstallsResponse{Items: items},
 		}); err != nil {
 			return err
 		}
@@ -692,12 +701,24 @@ func (sr *serviceRunner) unblockListenerPipe() {
 	_ = conn.Close()
 }
 
-func (sr *serviceRunner) closeListenerPipe() {
+func (sr *serviceRunner) takeListenerPipe(handle windows.Handle) bool {
 	sr.pipeListenerMu.Lock()
 	defer sr.pipeListenerMu.Unlock()
-	if sr.pipeListenerHandle != 0 && sr.pipeListenerHandle != windows.InvalidHandle {
-		_ = windows.CloseHandle(sr.pipeListenerHandle)
-		sr.pipeListenerHandle = 0
+	if sr.pipeListenerHandle != handle {
+		return false
+	}
+	sr.pipeListenerHandle = 0
+	return true
+}
+
+func (sr *serviceRunner) closeListenerPipe() {
+	sr.pipeListenerMu.Lock()
+	handle := sr.pipeListenerHandle
+	sr.pipeListenerHandle = 0
+	sr.pipeListenerMu.Unlock()
+
+	if handle != 0 && handle != windows.InvalidHandle {
+		_ = windows.CloseHandle(handle)
 	}
 }
 
@@ -718,14 +739,6 @@ func (sr *serviceRunner) closeActiveConnections() {
 	defer sr.activeConnMu.Unlock()
 	for handle := range sr.activeConns {
 		_ = windows.CloseHandle(handle)
-	}
-}
-
-func (sr *serviceRunner) clearListenerPipe(handle windows.Handle) {
-	sr.pipeListenerMu.Lock()
-	defer sr.pipeListenerMu.Unlock()
-	if sr.pipeListenerHandle == handle {
-		sr.pipeListenerHandle = 0
 	}
 }
 

--- a/pkg/service/run_windows.go
+++ b/pkg/service/run_windows.go
@@ -146,11 +146,26 @@ func (sr *serviceRunner) executeCommandSafe(cmd Command) (resp CommandResponse, 
 }
 
 func (sr *serviceRunner) stop(ctx context.Context) {
+	// Connect a short-lived client before closing the listener. ConnectNamedPipe is
+	// synchronous, so closing the server handle from another goroutine does not
+	// reliably wake an idle listener. A client connection releases the blocked
+	// accept so the serve loop can observe ctx cancellation and exit.
+	sr.unblockListenerPipe()
 	sr.closeListenerPipe()
 	sr.closeActiveConnections()
-	sr.wg.Wait()
-	gorillalog.Close()
-	_ = ctx
+
+	done := make(chan struct{})
+	go func() {
+		sr.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		gorillalog.Close()
+	case <-ctx.Done():
+		gorillalog.Warn("service runner shutdown timed out:", ctx.Err())
+	}
 }
 
 func (sr *serviceRunner) submit(ctx context.Context, cmd Command) (CommandResponse, error) {
@@ -219,6 +234,10 @@ func (sr *serviceRunner) serveNamedPipe(ctx context.Context) error {
 		}
 
 		sr.clearListenerPipe(handle)
+		if ctx.Err() != nil {
+			_ = windows.CloseHandle(handle)
+			return ctx.Err()
+		}
 		select {
 		case sr.handlerSem <- struct{}{}:
 			sr.trackActiveConnection(handle)
@@ -663,6 +682,14 @@ func createNamedPipe(pipePath string) (windows.Handle, error) {
 		0,
 		&sa,
 	)
+}
+
+func (sr *serviceRunner) unblockListenerPipe() {
+	conn, err := openPipe(servicePipePath(sr.cfg.ServicePipeName), 250*time.Millisecond)
+	if err != nil {
+		return
+	}
+	_ = conn.Close()
 }
 
 func (sr *serviceRunner) closeListenerPipe() {

--- a/pkg/service/shutdown_windows_test.go
+++ b/pkg/service/shutdown_windows_test.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/1dustindavis/gorilla/pkg/config"
+	"golang.org/x/sys/windows"
+)
+
+func TestServiceRunnerStopUnblocksIdleNamedPipeListener(t *testing.T) {
+	cfg := config.Configuration{
+		AppDataPath:     t.TempDir(),
+		ServicePipeName: fmt.Sprintf("gorilla-stop-test-%d", time.Now().UnixNano()),
+		ServiceInterval: "1h",
+		ServiceMode:     true,
+		ServiceName:     "gorilla-stop-test",
+	}
+
+	sr := newServiceRunner(cfg, func(config.Configuration) error { return nil })
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := sr.start(ctx); err != nil {
+		t.Fatalf("service start failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		sr.pipeListenerMu.Lock()
+		handle := sr.pipeListenerHandle
+		sr.pipeListenerMu.Unlock()
+		if handle != 0 && handle != windows.InvalidHandle {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("service did not enter idle named-pipe accept state")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer stopCancel()
+
+	started := time.Now()
+	sr.stop(stopCtx)
+	elapsed := time.Since(started)
+
+	if stopCtx.Err() != nil {
+		t.Fatalf("service shutdown hit its context deadline instead of unblocking the idle pipe listener: %v", stopCtx.Err())
+	}
+	if elapsed >= 2*time.Second {
+		t.Fatalf("service shutdown took %v; expected idle pipe listener to unblock promptly", elapsed)
+	}
+}

--- a/pkg/service/shutdown_windows_test.go
+++ b/pkg/service/shutdown_windows_test.go
@@ -48,14 +48,14 @@ func TestServiceRunnerStopUnblocksIdleNamedPipeListener(t *testing.T) {
 
 			cancel()
 			stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer stopCancel()
 
 			started := time.Now()
 			sr.stop(stopCtx)
 			elapsed := time.Since(started)
-			stopCancel()
 
-			if stopCtx.Err() != context.Canceled {
-				t.Fatalf("expected completed shutdown context to be canceled after cleanup, got %v", stopCtx.Err())
+			if stopCtx.Err() != nil {
+				t.Fatalf("service shutdown hit its context deadline instead of unblocking the idle pipe listener: %v", stopCtx.Err())
 			}
 			if elapsed >= 2*time.Second {
 				t.Fatalf("service shutdown took %v; expected idle pipe listener to unblock promptly", elapsed)

--- a/pkg/service/shutdown_windows_test.go
+++ b/pkg/service/shutdown_windows_test.go
@@ -13,47 +13,76 @@ import (
 )
 
 func TestServiceRunnerStopUnblocksIdleNamedPipeListener(t *testing.T) {
-	cfg := config.Configuration{
-		AppDataPath:     t.TempDir(),
-		ServicePipeName: fmt.Sprintf("gorilla-stop-test-%d", time.Now().UnixNano()),
-		ServiceInterval: "1h",
-		ServiceMode:     true,
-		ServiceName:     "gorilla-stop-test",
-	}
+	const iterations = 10
 
-	sr := newServiceRunner(cfg, func(config.Configuration) error { return nil })
-	ctx, cancel := context.WithCancel(context.Background())
-	if err := sr.start(ctx); err != nil {
-		t.Fatalf("service start failed: %v", err)
-	}
+	for i := 0; i < iterations; i++ {
+		t.Run(fmt.Sprintf("iteration-%d", i), func(t *testing.T) {
+			cfg := config.Configuration{
+				AppDataPath:     t.TempDir(),
+				ServicePipeName: fmt.Sprintf("gorilla-stop-test-%d-%d", time.Now().UnixNano(), i),
+				ServiceInterval: "1h",
+				ServiceMode:     true,
+				ServiceName:     "gorilla-stop-test",
+			}
 
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		sr.pipeListenerMu.Lock()
-		handle := sr.pipeListenerHandle
-		sr.pipeListenerMu.Unlock()
-		if handle != 0 && handle != windows.InvalidHandle {
-			break
-		}
-		if time.Now().After(deadline) {
+			sr := newServiceRunner(cfg, func(config.Configuration) error { return nil })
+			ctx, cancel := context.WithCancel(context.Background())
+			if err := sr.start(ctx); err != nil {
+				t.Fatalf("service start failed: %v", err)
+			}
+
+			deadline := time.Now().Add(2 * time.Second)
+			for {
+				sr.pipeListenerMu.Lock()
+				handle := sr.pipeListenerHandle
+				sr.pipeListenerMu.Unlock()
+				if handle != 0 && handle != windows.InvalidHandle {
+					break
+				}
+				if time.Now().After(deadline) {
+					cancel()
+					t.Fatal("service did not enter idle named-pipe accept state")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
 			cancel()
-			t.Fatal("service did not enter idle named-pipe accept state")
-		}
-		time.Sleep(10 * time.Millisecond)
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
+
+			started := time.Now()
+			sr.stop(stopCtx)
+			elapsed := time.Since(started)
+			stopCancel()
+
+			if stopCtx.Err() != context.Canceled {
+				t.Fatalf("expected completed shutdown context to be canceled after cleanup, got %v", stopCtx.Err())
+			}
+			if elapsed >= 2*time.Second {
+				t.Fatalf("service shutdown took %v; expected idle pipe listener to unblock promptly", elapsed)
+			}
+
+			sr.pipeListenerMu.Lock()
+			remainingHandle := sr.pipeListenerHandle
+			sr.pipeListenerMu.Unlock()
+			if remainingHandle != 0 {
+				t.Fatalf("listener handle remained registered after shutdown: %v", remainingHandle)
+			}
+		})
 	}
+}
 
-	cancel()
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer stopCancel()
+func TestTakeListenerPipeTransfersOwnershipOnce(t *testing.T) {
+	sr := newServiceRunner(config.Configuration{}, func(config.Configuration) error { return nil })
+	handle := windows.Handle(1234)
+	sr.pipeListenerHandle = handle
 
-	started := time.Now()
-	sr.stop(stopCtx)
-	elapsed := time.Since(started)
-
-	if stopCtx.Err() != nil {
-		t.Fatalf("service shutdown hit its context deadline instead of unblocking the idle pipe listener: %v", stopCtx.Err())
+	if !sr.takeListenerPipe(handle) {
+		t.Fatal("expected first takeListenerPipe call to take ownership")
 	}
-	if elapsed >= 2*time.Second {
-		t.Fatalf("service shutdown took %v; expected idle pipe listener to unblock promptly", elapsed)
+	if sr.takeListenerPipe(handle) {
+		t.Fatal("expected listener ownership to be transferable only once")
+	}
+	if sr.pipeListenerHandle != 0 {
+		t.Fatalf("listener handle was not cleared after ownership transfer: %v", sr.pipeListenerHandle)
 	}
 }


### PR DESCRIPTION
## Summary
- unblock the synchronous named-pipe accept during service shutdown so the service runner can observe cancellation and exit
- avoid dispatching the synthetic unblock connection into a normal pipe handler once shutdown has begun
- make listener-handle ownership explicit so shutdown and the listener cannot both close the same raw Windows handle
- make `serviceRunner.stop` honor its shutdown context instead of waiting indefinitely
- add Windows regression coverage that repeatedly exercises idle-listener shutdown and verifies listener ownership transfers only once

## Why
Stage 7 installed-product validation consistently reaches `STOP_PENDING` after SCM accepts the stop request, then remains there until the harness timeout. Investigation traced the block to the idle synchronous `ConnectNamedPipe` call: cancellation alone cannot wake it, and the existing reliability tests already worked around the same behavior by opening a temporary client connection before teardown.

This moves that unblock behavior into production shutdown and keeps the existing 10-second service shutdown bound meaningful.

A follow-up review identified a raw-handle ownership race between `closeListenerPipe()` and the listener goroutine after the synthetic unblock connection succeeds. The implementation now atomically transfers ownership under `pipeListenerMu`; whichever path takes the registered handle owns closing it, and the other path will not close the stale value.

## Validation
The regression test exercises the exact idle-listener shutdown path that previously required `bestEffortUnblockPipeListener` in tests, repeats it to exercise shutdown timing, and separately asserts that listener ownership can be transferred only once. The definitive end-to-end validation remains the manual Released-Binary Integration / installed-product Stage 7 run against this branch.