### PR TITLE
Improve deterministic Go installer testability

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -19,10 +19,12 @@ import (
 )
 
 var (
+	// Base command for each installer type
 	commandNupkg = filepath.Join(os.Getenv("ProgramData"), "chocolatey/bin/choco.exe")
 	commandMsi   = filepath.Join(os.Getenv("WINDIR"), "system32/", "msiexec.exe")
 	commandPs1   = filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
 
+	// These abstractions allows us to override when testing
 	execCommand       = exec.Command
 	statusCheckStatus = status.CheckStatus
 	runCommand        = runCMD
@@ -30,6 +32,7 @@ var (
 
 type commandRunner func(command string, arguments []string) (string, error)
 
+// runCommand executes a command and it's argurments in the CMD environment
 func runCMD(command string, arguments []string) (string, error) {
 	cmd := execCommand(command, arguments...)
 	var cmdOutput []string
@@ -71,13 +74,18 @@ func runCMD(command string, arguments []string) (string, error) {
 	return strings.Join(cmdOutput, "\n"), err
 }
 
+// Get a Nupkg's id using `choco list`
 func getNupkgIDs(nupkgDir, versionArg string) ([]string, error) {
 	return getNupkgIDsWithRunner(nupkgDir, versionArg, runCommand)
 }
 
 func getNupkgIDsWithRunner(nupkgDir, versionArg string, runner commandRunner) ([]string, error) {
+
+	// Compile the arguments needed to get the id
 	command := commandNupkg
 	arguments := []string{"list", versionArg, "--id-only", "-r", "-s", nupkgDir}
+
+	// Run the command and parse each non-empty line as a candidate id
 	cmdOut, cmdErr := runner(command, arguments)
 	outputLines := strings.Split(cmdOut, "\n")
 	ids := make([]string, 0, len(outputLines))
@@ -120,10 +128,13 @@ func installItem(item catalog.Item, itemURL, cachePath string) string {
 }
 
 func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner commandRunner) string {
+
+	// Determine the paths needed for download and install
 	relPath, fileName := path.Split(item.Installer.Location)
 	absPath := filepath.Join(cachePath, relPath)
 	absFile := filepath.Join(absPath, fileName)
 
+	// Download the item if it is needed
 	valid := download.IfNeeded(absFile, itemURL, item.Installer.Hash)
 	if !valid {
 		msg := fmt.Sprint("Unable to download valid file: ", itemURL)
@@ -131,11 +142,16 @@ func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner 
 		return msg
 	}
 
+	// Determine the install type and command to pass
 	var installCmd string
 	var installArgs []string
 	if item.Installer.Type == "nupkg" {
+		// choco wants the "id" and parent dir when we install, so we need to determine both
 		gorillalog.Info("Determining nupkg id for", item.DisplayName)
 		nupkgDir := filepath.Dir(absFile)
+
+		// Since choco recommends the source is a directory,
+		// we need to pass a version to filter unexpected nupkgs (if we have a version)
 		var versionArg string
 		if item.Version != "" {
 			versionArg = fmt.Sprintf("--version=%s", item.Version)
@@ -146,11 +162,15 @@ func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner 
 			gorillalog.Warn(msg)
 			return msg
 		}
+
+		// Now pass the id along with the parent directory
 		gorillalog.Info("Installing nupkg for", item.DisplayName)
 		installCmd = commandNupkg
 		if nupkgID != "" && versionArg != "" {
+			// Only use this form if we have an ID and version number
 			installArgs = []string{"install", nupkgID, "-s", nupkgDir, versionArg, "-f", "-y", "-r"}
 		} else {
+			// If we dont have an id and version, fallback to the method choco doesn't recommend (but works)
 			installArgs = []string{"install", absFile, "-f", "-y", "-r"}
 		}
 	} else if item.Installer.Type == "msi" {
@@ -180,13 +200,18 @@ func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner 
 		return msg
 	}
 
+	// Run the command
 	installerOut, errOut := runner(installCmd, installArgs)
+	// Write success/failure event to log
 	if errOut != nil {
 		gorillalog.Warn(item.DisplayName, item.Version, "Installation FAILED")
 	} else {
 		gorillalog.Info(item.DisplayName, item.Version, "Installation SUCCESSFUL")
 	}
+
+	// Add the item to InstalledItems in GorillaReport
 	report.InstalledItems = append(report.InstalledItems, item)
+
 	return installerOut
 }
 
@@ -195,6 +220,8 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 }
 
 func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runner commandRunner) string {
+
+	// msix uninstall only needs the package name, no file download required
 	if item.Uninstaller.Type == "msix" || (item.Uninstaller.Type == "" && item.Installer.Type == "msix") {
 		gorillalog.Info("Uninstalling msix for", item.DisplayName)
 		if item.Check.Appx.Name == "" {
@@ -208,6 +235,7 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 		)
 		uninstallCmd := commandPs1
 		uninstallArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", removeCmd}
+		// Run the command
 		uninstallerOut, errOut := runner(uninstallCmd, uninstallArgs)
 		if errOut != nil {
 			gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
@@ -218,9 +246,12 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 		return uninstallerOut
 	}
 
+	// Determine the paths needed for download and uinstall
 	relPath, fileName := path.Split(item.Uninstaller.Location)
 	absPath := filepath.Join(cachePath, relPath)
 	absFile := filepath.Join(absPath, fileName)
+
+	// Download the item if it is needed
 	valid := download.IfNeeded(absFile, itemURL, item.Uninstaller.Hash)
 	if !valid {
 		msg := fmt.Sprint("Unable to download valid file: ", itemURL)
@@ -228,11 +259,16 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 		return msg
 	}
 
+	// Determine the uninstall type and build the command
 	var uninstallCmd string
 	var uninstallArgs []string
 	if item.Uninstaller.Type == "nupkg" {
+		// choco wants the "id" and parent dir when we uninstall, so we need to determine both
 		gorillalog.Info("Determining nupkg id for", item.DisplayName)
 		nupkgDir := filepath.Dir(absFile)
+
+		// Since choco recommends the source is a directory,
+		// we need to pass a version to filter unexpected nupkgs (if we have a version)
 		var versionArg string
 		if item.Version != "" {
 			versionArg = fmt.Sprintf("--version=%s", item.Version)
@@ -243,11 +279,15 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 			gorillalog.Warn(msg)
 			return msg
 		}
+
+		// Now pass the id along with the parent directory
 		gorillalog.Info("Uninstalling nupkg for", item.DisplayName)
 		uninstallCmd = commandNupkg
 		if nupkgID != "" && versionArg != "" {
+			// Only use this form if we have an ID and version number
 			uninstallArgs = []string{"uninstall", nupkgID, "-s", nupkgDir, versionArg, "-f", "-y", "-r"}
 		} else {
+			// If we dont have an id and version, fallback to the method choco doesn't recommend (but works)
 			uninstallArgs = []string{"uninstall", absFile, "-f", "-y", "-r"}
 		}
 	} else if item.Uninstaller.Type == "msi" {
@@ -268,13 +308,18 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 		return msg
 	}
 
+	// Run the command
 	uninstallerOut, errOut := runner(uninstallCmd, uninstallArgs)
+	// Write success/failure event to log
 	if errOut != nil {
 		gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
 	} else {
 		gorillalog.Info(item.DisplayName, item.Version, "Uninstallation SUCCESSFUL")
 	}
+
+	// Add the item to InstalledItems in GorillaReport
 	report.UninstalledItems = append(report.UninstalledItems, item)
+
 	return uninstallerOut
 }
 
@@ -282,12 +327,18 @@ func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded 
 	if err := os.MkdirAll(cachePath, 0755); err != nil {
 		return false, err
 	}
+
+	// Write InstallCheckScript to disk as a Powershell file
 	tmpScript := filepath.Join(cachePath, "tmpPostScript.ps1")
 	if err := os.WriteFile(tmpScript, []byte(catalogItem.PreScript), 0755); err != nil {
 		return false, err
 	}
+
+	// Build the command to execute the script
 	psCmd := filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
 	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
+
+	// Execute the script
 	cmd := execCommand(psCmd, psArgs...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -295,9 +346,13 @@ func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded 
 	err := cmd.Run()
 	cmdSuccess := cmd.ProcessState.Success()
 	outStr, errStr := stdout.String(), stderr.String()
+
+	// Delete the temporary script
 	if err := os.Remove(tmpScript); err != nil && !os.IsNotExist(err) {
 		gorillalog.Warn("Unable to remove temporary preinstall script:", tmpScript, err)
 	}
+
+	// Log results
 	gorillalog.Debug("Command Error:", err)
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
@@ -308,12 +363,18 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 	if err := os.MkdirAll(cachePath, 0755); err != nil {
 		return false, err
 	}
+
+	// Write InstallCheckScript to disk as a Powershell file
 	tmpScript := filepath.Join(cachePath, "tmpPostScript.ps1")
 	if err := os.WriteFile(tmpScript, []byte(catalogItem.PostScript), 0755); err != nil {
 		return false, err
 	}
+
+	// Build the command to execute the script
 	psCmd := filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
 	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
+
+	// Execute the script
 	cmd := execCommand(psCmd, psArgs...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -321,9 +382,13 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 	err := cmd.Run()
 	cmdSuccess := cmd.ProcessState.Success()
 	outStr, errStr := stdout.String(), stderr.String()
+
+	// Delete the temporary script
 	if err := os.Remove(tmpScript); err != nil && !os.IsNotExist(err) {
 		gorillalog.Warn("Unable to remove temporary postinstall script:", tmpScript, err)
 	}
+
+	// Log results
 	gorillalog.Debug("Command Error:", err)
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
@@ -331,28 +396,39 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 }
 
 var (
+	// By putting the functions in a variable, we can override later in tests
 	installItemFunc   = installItem
 	uninstallItemFunc = uninstallItem
 )
 
+// Install determines if action needs to be taken on a item and then
+// calls the appropriate function to install or uninstall
 func Install(item catalog.Item, installerType, urlPackages, cachePath string, checkOnly bool) string {
+	// Check the status and determine if any action is needed for this item
 	actionNeeded, err := statusCheckStatus(item, installerType, cachePath)
 	if err != nil {
 		msg := fmt.Sprint("Unable to check status: ", err)
 		gorillalog.Warn(msg)
 		return msg
 	}
+
+	// If no action is needed, return
 	if !actionNeeded {
 		return "Item not needed"
 	}
 
+	// Install or uninstall the item
 	if installerType == "install" || installerType == "update" {
+		// Check if checkonly mode is enabled
 		if checkOnly {
 			report.InstalledItems = append(report.InstalledItems, item)
 			gorillalog.Info("[CHECK ONLY] Skipping actions for", item.DisplayName)
+			// Check only mode doesn't perform any action, return
 			return "Check only enabled"
 		}
+		// Compile the item's URL
 		itemURL := urlPackages + item.Installer.Location
+		// Run PreInstall_Script if needed
 		if item.PreScript != "" {
 			gorillalog.Info("Running Pre-Install script for", item.DisplayName)
 			preScriptSuccess, err := preinstallScript(item, cachePath)
@@ -361,7 +437,9 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string, ch
 				return "PreInstall-Script error"
 			}
 		}
+		// Run the installer
 		installItemFunc(item, itemURL, cachePath)
+		// Run PostInstall_Script if needed
 		if item.PostScript != "" {
 			gorillalog.Info("Running Post-Install script for", item.DisplayName)
 			postScriptSuccess, err := postinstallScript(item, cachePath)
@@ -374,9 +452,12 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string, ch
 		if checkOnly {
 			report.InstalledItems = append(report.InstalledItems, item)
 			gorillalog.Info("[CHECK ONLY] Skipping actions for", item.DisplayName)
+			// Check only mode doesn't perform any action, return
 			return "Check only enabled"
 		}
+		// Compile the item's URL
 		itemURL := urlPackages + item.Uninstaller.Location
+		// Run the installer
 		uninstallItemFunc(item, itemURL, cachePath)
 	} else {
 		gorillalog.Warn("Unsupported item type", item.DisplayName, installerType)

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -19,18 +19,17 @@ import (
 )
 
 var (
-	// Base command for each installer type
 	commandNupkg = filepath.Join(os.Getenv("ProgramData"), "chocolatey/bin/choco.exe")
 	commandMsi   = filepath.Join(os.Getenv("WINDIR"), "system32/", "msiexec.exe")
 	commandPs1   = filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
 
-	// These abstractions allows us to override when testing
 	execCommand       = exec.Command
 	statusCheckStatus = status.CheckStatus
 	runCommand        = runCMD
 )
 
-// runCommand executes a command and it's argurments in the CMD environment
+type commandRunner func(command string, arguments []string) (string, error)
+
 func runCMD(command string, arguments []string) (string, error) {
 	cmd := execCommand(command, arguments...)
 	var cmdOutput []string
@@ -72,62 +71,59 @@ func runCMD(command string, arguments []string) (string, error) {
 	return strings.Join(cmdOutput, "\n"), err
 }
 
-// Get a Nupkg's id using `choco list`
 func getNupkgIDs(nupkgDir, versionArg string) ([]string, error) {
+	return getNupkgIDsWithRunner(nupkgDir, versionArg, runCommand)
+}
 
-	// Compile the arguments needed to get the id
+func getNupkgIDsWithRunner(nupkgDir, versionArg string, runner commandRunner) ([]string, error) {
 	command := commandNupkg
 	arguments := []string{"list", versionArg, "--id-only", "-r", "-s", nupkgDir}
-
-	// Run the command and parse each non-empty line as a candidate id
-	cmdOut, cmdErr := runCommand(command, arguments)
+	cmdOut, cmdErr := runner(command, arguments)
 	outputLines := strings.Split(cmdOut, "\n")
 	ids := make([]string, 0, len(outputLines))
 	for _, line := range outputLines {
 		candidate := strings.TrimSpace(line)
-		if candidate == "" {
-			continue
+		if candidate != "" {
+			ids = append(ids, candidate)
 		}
-		ids = append(ids, candidate)
 	}
-
 	return ids, cmdErr
 }
 
 func resolveNupkgID(itemName, nupkgDir, versionArg, packageID string) (string, error) {
+	return resolveNupkgIDWithRunner(itemName, nupkgDir, versionArg, packageID, runCommand)
+}
+
+func resolveNupkgIDWithRunner(itemName, nupkgDir, versionArg, packageID string, runner commandRunner) (string, error) {
 	explicitID := strings.TrimSpace(packageID)
 	if explicitID != "" {
 		return explicitID, nil
 	}
-
 	if versionArg == "" {
 		return "", nil
 	}
-
-	ids, cmdErr := getNupkgIDs(nupkgDir, versionArg)
+	ids, cmdErr := getNupkgIDsWithRunner(nupkgDir, versionArg, runner)
 	if cmdErr != nil {
 		return "", cmdErr
 	}
-
 	if len(ids) == 0 {
 		return "", fmt.Errorf("no package id was found for %s; set installer/uninstaller.package_id", itemName)
 	}
-
 	if len(ids) > 1 {
 		return "", fmt.Errorf("multiple package ids were found for %s: %s; set installer/uninstaller.package_id", itemName, strings.Join(ids, ", "))
 	}
-
 	return ids[0], nil
 }
 
 func installItem(item catalog.Item, itemURL, cachePath string) string {
+	return installItemWithRunner(item, itemURL, cachePath, runCommand)
+}
 
-	// Determine the paths needed for download and install
+func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner commandRunner) string {
 	relPath, fileName := path.Split(item.Installer.Location)
 	absPath := filepath.Join(cachePath, relPath)
 	absFile := filepath.Join(absPath, fileName)
 
-	// Download the item if it is needed
 	valid := download.IfNeeded(absFile, itemURL, item.Installer.Hash)
 	if !valid {
 		msg := fmt.Sprint("Unable to download valid file: ", itemURL)
@@ -135,56 +131,41 @@ func installItem(item catalog.Item, itemURL, cachePath string) string {
 		return msg
 	}
 
-	// Determine the install type and command to pass
 	var installCmd string
 	var installArgs []string
 	if item.Installer.Type == "nupkg" {
-		// choco wants the "id" and parent dir when we install, so we need to determine both
 		gorillalog.Info("Determining nupkg id for", item.DisplayName)
 		nupkgDir := filepath.Dir(absFile)
-
-		// Since choco recommends the source is a directory,
-		// we need to pass a version to filter unexpected nupkgs (if we have a version)
 		var versionArg string
-		var nupkgID string
 		if item.Version != "" {
 			versionArg = fmt.Sprintf("--version=%s", item.Version)
 		}
-
-		nupkgID, err := resolveNupkgID(item.DisplayName, nupkgDir, versionArg, item.Installer.PackageID)
+		nupkgID, err := resolveNupkgIDWithRunner(item.DisplayName, nupkgDir, versionArg, item.Installer.PackageID, runner)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to determine nupkg id for %s: %v", item.DisplayName, err)
 			gorillalog.Warn(msg)
 			return msg
 		}
-
-		// Now pass the id along with the parent directory
 		gorillalog.Info("Installing nupkg for", item.DisplayName)
 		installCmd = commandNupkg
 		if nupkgID != "" && versionArg != "" {
-			// Only use this form if we have an ID and version number
 			installArgs = []string{"install", nupkgID, "-s", nupkgDir, versionArg, "-f", "-y", "-r"}
 		} else {
-			// If we dont have an id and version, fallback to the method choco doesn't recommend (but works)
 			installArgs = []string{"install", absFile, "-f", "-y", "-r"}
 		}
-
 	} else if item.Installer.Type == "msi" {
 		gorillalog.Info("Installing msi for", item.DisplayName)
 		installCmd = commandMsi
 		installArgs = []string{"/i", absFile, "/qn", "/norestart"}
 		installArgs = append(installArgs, item.Installer.Arguments...)
-
 	} else if item.Installer.Type == "exe" {
 		gorillalog.Info("Installing exe for", item.DisplayName)
 		installCmd = absFile
 		installArgs = item.Installer.Arguments
-
 	} else if item.Installer.Type == "ps1" {
 		gorillalog.Info("Installing ps1 for", item.DisplayName)
 		installCmd = commandPs1
 		installArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", absFile}
-
 	} else if item.Installer.Type == "msix" {
 		gorillalog.Info("Installing msix for", item.DisplayName)
 		installCmd = commandPs1
@@ -193,32 +174,27 @@ func installItem(item catalog.Item, itemURL, cachePath string) string {
 			psCommand += " " + strings.Join(item.Installer.Arguments, " ")
 		}
 		installArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", psCommand}
-
 	} else {
 		msg := fmt.Sprint("Unsupported installer type", item.Installer.Type)
 		gorillalog.Warn(msg)
 		return msg
 	}
 
-	// Run the command
-	installerOut, errOut := runCommand(installCmd, installArgs)
-
-	// Write success/failure event to log
+	installerOut, errOut := runner(installCmd, installArgs)
 	if errOut != nil {
 		gorillalog.Warn(item.DisplayName, item.Version, "Installation FAILED")
 	} else {
 		gorillalog.Info(item.DisplayName, item.Version, "Installation SUCCESSFUL")
 	}
-
-	// Add the item to InstalledItems in GorillaReport
 	report.InstalledItems = append(report.InstalledItems, item)
-
 	return installerOut
 }
 
 func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
+	return uninstallItemWithRunner(item, itemURL, cachePath, runCommand)
+}
 
-	// msix uninstall only needs the package name, no file download required
+func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runner commandRunner) string {
 	if item.Uninstaller.Type == "msix" || (item.Uninstaller.Type == "" && item.Installer.Type == "msix") {
 		gorillalog.Info("Uninstalling msix for", item.DisplayName)
 		if item.Check.Appx.Name == "" {
@@ -232,7 +208,7 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 		)
 		uninstallCmd := commandPs1
 		uninstallArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", removeCmd}
-		uninstallerOut, errOut := runCommand(uninstallCmd, uninstallArgs)
+		uninstallerOut, errOut := runner(uninstallCmd, uninstallArgs)
 		if errOut != nil {
 			gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
 		} else {
@@ -242,12 +218,9 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 		return uninstallerOut
 	}
 
-	// Determine the paths needed for download and uinstall
 	relPath, fileName := path.Split(item.Uninstaller.Location)
 	absPath := filepath.Join(cachePath, relPath)
 	absFile := filepath.Join(absPath, fileName)
-
-	// Download the item if it is needed
 	valid := download.IfNeeded(absFile, itemURL, item.Uninstaller.Hash)
 	if !valid {
 		msg := fmt.Sprint("Unable to download valid file: ", itemURL)
@@ -255,75 +228,53 @@ func uninstallItem(item catalog.Item, itemURL, cachePath string) string {
 		return msg
 	}
 
-	// Determine the uninstall type and build the command
 	var uninstallCmd string
 	var uninstallArgs []string
-
 	if item.Uninstaller.Type == "nupkg" {
-		// choco wants the "id" and parent dir when we uninstall, so we need to determine both
 		gorillalog.Info("Determining nupkg id for", item.DisplayName)
 		nupkgDir := filepath.Dir(absFile)
-
-		// Since choco recommends the source is a directory,
-		// we need to pass a version to filter unexpected nupkgs (if we have a version)
 		var versionArg string
-		var nupkgID string
 		if item.Version != "" {
 			versionArg = fmt.Sprintf("--version=%s", item.Version)
 		}
-
-		nupkgID, err := resolveNupkgID(item.DisplayName, nupkgDir, versionArg, item.Uninstaller.PackageID)
+		nupkgID, err := resolveNupkgIDWithRunner(item.DisplayName, nupkgDir, versionArg, item.Uninstaller.PackageID, runner)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to determine nupkg id for %s: %v", item.DisplayName, err)
 			gorillalog.Warn(msg)
 			return msg
 		}
-
-		// Now pass the id along with the parent directory
 		gorillalog.Info("Uninstalling nupkg for", item.DisplayName)
 		uninstallCmd = commandNupkg
 		if nupkgID != "" && versionArg != "" {
-			// Only use this form if we have an ID and version number
 			uninstallArgs = []string{"uninstall", nupkgID, "-s", nupkgDir, versionArg, "-f", "-y", "-r"}
 		} else {
-			// If we dont have an id and version, fallback to the method choco doesn't recommend (but works)
 			uninstallArgs = []string{"uninstall", absFile, "-f", "-y", "-r"}
 		}
-
 	} else if item.Uninstaller.Type == "msi" {
 		gorillalog.Info("Uninstalling msi for", item.DisplayName)
 		uninstallCmd = commandMsi
 		uninstallArgs = []string{"/x", absFile, "/qn", "/norestart"}
-
 	} else if item.Uninstaller.Type == "exe" {
 		gorillalog.Info("Uninstalling exe for", item.DisplayName)
 		uninstallCmd = absFile
 		uninstallArgs = item.Uninstaller.Arguments
-
 	} else if item.Uninstaller.Type == "ps1" {
 		gorillalog.Info("Uninstalling ps1 for", item.DisplayName)
 		uninstallCmd = commandPs1
 		uninstallArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", absFile}
-
 	} else {
 		msg := fmt.Sprint("Unsupported uninstaller type", item.Uninstaller.Type)
 		gorillalog.Warn(msg)
 		return msg
 	}
 
-	// Run the command
-	uninstallerOut, errOut := runCommand(uninstallCmd, uninstallArgs)
-
-	// Write success/failure event to log
+	uninstallerOut, errOut := runner(uninstallCmd, uninstallArgs)
 	if errOut != nil {
 		gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
 	} else {
 		gorillalog.Info(item.DisplayName, item.Version, "Uninstallation SUCCESSFUL")
 	}
-
-	// Add the item to InstalledItems in GorillaReport
 	report.UninstalledItems = append(report.UninstalledItems, item)
-
 	return uninstallerOut
 }
 
@@ -331,18 +282,12 @@ func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded 
 	if err := os.MkdirAll(cachePath, 0755); err != nil {
 		return false, err
 	}
-
-	// Write InstallCheckScript to disk as a Powershell file
 	tmpScript := filepath.Join(cachePath, "tmpPostScript.ps1")
 	if err := os.WriteFile(tmpScript, []byte(catalogItem.PreScript), 0755); err != nil {
 		return false, err
 	}
-
-	// Build the command to execute the script
 	psCmd := filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
 	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
-
-	// Execute the script
 	cmd := execCommand(psCmd, psArgs...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -350,17 +295,12 @@ func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded 
 	err := cmd.Run()
 	cmdSuccess := cmd.ProcessState.Success()
 	outStr, errStr := stdout.String(), stderr.String()
-
-	// Delete the temporary script
 	if err := os.Remove(tmpScript); err != nil && !os.IsNotExist(err) {
 		gorillalog.Warn("Unable to remove temporary preinstall script:", tmpScript, err)
 	}
-
-	// Log results
 	gorillalog.Debug("Command Error:", err)
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
-
 	return cmdSuccess, err
 }
 
@@ -368,18 +308,12 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 	if err := os.MkdirAll(cachePath, 0755); err != nil {
 		return false, err
 	}
-
-	// Write InstallCheckScript to disk as a Powershell file
 	tmpScript := filepath.Join(cachePath, "tmpPostScript.ps1")
 	if err := os.WriteFile(tmpScript, []byte(catalogItem.PostScript), 0755); err != nil {
 		return false, err
 	}
-
-	// Build the command to execute the script
 	psCmd := filepath.Join(os.Getenv("WINDIR"), "system32/", "WindowsPowershell", "v1.0", "powershell.exe")
 	psArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", tmpScript}
-
-	// Execute the script
 	cmd := execCommand(psCmd, psArgs...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -387,93 +321,66 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 	err := cmd.Run()
 	cmdSuccess := cmd.ProcessState.Success()
 	outStr, errStr := stdout.String(), stderr.String()
-
-	// Delete the temporary script
 	if err := os.Remove(tmpScript); err != nil && !os.IsNotExist(err) {
 		gorillalog.Warn("Unable to remove temporary postinstall script:", tmpScript, err)
 	}
-
-	// Log results
 	gorillalog.Debug("Command Error:", err)
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
-
 	return cmdSuccess, err
 }
 
 var (
-	// By putting the functions in a variable, we can override later in tests
 	installItemFunc   = installItem
 	uninstallItemFunc = uninstallItem
 )
 
-// Install determines if action needs to be taken on a item and then
-// calls the appropriate function to install or uninstall
 func Install(item catalog.Item, installerType, urlPackages, cachePath string, checkOnly bool) string {
-	// Check the status and determine if any action is needed for this item
 	actionNeeded, err := statusCheckStatus(item, installerType, cachePath)
 	if err != nil {
 		msg := fmt.Sprint("Unable to check status: ", err)
 		gorillalog.Warn(msg)
 		return msg
 	}
-
-	// If no action is needed, return
 	if !actionNeeded {
 		return "Item not needed"
 	}
 
-	// Install or uninstall the item
 	if installerType == "install" || installerType == "update" {
-		// Check if checkonly mode is enabled
 		if checkOnly {
 			report.InstalledItems = append(report.InstalledItems, item)
 			gorillalog.Info("[CHECK ONLY] Skipping actions for", item.DisplayName)
-			// Check only mode doesn't perform any action, return
 			return "Check only enabled"
-		} else {
-			// Compile the item's URL
-			itemURL := urlPackages + item.Installer.Location
-			// Run PreInstall_Script if needed
-			if item.PreScript != "" {
-				gorillalog.Info("Running Pre-Install script for", item.DisplayName)
-				preScriptSuccess, err := preinstallScript(item, cachePath)
-				if !preScriptSuccess {
-					gorillalog.Error("Pre-Install script error:", err)
-					return "PreInstall-Script error"
-				}
+		}
+		itemURL := urlPackages + item.Installer.Location
+		if item.PreScript != "" {
+			gorillalog.Info("Running Pre-Install script for", item.DisplayName)
+			preScriptSuccess, err := preinstallScript(item, cachePath)
+			if !preScriptSuccess {
+				gorillalog.Error("Pre-Install script error:", err)
+				return "PreInstall-Script error"
 			}
-
-			// Run the installer
-			installItemFunc(item, itemURL, cachePath)
-
-			// Run PostInstall_Script if needed
-			if item.PostScript != "" {
-				gorillalog.Info("Running Post-Install script for", item.DisplayName)
-				postScriptSuccess, err := postinstallScript(item, cachePath)
-				if !postScriptSuccess {
-					gorillalog.Error("Post-Install script error:", err)
-					return "PostInstall-Script error"
-				}
+		}
+		installItemFunc(item, itemURL, cachePath)
+		if item.PostScript != "" {
+			gorillalog.Info("Running Post-Install script for", item.DisplayName)
+			postScriptSuccess, err := postinstallScript(item, cachePath)
+			if !postScriptSuccess {
+				gorillalog.Error("Post-Install script error:", err)
+				return "PostInstall-Script error"
 			}
 		}
 	} else if installerType == "uninstall" {
 		if checkOnly {
 			report.InstalledItems = append(report.InstalledItems, item)
 			gorillalog.Info("[CHECK ONLY] Skipping actions for", item.DisplayName)
-			// Check only mode doesn't perform any action, return
 			return "Check only enabled"
-		} else {
-			// Compile the item's URL
-			itemURL := urlPackages + item.Uninstaller.Location
-			// Run the installer
-			uninstallItemFunc(item, itemURL, cachePath)
 		}
+		itemURL := urlPackages + item.Uninstaller.Location
+		uninstallItemFunc(item, itemURL, cachePath)
 	} else {
 		gorillalog.Warn("Unsupported item type", item.DisplayName, installerType)
 		return "Unsupported item type"
-
 	}
-
 	return ""
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -91,10 +91,12 @@ func getNupkgIDsWithRunner(nupkgDir, versionArg string, runner commandRunner) ([
 	ids := make([]string, 0, len(outputLines))
 	for _, line := range outputLines {
 		candidate := strings.TrimSpace(line)
-		if candidate != "" {
-			ids = append(ids, candidate)
+		if candidate == "" {
+			continue
 		}
+		ids = append(ids, candidate)
 	}
+
 	return ids, cmdErr
 }
 
@@ -107,19 +109,24 @@ func resolveNupkgIDWithRunner(itemName, nupkgDir, versionArg, packageID string, 
 	if explicitID != "" {
 		return explicitID, nil
 	}
+
 	if versionArg == "" {
 		return "", nil
 	}
+
 	ids, cmdErr := getNupkgIDsWithRunner(nupkgDir, versionArg, runner)
 	if cmdErr != nil {
 		return "", cmdErr
 	}
+
 	if len(ids) == 0 {
 		return "", fmt.Errorf("no package id was found for %s; set installer/uninstaller.package_id", itemName)
 	}
+
 	if len(ids) > 1 {
 		return "", fmt.Errorf("multiple package ids were found for %s: %s; set installer/uninstaller.package_id", itemName, strings.Join(ids, ", "))
 	}
+
 	return ids[0], nil
 }
 
@@ -153,9 +160,11 @@ func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner 
 		// Since choco recommends the source is a directory,
 		// we need to pass a version to filter unexpected nupkgs (if we have a version)
 		var versionArg string
+		var nupkgID string
 		if item.Version != "" {
 			versionArg = fmt.Sprintf("--version=%s", item.Version)
 		}
+
 		nupkgID, err := resolveNupkgIDWithRunner(item.DisplayName, nupkgDir, versionArg, item.Installer.PackageID, runner)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to determine nupkg id for %s: %v", item.DisplayName, err)
@@ -173,19 +182,23 @@ func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner 
 			// If we dont have an id and version, fallback to the method choco doesn't recommend (but works)
 			installArgs = []string{"install", absFile, "-f", "-y", "-r"}
 		}
+
 	} else if item.Installer.Type == "msi" {
 		gorillalog.Info("Installing msi for", item.DisplayName)
 		installCmd = commandMsi
 		installArgs = []string{"/i", absFile, "/qn", "/norestart"}
 		installArgs = append(installArgs, item.Installer.Arguments...)
+
 	} else if item.Installer.Type == "exe" {
 		gorillalog.Info("Installing exe for", item.DisplayName)
 		installCmd = absFile
 		installArgs = item.Installer.Arguments
+
 	} else if item.Installer.Type == "ps1" {
 		gorillalog.Info("Installing ps1 for", item.DisplayName)
 		installCmd = commandPs1
 		installArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", absFile}
+
 	} else if item.Installer.Type == "msix" {
 		gorillalog.Info("Installing msix for", item.DisplayName)
 		installCmd = commandPs1
@@ -194,6 +207,7 @@ func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner 
 			psCommand += " " + strings.Join(item.Installer.Arguments, " ")
 		}
 		installArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", psCommand}
+
 	} else {
 		msg := fmt.Sprint("Unsupported installer type", item.Installer.Type)
 		gorillalog.Warn(msg)
@@ -202,6 +216,7 @@ func installItemWithRunner(item catalog.Item, itemURL, cachePath string, runner 
 
 	// Run the command
 	installerOut, errOut := runner(installCmd, installArgs)
+
 	// Write success/failure event to log
 	if errOut != nil {
 		gorillalog.Warn(item.DisplayName, item.Version, "Installation FAILED")
@@ -235,7 +250,6 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 		)
 		uninstallCmd := commandPs1
 		uninstallArgs := []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", removeCmd}
-		// Run the command
 		uninstallerOut, errOut := runner(uninstallCmd, uninstallArgs)
 		if errOut != nil {
 			gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
@@ -262,6 +276,7 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 	// Determine the uninstall type and build the command
 	var uninstallCmd string
 	var uninstallArgs []string
+
 	if item.Uninstaller.Type == "nupkg" {
 		// choco wants the "id" and parent dir when we uninstall, so we need to determine both
 		gorillalog.Info("Determining nupkg id for", item.DisplayName)
@@ -270,9 +285,11 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 		// Since choco recommends the source is a directory,
 		// we need to pass a version to filter unexpected nupkgs (if we have a version)
 		var versionArg string
+		var nupkgID string
 		if item.Version != "" {
 			versionArg = fmt.Sprintf("--version=%s", item.Version)
 		}
+
 		nupkgID, err := resolveNupkgIDWithRunner(item.DisplayName, nupkgDir, versionArg, item.Uninstaller.PackageID, runner)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to determine nupkg id for %s: %v", item.DisplayName, err)
@@ -290,18 +307,22 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 			// If we dont have an id and version, fallback to the method choco doesn't recommend (but works)
 			uninstallArgs = []string{"uninstall", absFile, "-f", "-y", "-r"}
 		}
+
 	} else if item.Uninstaller.Type == "msi" {
 		gorillalog.Info("Uninstalling msi for", item.DisplayName)
 		uninstallCmd = commandMsi
 		uninstallArgs = []string{"/x", absFile, "/qn", "/norestart"}
+
 	} else if item.Uninstaller.Type == "exe" {
 		gorillalog.Info("Uninstalling exe for", item.DisplayName)
 		uninstallCmd = absFile
 		uninstallArgs = item.Uninstaller.Arguments
+
 	} else if item.Uninstaller.Type == "ps1" {
 		gorillalog.Info("Uninstalling ps1 for", item.DisplayName)
 		uninstallCmd = commandPs1
 		uninstallArgs = []string{"-NoProfile", "-NoLogo", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", absFile}
+
 	} else {
 		msg := fmt.Sprint("Unsupported uninstaller type", item.Uninstaller.Type)
 		gorillalog.Warn(msg)
@@ -310,6 +331,7 @@ func uninstallItemWithRunner(item catalog.Item, itemURL, cachePath string, runne
 
 	// Run the command
 	uninstallerOut, errOut := runner(uninstallCmd, uninstallArgs)
+
 	// Write success/failure event to log
 	if errOut != nil {
 		gorillalog.Warn(item.DisplayName, item.Version, "Uninstallation FAILED")
@@ -356,6 +378,7 @@ func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded 
 	gorillalog.Debug("Command Error:", err)
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
+
 	return cmdSuccess, err
 }
 
@@ -392,6 +415,7 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 	gorillalog.Debug("Command Error:", err)
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
+
 	return cmdSuccess, err
 }
 
@@ -425,27 +449,30 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string, ch
 			gorillalog.Info("[CHECK ONLY] Skipping actions for", item.DisplayName)
 			// Check only mode doesn't perform any action, return
 			return "Check only enabled"
-		}
-		// Compile the item's URL
-		itemURL := urlPackages + item.Installer.Location
-		// Run PreInstall_Script if needed
-		if item.PreScript != "" {
-			gorillalog.Info("Running Pre-Install script for", item.DisplayName)
-			preScriptSuccess, err := preinstallScript(item, cachePath)
-			if !preScriptSuccess {
-				gorillalog.Error("Pre-Install script error:", err)
-				return "PreInstall-Script error"
+		} else {
+			// Compile the item's URL
+			itemURL := urlPackages + item.Installer.Location
+			// Run PreInstall_Script if needed
+			if item.PreScript != "" {
+				gorillalog.Info("Running Pre-Install script for", item.DisplayName)
+				preScriptSuccess, err := preinstallScript(item, cachePath)
+				if !preScriptSuccess {
+					gorillalog.Error("Pre-Install script error:", err)
+					return "PreInstall-Script error"
+				}
 			}
-		}
-		// Run the installer
-		installItemFunc(item, itemURL, cachePath)
-		// Run PostInstall_Script if needed
-		if item.PostScript != "" {
-			gorillalog.Info("Running Post-Install script for", item.DisplayName)
-			postScriptSuccess, err := postinstallScript(item, cachePath)
-			if !postScriptSuccess {
-				gorillalog.Error("Post-Install script error:", err)
-				return "PostInstall-Script error"
+
+			// Run the installer
+			installItemFunc(item, itemURL, cachePath)
+
+			// Run PostInstall_Script if needed
+			if item.PostScript != "" {
+				gorillalog.Info("Running Post-Install script for", item.DisplayName)
+				postScriptSuccess, err := postinstallScript(item, cachePath)
+				if !postScriptSuccess {
+					gorillalog.Error("Post-Install script error:", err)
+					return "PostInstall-Script error"
+				}
 			}
 		}
 	} else if installerType == "uninstall" {
@@ -454,14 +481,17 @@ func Install(item catalog.Item, installerType, urlPackages, cachePath string, ch
 			gorillalog.Info("[CHECK ONLY] Skipping actions for", item.DisplayName)
 			// Check only mode doesn't perform any action, return
 			return "Check only enabled"
+		} else {
+			// Compile the item's URL
+			itemURL := urlPackages + item.Uninstaller.Location
+			// Run the installer
+			uninstallItemFunc(item, itemURL, cachePath)
 		}
-		// Compile the item's URL
-		itemURL := urlPackages + item.Uninstaller.Location
-		// Run the installer
-		uninstallItemFunc(item, itemURL, cachePath)
 	} else {
 		gorillalog.Warn("Unsupported item type", item.DisplayName, installerType)
 		return "Unsupported item type"
+
 	}
+
 	return ""
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -75,10 +75,6 @@ func runCMD(command string, arguments []string) (string, error) {
 }
 
 // Get a Nupkg's id using `choco list`
-func getNupkgIDs(nupkgDir, versionArg string) ([]string, error) {
-	return getNupkgIDsWithRunner(nupkgDir, versionArg, runCommand)
-}
-
 func getNupkgIDsWithRunner(nupkgDir, versionArg string, runner commandRunner) ([]string, error) {
 
 	// Compile the arguments needed to get the id
@@ -98,10 +94,6 @@ func getNupkgIDsWithRunner(nupkgDir, versionArg string, runner commandRunner) ([
 	}
 
 	return ids, cmdErr
-}
-
-func resolveNupkgID(itemName, nupkgDir, versionArg, packageID string) (string, error) {
-	return resolveNupkgIDWithRunner(itemName, nupkgDir, versionArg, packageID, runCommand)
 }
 
 func resolveNupkgIDWithRunner(itemName, nupkgDir, versionArg, packageID string, runner commandRunner) (string, error) {

--- a/pkg/installer/runner_test.go
+++ b/pkg/installer/runner_test.go
@@ -1,0 +1,136 @@
+package installer
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/1dustindavis/gorilla/pkg/catalog"
+	"github.com/1dustindavis/gorilla/pkg/report"
+)
+
+func TestGetNupkgIDsWithRunner(t *testing.T) {
+	var gotCommand string
+	var gotArguments []string
+	runner := func(command string, arguments []string) (string, error) {
+		gotCommand = command
+		gotArguments = append([]string(nil), arguments...)
+		return " chef-client \n\nchef-client-alt\n", nil
+	}
+
+	ids, err := getNupkgIDsWithRunner(`C:\packages`, "--version=1.2.3", runner)
+	if err != nil {
+		t.Fatalf("getNupkgIDsWithRunner returned error: %v", err)
+	}
+	if want := []string{"chef-client", "chef-client-alt"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("ids = %#v, want %#v", ids, want)
+	}
+	if gotCommand != commandNupkg {
+		t.Fatalf("command = %q, want %q", gotCommand, commandNupkg)
+	}
+	wantArguments := []string{"list", "--version=1.2.3", "--id-only", "-r", "-s", `C:\packages`}
+	if !reflect.DeepEqual(gotArguments, wantArguments) {
+		t.Fatalf("arguments = %#v, want %#v", gotArguments, wantArguments)
+	}
+}
+
+func TestResolveNupkgIDWithRunnerExplicitIDDoesNotExecute(t *testing.T) {
+	runner := func(string, []string) (string, error) {
+		t.Fatal("runner should not be called when package_id is explicit")
+		return "", nil
+	}
+
+	id, err := resolveNupkgIDWithRunner("Chef Client", `C:\packages`, "--version=1.2.3", " chef-client ", runner)
+	if err != nil {
+		t.Fatalf("resolveNupkgIDWithRunner returned error: %v", err)
+	}
+	if id != "chef-client" {
+		t.Fatalf("id = %q, want %q", id, "chef-client")
+	}
+}
+
+func TestResolveNupkgIDWithRunnerPropagatesLookupError(t *testing.T) {
+	lookupErr := errors.New("lookup failed")
+	runner := func(string, []string) (string, error) {
+		return "", lookupErr
+	}
+
+	_, err := resolveNupkgIDWithRunner("Chef Client", `C:\packages`, "--version=1.2.3", "", runner)
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("error = %v, want %v", err, lookupErr)
+	}
+}
+
+func TestInstallItemWithRunnerBuildsMSICommandWithoutExecutingInstaller(t *testing.T) {
+	originalInstalledItems := report.InstalledItems
+	t.Cleanup(func() { report.InstalledItems = originalInstalledItems })
+
+	item := catalog.Item{
+		DisplayName: "MSI Test",
+		Installer: catalog.InstallerItem{
+			Type:      "msi",
+			Location:  "packages/chef-client/chef-client-14.3.37-1-x64.msi",
+			Hash:      "a1d4982abbb2bd2ccc238372ae688c790659c2c120efcee329fcca49c7c8fa9a",
+			Arguments: []string{"/L=1033", "/S"},
+		},
+	}
+
+	var gotCommand string
+	var gotArguments []string
+	runner := func(command string, arguments []string) (string, error) {
+		gotCommand = command
+		gotArguments = append([]string(nil), arguments...)
+		return "fake installer output", nil
+	}
+
+	gotOutput := installItemWithRunner(item, "https://example.com/chef-client/chef-client-14.3.37-1-x64.msi", "testdata/", runner)
+	if gotOutput != "fake installer output" {
+		t.Fatalf("output = %q, want %q", gotOutput, "fake installer output")
+	}
+	if gotCommand != commandMsi {
+		t.Fatalf("command = %q, want %q", gotCommand, commandMsi)
+	}
+	absFile := filepath.Join("testdata", "packages/chef-client/chef-client-14.3.37-1-x64.msi")
+	wantArguments := []string{"/i", absFile, "/qn", "/norestart", "/L=1033", "/S"}
+	if !reflect.DeepEqual(gotArguments, wantArguments) {
+		t.Fatalf("arguments = %#v, want %#v", gotArguments, wantArguments)
+	}
+}
+
+func TestUninstallItemWithRunnerBuildsMSIXCommandWithoutExecutingPowerShell(t *testing.T) {
+	originalUninstalledItems := report.UninstalledItems
+	t.Cleanup(func() { report.UninstalledItems = originalUninstalledItems })
+
+	item := catalog.Item{
+		DisplayName: "MSIX Test",
+		Installer:   catalog.InstallerItem{Type: "msix"},
+		Uninstaller: catalog.InstallerItem{Type: "msix"},
+		Check: catalog.InstallCheck{
+			Appx: catalog.AppxCheck{Name: "Gorilla.Test.App"},
+		},
+	}
+
+	var gotCommand string
+	var gotArguments []string
+	runner := func(command string, arguments []string) (string, error) {
+		gotCommand = command
+		gotArguments = append([]string(nil), arguments...)
+		return "fake uninstall output", nil
+	}
+
+	gotOutput := uninstallItemWithRunner(item, "", "testdata/", runner)
+	if gotOutput != "fake uninstall output" {
+		t.Fatalf("output = %q, want %q", gotOutput, "fake uninstall output")
+	}
+	if gotCommand != commandPs1 {
+		t.Fatalf("command = %q, want %q", gotCommand, commandPs1)
+	}
+	if len(gotArguments) != 7 || gotArguments[5] != "-Command" {
+		t.Fatalf("unexpected PowerShell arguments: %#v", gotArguments)
+	}
+	wantCommand := "$pkg = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq 'Gorilla.Test.App' }; if ($pkg) { Remove-AppxProvisionedPackage -Online -PackageName $pkg.PackageName }; Get-AppxPackage -Name 'Gorilla.Test.App' -AllUsers | Remove-AppxPackage -AllUsers -ErrorAction SilentlyContinue"
+	if gotArguments[6] != wantCommand {
+		t.Fatalf("PowerShell command = %q, want %q", gotArguments[6], wantCommand)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the behavior-preserving Stage 8 Go-testability work from #171.

- adds a narrow command-runner seam at the installer/process boundary without changing Gorilla's public installer API
- keeps production execution on the existing `runCMD` / `exec.Command` path
- makes installer command selection and NUPKG package-ID resolution directly testable with in-memory runners instead of launching real installers or helper processes
- adds deterministic coverage for NUPKG lookup/error propagation, MSI install command construction, and MSIX uninstall command construction
- keeps the existing Windows integration and released-binary fixture suites as the separate proof of the real OS/installer boundary
- deliberately leaves existing installer success/failure/reporting semantics unchanged

## Behavior-preservation constraint

This PR is intentionally testability-only. Product failures exposed while making the boundary deterministic will be fixed separately with explicit regression PRs rather than folded into this refactor.

In particular, this PR does not change installer error propagation, reporting behavior, or the existing pre/post-script process-start semantics.

## Validation

Fresh CI on final head `6fc1d505894c6a1cf9b0b846682121fe060d5ae1` is green across:

- Go Tests — formatting, Windows-targeted vet, pinned Staticcheck, and race-enabled tests all passed
- UI Client Tests
- Windows Integration — real source-built Windows installer fixtures passed
- Windows UI Tests
- Released-Binary Integration — produced-binary fixture validation passed

The first CI attempt exposed two now-unused compatibility wrappers through Staticcheck (`U1000`); they were removed rather than suppressed, and the complete PR was re-reviewed before the fresh green run.

Relates to #171 Stage 8.