### PR TITLE
Handle script process-start failures without panicking

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -358,7 +358,7 @@ func preinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded 
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	cmdSuccess := cmd.ProcessState.Success()
+	cmdSuccess := cmd.ProcessState != nil && cmd.ProcessState.Success()
 	outStr, errStr := stdout.String(), stderr.String()
 
 	// Delete the temporary script
@@ -395,7 +395,7 @@ func postinstallScript(catalogItem catalog.Item, cachePath string) (actionNeeded
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	cmdSuccess := cmd.ProcessState.Success()
+	cmdSuccess := cmd.ProcessState != nil && cmd.ProcessState.Success()
 	outStr, errStr := stdout.String(), stderr.String()
 
 	// Delete the temporary script

--- a/pkg/installer/script_process_start_test.go
+++ b/pkg/installer/script_process_start_test.go
@@ -1,0 +1,52 @@
+package installer
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/1dustindavis/gorilla/pkg/catalog"
+)
+
+func TestInstallScriptsReturnProcessStartError(t *testing.T) {
+	orig := execCommand
+	execCommand = func(string, ...string) *exec.Cmd {
+		return exec.Command(filepath.Join(t.TempDir(), "missing-powershell.exe"))
+	}
+	defer func() { execCommand = orig }()
+
+	tests := []struct {
+		name   string
+		run    func(catalog.Item, string) (bool, error)
+		script func(*catalog.Item)
+	}{
+		{
+			name: "preinstall",
+			run:  preinstallScript,
+			script: func(item *catalog.Item) {
+				item.PreScript = "Write-Output pre"
+			},
+		},
+		{
+			name: "postinstall",
+			run:  postinstallScript,
+			script: func(item *catalog.Item) {
+				item.PostScript = "Write-Output post"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := catalog.Item{}
+			tt.script(&item)
+			success, err := tt.run(item, t.TempDir())
+			if err == nil {
+				t.Fatal("expected process start error")
+			}
+			if success {
+				t.Fatal("expected failed script execution")
+			}
+		})
+	}
+}

--- a/pkg/status/script_process_start_test.go
+++ b/pkg/status/script_process_start_test.go
@@ -1,0 +1,29 @@
+package status
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/1dustindavis/gorilla/pkg/catalog"
+)
+
+func TestCheckScriptReturnsProcessStartError(t *testing.T) {
+	orig := execCommand
+	execCommand = func(string, ...string) *exec.Cmd {
+		return exec.Command(filepath.Join(t.TempDir(), "missing-powershell.exe"))
+	}
+	defer func() { execCommand = orig }()
+
+	item := catalog.Item{
+		Check: catalog.InstallCheck{Script: "Write-Output check"},
+	}
+
+	actionNeeded, err := checkScript(item, t.TempDir(), "install")
+	if err == nil {
+		t.Fatal("expected process start error")
+	}
+	if actionNeeded {
+		t.Fatal("expected no action decision when script execution cannot start")
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -113,7 +113,7 @@ func checkScript(catalogItem catalog.Item, cachePath string, installType string)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	cmdSuccess := cmd.ProcessState.Success()
+	cmdSuccess := cmd.ProcessState != nil && cmd.ProcessState.Success()
 	outStr, errStr := stdout.String(), stderr.String()
 
 	// Delete the temporary script
@@ -125,6 +125,10 @@ func checkScript(catalogItem catalog.Item, cachePath string, installType string)
 	gorillalog.Debug("Command Error:", err)
 	gorillalog.Debug("stdout:", outStr)
 	gorillalog.Debug("stderr:", errStr)
+
+	if cmd.ProcessState == nil {
+		return false, err
+	}
 
 	actionNeeded = false
 	// Application not installed if exit 0
@@ -143,7 +147,7 @@ func checkPath(catalogItem catalog.Item, installType string) (actionNeeded bool,
 	// Iterate through all file provided paths
 	for _, checkFile := range catalogItem.Check.File {
 		path := filepath.Clean(checkFile.Path)
-		gorillalog.Debug("Check file path:", path)
+		gorillalog.Debug("Check file path:", checkFile.Path)
 		_, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -155,7 +159,7 @@ func checkPath(catalogItem catalog.Item, installType string) (actionNeeded bool,
 					break
 				}
 
-				// When doing an update or uninstall, and the file path does
+				// When doing an update or uninstall, and the path does
 				// not exist, do nothing
 				if installType == "update" || installType == "uninstall" {
 					gorillalog.Debug("No action needed: Install type is", installType)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -147,7 +147,7 @@ func checkPath(catalogItem catalog.Item, installType string) (actionNeeded bool,
 	// Iterate through all file provided paths
 	for _, checkFile := range catalogItem.Check.File {
 		path := filepath.Clean(checkFile.Path)
-		gorillalog.Debug("Check file path:", checkFile.Path)
+		gorillalog.Debug("Check file path:", path)
 		_, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -159,7 +159,7 @@ func checkPath(catalogItem catalog.Item, installType string) (actionNeeded bool,
 					break
 				}
 
-				// When doing an update or uninstall, and the path does
+				// When doing an update or uninstall, and the file path does
 				// not exist, do nothing
 				if installType == "update" || installType == "uninstall" {
 					gorillalog.Debug("No action needed: Install type is", installType)


### PR DESCRIPTION
## Summary

Fixes a confirmed process-start failure path in Gorilla's PowerShell-backed scripts.

- prevents pre-install and post-install scripts from dereferencing a nil `ProcessState` when PowerShell fails to start
- makes status check scripts return the underlying start error instead of panicking
- preserves existing nonzero-exit semantics when a script process starts successfully
- adds focused regression coverage for missing/unstartable PowerShell in installer and status script paths

## Scope

This PR is intentionally narrow. It does not change installer execution/reporting semantics or broader script behavior beyond the confirmed start-failure panic path.

The status path still treats a started script's exit code exactly as before; only a failure to create/start a process now returns the execution error rather than dereferencing a nil `ProcessState`.

## Validation

Fresh CI on final head `88be699c7ed1c0e88d0decd475257ae06473cf2b` is green across:

- Go Tests — formatting, Windows-targeted vet, pinned Staticcheck, and race-enabled tests passed
- UI Client Tests
- Windows UI Tests
- Windows Integration — real source-built Windows installer fixtures passed
- Released-Binary Integration — produced-binary fixture validation passed

Final cumulative review confirms the production diff is limited to two nil-safe installer script success checks and the status-script nil-safe check/start-error return. A review after the initial status production commit caught two unrelated replacement artifacts; those were restored before the installer change and are absent from the final diff.

Follow-up to #201 and #202 / Stage 8 work from #171.