### PR TITLE
Add selective mutation testing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ]
+    }
+  }
+}

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -1,0 +1,84 @@
+name: Mutation Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Mutation suite to run
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - go
+          - ui
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Go mutation tests
+    if: ${{ inputs.suite == 'all' || inputs.suite == 'go' }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Set Git config
+        run: git config --global core.autocrlf false
+
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure Go cache paths
+        shell: pwsh
+        run: |
+          "GOMODCACHE=$env:RUNNER_TEMP\go\pkg\mod" >> $env:GITHUB_ENV
+          "GOCACHE=$env:RUNNER_TEMP\go-build" >> $env:GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            Makefile
+            .github/workflows/mutation-tests.yml
+
+      - name: Run Go mutation tests
+        run: make mutation-go
+
+  ui:
+    name: UI Core mutation tests
+    if: ${{ inputs.suite == 'all' || inputs.suite == 'ui' }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Set Git config
+        run: git config --global core.autocrlf false
+
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure NuGet package path
+        shell: pwsh
+        run: |
+          $nugetPackages = Join-Path $env:RUNNER_TEMP 'nuget-packages'
+          "NUGET_PACKAGES=$nugetPackages" >> $env:GITHUB_ENV
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Run UI Core mutation tests
+        run: make mutation-ui
+
+      - name: Upload Stryker reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: stryker-reports-${{ github.run_id }}
+          path: gorilla-ui/tests/Gorilla.UI.Core.Tests/StrykerOutput/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -46,7 +46,19 @@ jobs:
             .github/workflows/mutation-tests.yml
 
       - name: Run Go mutation tests
-        run: make mutation-go
+        shell: pwsh
+        run: |
+          make mutation-go 2>&1 | Tee-Object -FilePath gremlins-output.txt
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload Gremlins output
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: gremlins-output-${{ github.run_id }}
+          path: gremlins-output.txt
+          if-no-files-found: warn
+          retention-days: 14
 
   ui:
     name: UI Core mutation tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,15 @@ Use these for fast focused iteration or CI jobs that own one validation layer:
 - `make release-integration GORILLA_RELEASE_EXE=<path>`
 - `make installed-product-integration GORILLA_RELEASE_MSIX=<path> GORILLA_RELEASE_EXE=<path>`
 
+Mutation testing is an opt-in quality tool rather than a canonical validation level:
+
+- `make mutation-go` runs pinned Gremlins against the selected pure-Go mutation scope.
+- `make mutation-ui` restores the repository-local Stryker.NET tool and mutates selected `Gorilla.UI.Core` logic.
+- `make mutation` composes both mutation suites.
+- Do not add mutation testing to `verify*` or make it an every-PR gate unless measured runtime and signal quality justify that policy later.
+- Treat useful surviving mutants as prompts to improve behavioral assertions. Do not change production behavior merely to improve mutation score; address real defects separately.
+- See `docs/mutation-testing.md` for current scope and interpretation guidance.
+
 `make lint` and `make test` remain supported compatibility aliases for Go linting and Go tests respectively. `make lint` includes `staticcheck`.
 
 ### Which level to use

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: build
 .PHONY: build bootstrap bootstrap-run manual-test-server clean help \
 	go-format go-vet go-staticcheck go-test lint test \
 	ui-restore ui-lint ui-test ui-windows-build ui-e2e ui-e2e-test \
+	mutation mutation-go mutation-ui \
 	windows-integration release-integration installed-product-integration \
 	verify verify-windows verify-e2e verify-release
 
@@ -19,6 +20,7 @@ REVISION = $(shell git rev-parse HEAD)
 REVSHORT = $(shell git rev-parse --short HEAD)
 APP_NAME = gorilla
 STATICCHECK_VERSION ?= v0.7.0
+GREMLINS_VERSION ?= v0.6.0
 MANUAL_TEST_DIR = build/manual-test
 MANUAL_TEST_SERVER_ROOT = ${MANUAL_TEST_DIR}/server-root
 MANUAL_TEST_VM_DIR = ${MANUAL_TEST_DIR}/vm
@@ -86,6 +88,10 @@ define HELP_TEXT
 	make release-integration GORILLA_RELEASE_EXE=... - Test a supplied release binary against installer fixtures
 	make installed-product-integration GORILLA_RELEASE_MSIX=... - Install the produced MSIX and validate service/UI/package interoperability
 
+	make mutation        - Run the selected Go and UI Core mutation suites
+	make mutation-go     - Run Gremlins against selected pure Go logic
+	make mutation-ui     - Run Stryker.NET against selected Gorilla.UI.Core logic
+
 	make lint           - Compatibility alias for Go format/vet/staticcheck
 	make test           - Compatibility alias for Go tests
 
@@ -109,6 +115,7 @@ clean:
 	rm -rf gorilla-ui/tests/Gorilla.UI.Core.Tests/bin/
 	rm -rf gorilla-ui/tests/Gorilla.UI.Core.Tests/obj/
 	rm -rf gorilla-ui/tests/Gorilla.UI.Core.Tests/TestResults/
+	rm -rf gorilla-ui/tests/Gorilla.UI.Core.Tests/StrykerOutput/
 	rm -rf gorilla-ui/tools/PipeHarness/bin/
 	rm -rf gorilla-ui/tools/PipeHarness/obj/
 	rm -rf gorilla-ui/src/Gorilla.UI.App/AppPackages/
@@ -202,6 +209,18 @@ ui-lint: ui-restore
 ui-test: ui-lint
 	dotnet test gorilla-ui/tests/Gorilla.UI.Client.Tests/Gorilla.UI.Client.Tests.csproj --no-build --no-restore
 	dotnet test gorilla-ui/tests/Gorilla.UI.Core.Tests/Gorilla.UI.Core.Tests.csproj --no-build --no-restore
+
+# Mutation testing is an explicitly opt-in quality tool. It is deliberately
+# excluded from verify/verify-windows/verify-e2e/verify-release until runtime
+# and signal quality justify a stricter cadence.
+mutation-go: gomodcheck
+	go run github.com/go-gremlins/gremlins@$(GREMLINS_VERSION) unleash ./pkg/manifest
+
+mutation-ui:
+	dotnet tool restore
+	cd gorilla-ui/tests/Gorilla.UI.Core.Tests && dotnet stryker
+
+mutation: mutation-go mutation-ui
 
 ui-windows-build:
 ifeq ($(OS), Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ ui-test: ui-lint
 # excluded from verify/verify-windows/verify-e2e/verify-release until runtime
 # and signal quality justify a stricter cadence.
 mutation-go: gomodcheck
-	go run github.com/go-gremlins/gremlins@$(GREMLINS_VERSION) unleash ./pkg/manifest
+	go run github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION) unleash ./pkg/manifest
 
 mutation-ui:
 	dotnet tool restore

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ REVSHORT = $(shell git rev-parse --short HEAD)
 APP_NAME = gorilla
 STATICCHECK_VERSION ?= v0.7.0
 GREMLINS_VERSION ?= v0.6.0
+MUTATION_GO_PACKAGES := ./pkg/manifest ./pkg/catalog ./pkg/process ./pkg/admin
 MANUAL_TEST_DIR = build/manual-test
 MANUAL_TEST_SERVER_ROOT = ${MANUAL_TEST_DIR}/server-root
 MANUAL_TEST_VM_DIR = ${MANUAL_TEST_DIR}/vm
@@ -214,7 +215,10 @@ ui-test: ui-lint
 # excluded from verify/verify-windows/verify-e2e/verify-release until runtime
 # and signal quality justify a stricter cadence.
 mutation-go: gomodcheck
-	go run github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION) unleash ./pkg/manifest
+	@for package in $(MUTATION_GO_PACKAGES); do \
+		echo "Running Gremlins against $$package"; \
+		go run github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION) unleash --workers 1 --timeout-coefficient 20 $$package || exit $$?; \
+	done
 
 mutation-ui:
 	dotnet tool restore

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,5 +28,6 @@ By default, logs are written to `%ProgramData%\gorilla\gorilla.log` and the run 
 - [Manifests](manifests.md)
 - [App Catalog](app-catalog.md)
 - [Repository administration](repo-admin-tools.md)
+- [Mutation testing](mutation-testing.md)
 - [Installing Chocolatey with Gorilla](installing-chocolatey.md)
 - [Community](community.md)

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -1,10 +1,10 @@
 # Mutation testing
 
-Gorilla uses mutation testing selectively to assess whether focused unit tests detect meaningful changes in high-value pure logic. Mutation testing is a diagnostic quality tool, not part of the required `verify*` validation contract.
+Mutation testing helps us find tests that run code without really proving its behavior. It is optional and is not part of the normal `verify*` checks.
 
-## Commands
+## Run it
 
-Run the selected suites from the repository root:
+From the repo root:
 
 ```text
 make mutation-go
@@ -12,51 +12,43 @@ make mutation-ui
 make mutation
 ```
 
-- `make mutation-go` runs pinned Gremlins against `pkg/manifest`.
-- `make mutation-ui` restores the repository-local Stryker.NET tool and runs it against selected `Gorilla.UI.Core` behavior.
-- `make mutation` composes both suites.
+- `make mutation-go` runs Gremlins against `pkg/manifest`.
+- `make mutation-ui` runs Stryker.NET against selected `Gorilla.UI.Core` logic.
+- `make mutation` runs both.
 
-The Go tool version is pinned by `GREMLINS_VERSION` in the Makefile. Stryker.NET is pinned in `.config/dotnet-tools.json` and configured by `gorilla-ui/tests/Gorilla.UI.Core.Tests/stryker-config.json`.
+You can also run the manual **Mutation Tests** workflow in GitHub Actions and choose `all`, `go`, or `ui`. The workflow is manual-only and does not run on pushes or pull requests.
 
-## Manual GitHub Actions runs
+## What we mutate
 
-After `.github/workflows/mutation-tests.yml` is present on the default branch, use **Actions > Mutation Tests > Run workflow** to run mutation testing without making it part of normal PR validation.
+Keep the scope small and useful.
 
-The workflow accepts a `suite` choice:
+Go:
 
-- `all` runs both mutation suites.
-- `go` runs only Gremlins.
-- `ui` runs only Stryker.NET.
+- `pkg/manifest`
 
-The workflow can be dispatched against a selected branch or tag, so after this workflow is merged you can still choose a later PR branch when you want to investigate its mutation behavior. Each mutation job has a 60-minute timeout. Gremlins console output and Stryker reports are uploaded as workflow artifacts and retained for 14 days.
-
-The workflow has no `push`, `pull_request`, or scheduled trigger. It is intentionally manual-only and is not a required status check.
-
-## Scope
-
-Keep mutation scope deliberately narrow. Prefer deterministic, branch-heavy logic whose behavior should already be described by ordinary unit tests.
-
-The initial Go scope is `pkg/manifest`. The initial .NET scope covers:
+.NET:
 
 - `OptionalInstallsStartupLoader`
 - `OperationTracker`
 - `HomeViewModel`
 
-Do not expand mutation testing simply to increase the number of mutants. Avoid Windows service wrappers, installer/process adapters, WinUI code-behind, generated files, and FlaUI tests unless a concrete future need justifies the cost and signal quality.
+Avoid mutating Windows service wrappers, installer/process adapters, WinUI code-behind, generated files, and FlaUI tests unless there is a good reason to expand the scope.
 
-## Interpreting survivors
+## What to do with survivors
 
-A surviving mutant is a prompt to inspect the behavior, not an automatic failure requiring production changes.
+A surviving mutant means a test did not catch a code change. Check whether that change matters.
 
-For each useful survivor:
+- If it represents real behavior, improve the test.
+- If it is equivalent or meaningless, ignore it or exclude it narrowly if that makes the results easier to use.
+- If it exposes a real product bug, fix the bug separately instead of changing production code just to improve the mutation score.
 
-1. Determine whether the mutation represents meaningful observable behavior.
-2. If an existing test should distinguish it, strengthen the assertion or add the missing behavioral case.
-3. If the mutant is equivalent or otherwise not behaviorally meaningful, leave it alone or exclude it narrowly only when the exclusion improves signal.
-4. If investigation exposes a real product defect or ambiguous product contract, fix that behavior separately rather than changing production code merely to improve mutation score.
+We are not enforcing a mutation score or running mutation tests on every PR. We can revisit that after we have enough runtime and signal data.
 
-Do not target a repository-wide mutation percentage and do not make mutation testing an every-PR gate unless measured runtime and signal quality justify that policy later.
+## Reports
 
-## Reports and cleanup
+The GitHub Actions workflow keeps mutation artifacts for 14 days.
 
-Stryker writes local reports under `StrykerOutput/`; these outputs are ignored by Git and removed by `make clean`. Local Gremlins runs report results directly to the console. Manual GitHub Actions runs preserve both suites' output as workflow artifacts for investigation.
+- Gremlins output is saved from the Go job.
+- Stryker reports are saved from `StrykerOutput/`.
+
+Local Stryker output is ignored by Git and removed by `make clean`.

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -18,6 +18,20 @@ make mutation
 
 The Go tool version is pinned by `GREMLINS_VERSION` in the Makefile. Stryker.NET is pinned in `.config/dotnet-tools.json` and configured by `gorilla-ui/tests/Gorilla.UI.Core.Tests/stryker-config.json`.
 
+## Manual GitHub Actions runs
+
+After `.github/workflows/mutation-tests.yml` is present on the default branch, use **Actions > Mutation Tests > Run workflow** to run mutation testing without making it part of normal PR validation.
+
+The workflow accepts a `suite` choice:
+
+- `all` runs both mutation suites.
+- `go` runs only Gremlins.
+- `ui` runs only Stryker.NET.
+
+The workflow can be dispatched against a selected branch or tag, so after this workflow is merged you can still choose a later PR branch when you want to investigate its mutation behavior. Each mutation job has a 60-minute timeout. Gremlins console output and Stryker reports are uploaded as workflow artifacts and retained for 14 days.
+
+The workflow has no `push`, `pull_request`, or scheduled trigger. It is intentionally manual-only and is not a required status check.
+
 ## Scope
 
 Keep mutation scope deliberately narrow. Prefer deterministic, branch-heavy logic whose behavior should already be described by ordinary unit tests.
@@ -45,4 +59,4 @@ Do not target a repository-wide mutation percentage and do not make mutation tes
 
 ## Reports and cleanup
 
-Stryker writes reports under `StrykerOutput/`; these outputs are ignored by Git and removed by `make clean`. Gremlins reports results directly during the run.
+Stryker writes local reports under `StrykerOutput/`; these outputs are ignored by Git and removed by `make clean`. Local Gremlins runs report results directly to the console. Manual GitHub Actions runs preserve both suites' output as workflow artifacts for investigation.

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -12,7 +12,7 @@ make mutation-ui
 make mutation
 ```
 
-- `make mutation-go` runs Gremlins against `pkg/manifest`.
+- `make mutation-go` runs Gremlins sequentially against the selected Go packages. It uses one worker and a larger timeout coefficient so fast package baselines do not produce load-sensitive false timeouts.
 - `make mutation-ui` runs Stryker.NET against selected `Gorilla.UI.Core` logic.
 - `make mutation` runs both.
 
@@ -25,6 +25,9 @@ Keep the scope small and useful.
 Go:
 
 - `pkg/manifest`
+- `pkg/catalog`
+- `pkg/process`
+- `pkg/admin`
 
 .NET:
 
@@ -32,7 +35,9 @@ Go:
 - `OperationTracker`
 - `HomeViewModel`
 
-Avoid mutating Windows service wrappers, installer/process adapters, WinUI code-behind, generated files, and FlaUI tests unless there is a good reason to expand the scope.
+The Go scope covers manifest and catalog loading, catalog selection and operation orchestration, and catalog-building behavior. Despite its name, `pkg/process` contains portable orchestration logic rather than OS process-management adapters.
+
+Avoid mutating Windows service/process wrappers, installer adapters, WinUI code-behind, generated files, and FlaUI tests unless there is a good reason to expand the scope.
 
 ## What to do with survivors
 

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -1,0 +1,48 @@
+# Mutation testing
+
+Gorilla uses mutation testing selectively to assess whether focused unit tests detect meaningful changes in high-value pure logic. Mutation testing is a diagnostic quality tool, not part of the required `verify*` validation contract.
+
+## Commands
+
+Run the selected suites from the repository root:
+
+```text
+make mutation-go
+make mutation-ui
+make mutation
+```
+
+- `make mutation-go` runs pinned Gremlins against `pkg/manifest`.
+- `make mutation-ui` restores the repository-local Stryker.NET tool and runs it against selected `Gorilla.UI.Core` behavior.
+- `make mutation` composes both suites.
+
+The Go tool version is pinned by `GREMLINS_VERSION` in the Makefile. Stryker.NET is pinned in `.config/dotnet-tools.json` and configured by `gorilla-ui/tests/Gorilla.UI.Core.Tests/stryker-config.json`.
+
+## Scope
+
+Keep mutation scope deliberately narrow. Prefer deterministic, branch-heavy logic whose behavior should already be described by ordinary unit tests.
+
+The initial Go scope is `pkg/manifest`. The initial .NET scope covers:
+
+- `OptionalInstallsStartupLoader`
+- `OperationTracker`
+- `HomeViewModel`
+
+Do not expand mutation testing simply to increase the number of mutants. Avoid Windows service wrappers, installer/process adapters, WinUI code-behind, generated files, and FlaUI tests unless a concrete future need justifies the cost and signal quality.
+
+## Interpreting survivors
+
+A surviving mutant is a prompt to inspect the behavior, not an automatic failure requiring production changes.
+
+For each useful survivor:
+
+1. Determine whether the mutation represents meaningful observable behavior.
+2. If an existing test should distinguish it, strengthen the assertion or add the missing behavioral case.
+3. If the mutant is equivalent or otherwise not behaviorally meaningful, leave it alone or exclude it narrowly only when the exclusion improves signal.
+4. If investigation exposes a real product defect or ambiguous product contract, fix that behavior separately rather than changing production code merely to improve mutation score.
+
+Do not target a repository-wide mutation percentage and do not make mutation testing an every-PR gate unless measured runtime and signal quality justify that policy later.
+
+## Reports and cleanup
+
+Stryker writes reports under `StrykerOutput/`; these outputs are ignored by Git and removed by `make clean`. Gremlins reports results directly during the run.

--- a/gorilla-ui/.gitignore
+++ b/gorilla-ui/.gitignore
@@ -3,6 +3,7 @@
 **/obj/
 .vs/
 **/TestResults/
+**/StrykerOutput/
 **/*.user
 **/*.rsuser
 **/*.suo

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/stryker-config.json
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/stryker-config.json
@@ -1,0 +1,14 @@
+{
+  "stryker-config": {
+    "mutate": [
+      "OptionalInstallsStartupLoader.cs",
+      "Services/OperationTracker.cs",
+      "ViewModels/HomeViewModel.cs"
+    ],
+    "reporters": [
+      "progress",
+      "json",
+      "html"
+    ]
+  }
+}

--- a/pkg/status/properties_stub.go
+++ b/pkg/status/properties_stub.go
@@ -17,7 +17,6 @@ func GetFileMetadata(path string) WindowsMetadata {
 	// Set a fake `productName` and `versionString`
 	var fakeMetadata WindowsMetadata
 	fakeMetadata.productName = "Gorilla Test"
-	fakeMetadata.companyName = "Gorilla Inc"
 	fakeMetadata.versionString = "3.2.0.1"
 	fakeMetadata.versionMajor = 3
 	fakeMetadata.versionMinor = 2


### PR DESCRIPTION
## Summary

Implements Stage 9 of #171 as an opt-in quality tool rather than an every-PR gate.

- pins Gremlins v0.6.0 for Go mutation testing and Stryker.NET 4.16.0 as a repository-local .NET tool
- adds `make mutation-go`, `make mutation-ui`, and composed `make mutation` entry points
- uses a selective Go scope covering `pkg/manifest`, `pkg/catalog`, `pkg/process`, and `pkg/admin`
- scopes Stryker.NET to high-value `Gorilla.UI.Core` behavior: startup orchestration, operation tracking, and `HomeViewModel`
- adds a manual-only `Mutation Tests` GitHub Actions workflow with `all`, `go`, and `ui` choices
- preserves Gremlins console output and Stryker reports as 14-day workflow artifacts
- keeps mutation testing completely outside `verify`, `verify-windows`, `verify-e2e`, and `verify-release`
- configures Stryker reports without a mutation-score failure threshold
- ignores/cleans generated Stryker output
- documents how to interpret surviving mutants and explicitly separates real product defects from mutation-score cleanup
- fixes a stale non-Windows status stub field so the expanded Go scope remains portable

## Design

Mutation testing is intentionally selective. The Go target covers manifest and catalog loading, catalog selection and operation orchestration, and catalog-building behavior. Despite its name, `pkg/process` contains portable orchestration logic rather than OS process-management adapters. The target set avoids Windows service/process wrappers, installer adapters, WinUI code-behind, generated files, and FlaUI tests.

The GitHub Actions entry point uses only `workflow_dispatch`; it has no push, pull-request, or scheduled trigger and is not part of required validation. Each suite has a 60-minute timeout so runtime can be measured safely before considering any future cadence.

GitHub requires a `workflow_dispatch` workflow to exist on the default branch before the Actions UI can dispatch it. After this PR merges, `Actions > Mutation Tests > Run workflow` can target `main` or another selected branch/tag.

`pkg/version` is deliberately not included even though version comparison was an illustrative candidate in #171: the current package primarily exposes build metadata/printing and does not contain meaningful semantic version-comparison logic.

## Tool verification

The pinned versions were independently checked against the current upstream releases:

- Gremlins: v0.6.0
- Stryker.NET: 4.16.0

The Gremlins invocation uses its actual executable package at `github.com/go-gremlins/gremlins/cmd/gremlins`; cumulative review caught and corrected an earlier module-root invocation before this PR was opened.

## Mutation test results

The expanded Go suite was run against commit `b605276311532c51108bbe22190c6f5afd58be43`. The .NET mutation inputs have not changed since their recorded run against `ab49689ebebd594174c2c5993d734e5147d7bdc5`.

### Go

| Package | Generated | Killed | Survived | Timed out | Uncovered | Test efficacy |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `pkg/manifest` | 18 | 16 | 1 | 1 | 0 | 94.12% |
| `pkg/catalog` | 8 | 8 | 0 | 0 | 0 | 100.00% |
| `pkg/process` | 24 | 15 | 9 | 0 | 0 | 62.50% |
| `pkg/admin` | 15 | 15 | 0 | 0 | 0 | 100.00% |
| **Total** | **65** | **54** | **10** | **1** | **0** | **84.38%** |

All four packages had 100% mutator coverage. The composed local run completed in approximately 48 seconds, including repeated pinned-tool startup. Gremlins runs the packages sequentially with one worker and a timeout coefficient of 20; this prevents millisecond-scale cached test baselines and transient runner load from misclassifying ordinary test failures as timeouts.

The surviving `pkg/manifest` conditional-boundary mutant changes `len(cfg.LocalManifests) > 0` to `>= 0`. It is behaviorally equivalent because the following range loop still performs no work for an empty slice. The timed-out condition-negation mutant creates non-terminating manifest traversal and was therefore detected by the timeout.

All `pkg/catalog` and `pkg/admin` mutants were killed. The nine `pkg/process` survivors affect warning-message composition or behaviorally equivalent/edge-only boundaries, including empty-slice guards and the exact cache-age threshold. Mutants affecting valid catalog-item selection, dependency execution, install/update/uninstall dispatch, and cleanup decisions were killed. These results establish a baseline without changing production behavior merely to improve the score.

### .NET (`Gorilla.UI.Core`)

- 128 mutants generated
- 58 eligible mutants executed
- 40 killed
- 18 survived
- 3 had no coverage
- 11 produced compile errors
- 56 were ignored by Stryker's configured mutation and block filters
- 65.57% mutation score
- completed in approximately 76 seconds with the workflow's .NET 8.0.414 compiler

All eligible mutants in `OptionalInstallsStartupLoader` and `OperationTracker` were killed. The 18 survivors and three uncovered mutants are in `HomeViewModel`. They identify test gaps around transient busy state, property-change notifications, rejected-operation tracking, missing-item lookup, non-terminal streams, cancellation propagation, live status text, refresh-warning preservation, and operation-error fallback behavior.

These survivors do not fail the opt-in suite because no mutation-score threshold is configured. They provide a concrete baseline and follow-up test targets without making mutation testing part of the required PR validation contract.

The .NET run was repeated with the workflow's .NET 8 compiler and produced identical mutant statuses. The local Work-mode runner required a diagnostic-only VSTest launcher workaround for an environment-specific `ProcessName` lookup failure; Gorilla source, Stryker's mutation engine and configuration, and test behavior were unchanged.

## Validation

The branch was reviewed cumulatively after every commit and again from the complete PR patch. The final diff remains focused on mutation infrastructure, configuration, documentation, and the manual workflow. The only runtime-adjacent change removes an assignment to a nonexistent field from the non-Windows status stub, restoring portable compilation without changing Windows behavior. No existing CI trigger or canonical validation target is modified.

Normal PR CI remains the regression validation for the existing Gorilla test/build layers. Mutation runs remain explicit by design so their runtime and survivor signal can be evaluated before any future automation decision.

Relates to #171 Stage 9.