### PR TITLE
Consume truthful App Catalog operation results in UI client

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -53,6 +53,8 @@
                             Margin="12,0,0,0"
                             Content="Install"
                             Tag="{Binding ItemName}"
+                            IsEnabled="{Binding CanInstall}"
+                            ToolTipService.ToolTip="{Binding InstallUnavailableReason}"
                             Click="InstallButton_Click"
                             AutomationProperties.AutomationId="InstallButton" />
                         <Button
@@ -60,6 +62,8 @@
                             Margin="8,0,0,0"
                             Content="Remove"
                             Tag="{Binding ItemName}"
+                            IsEnabled="{Binding CanRemove}"
+                            ToolTipService.ToolTip="{Binding RemoveUnavailableReason}"
                             Click="RemoveButton_Click"
                             AutomationProperties.AutomationId="RemoveButton" />
                     </Grid>

--- a/gorilla-ui/src/Gorilla.UI.Client/AppCatalogContracts.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/AppCatalogContracts.cs
@@ -1,4 +1,3 @@
-// Planned v2 payloads. The live v1 transport remains unchanged until stage 2/3.
 namespace Gorilla.UI.Client.AppCatalog;
 
 public enum ObservedState { Absent, Installed, UpdateAvailable, Unknown, DetectionFailed }
@@ -26,7 +25,12 @@ public sealed record Policy(
 
 public sealed record ActionDecision(bool Allowed, string Reason);
 public sealed record Actions(ActionDecision Install, ActionDecision Remove);
-public sealed record Result(Outcome Outcome, string Code);
+public sealed record Result(
+    Outcome Outcome,
+    string Code,
+    string? DetailCode = null,
+    string? Message = null
+);
 
 public sealed record Operation(
     string OperationId,

--- a/gorilla-ui/src/Gorilla.UI.Client/Contracts.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/Contracts.cs
@@ -7,9 +7,7 @@ public enum OperationState
     Downloading,
     Installing,
     Removing,
-    Succeeded,
-    Failed,
-    Canceled,
+    Completed,
 }
 
 public enum OptionalInstallStatus
@@ -53,11 +51,8 @@ public sealed record OperationStatusEvent(
     int? ProgressPercent,
     string Message,
     DateTimeOffset TimestampUtc,
-    string? ErrorCode = null,
-    string? ErrorMessage = null,
-    string? CanceledBy = null,
-    string? ItemName = null,
-    AppCatalog.Action? Action = null,
+    string ItemName,
+    AppCatalog.Action Action,
     AppCatalog.Result? Result = null
 );
 

--- a/gorilla-ui/src/Gorilla.UI.Client/Contracts.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/Contracts.cs
@@ -50,12 +50,15 @@ public sealed record OperationAccepted(
 public sealed record OperationStatusEvent(
     string OperationId,
     OperationState State,
-    int ProgressPercent,
+    int? ProgressPercent,
     string Message,
     DateTimeOffset TimestampUtc,
     string? ErrorCode = null,
     string? ErrorMessage = null,
-    string? CanceledBy = null
+    string? CanceledBy = null,
+    string? ItemName = null,
+    AppCatalog.Action? Action = null,
+    AppCatalog.Result? Result = null
 );
 
 public interface IGorillaServiceClient

--- a/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
@@ -187,11 +187,8 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
                     ProgressPercent: eventEnvelope.Payload.ProgressPercent,
                     Message: eventEnvelope.Payload.Message,
                     TimestampUtc: eventEnvelope.TimestampUtc,
-                    ErrorCode: eventEnvelope.Payload.ErrorCode,
-                    ErrorMessage: eventEnvelope.Payload.ErrorMessage,
-                    CanceledBy: eventEnvelope.Payload.CanceledBy,
-                    ItemName: eventEnvelope.Payload.ItemName,
-                    Action: eventEnvelope.Payload.Action,
+                    ItemName: eventEnvelope.Payload.ItemName!,
+                    Action: eventEnvelope.Payload.Action!.Value,
                     Result: eventEnvelope.Payload.Result
                 );
 
@@ -200,15 +197,15 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
                     $"stream:event operationId={ev.OperationId} itemName={ev.ItemName} action={ev.Action} state={ev.State} progress={ev.ProgressPercent} outcome={ev.Result?.Outcome}"
                 );
 
-                if (IsTerminal(ev.State))
+                if (ev.State == OperationState.Completed)
                 {
-                    ClientDiagnostics.Log($"stream:end operationId={ev.OperationId} terminalState={ev.State}");
+                    ClientDiagnostics.Log($"stream:end operationId={ev.OperationId} outcome={ev.Result!.Outcome}");
                     completed = true;
                     terminalState = ev.State.ToString();
-                    result = ev.State switch
+                    result = ev.Result.Outcome switch
                     {
-                        OperationState.Succeeded => "ok",
-                        OperationState.Canceled => "canceled",
+                        AppCatalog.Outcome.Succeeded or AppCatalog.Outcome.AlreadySatisfied => "ok",
+                        AppCatalog.Outcome.Interrupted => "canceled",
                         _ => "error"
                     };
                     yield break;
@@ -222,23 +219,11 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
                 result = "canceled";
             }
 
-            if (completed)
-            {
-                ClientDiagnostics.Log(
-                    $"stream:lifecycle operationId={operationId} state={terminalState} result={result} durationMs={duration.ElapsedMilliseconds}"
-                );
-            }
-            else
-            {
-                ClientDiagnostics.Log(
-                    $"stream:lifecycle operationId={operationId} state={terminalState} result={result} durationMs={duration.ElapsedMilliseconds}"
-                );
-            }
+            ClientDiagnostics.Log(
+                $"stream:lifecycle operationId={operationId} state={terminalState} result={result} durationMs={duration.ElapsedMilliseconds}"
+            );
         }
     }
-
-    private static bool IsTerminal(OperationState state) =>
-        state is OperationState.Succeeded or OperationState.Failed or OperationState.Canceled;
 
     private static ServiceEnvelope<TPayload> CreateRequestEnvelope<TPayload>(
         string operation,

--- a/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
@@ -189,11 +189,16 @@ public sealed class NamedPipeGorillaServiceClient : IGorillaServiceClient
                     TimestampUtc: eventEnvelope.TimestampUtc,
                     ErrorCode: eventEnvelope.Payload.ErrorCode,
                     ErrorMessage: eventEnvelope.Payload.ErrorMessage,
-                    CanceledBy: eventEnvelope.Payload.CanceledBy
+                    CanceledBy: eventEnvelope.Payload.CanceledBy,
+                    ItemName: eventEnvelope.Payload.ItemName,
+                    Action: eventEnvelope.Payload.Action,
+                    Result: eventEnvelope.Payload.Result
                 );
 
                 yield return ev;
-                ClientDiagnostics.Log($"stream:event operationId={ev.OperationId} state={ev.State} progress={ev.ProgressPercent}");
+                ClientDiagnostics.Log(
+                    $"stream:event operationId={ev.OperationId} itemName={ev.ItemName} action={ev.Action} state={ev.State} progress={ev.ProgressPercent} outcome={ev.Result?.Outcome}"
+                );
 
                 if (IsTerminal(ev.State))
                 {

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolPayloads.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolPayloads.cs
@@ -23,11 +23,8 @@ public sealed record OperationStatusEventPayload(
     OperationState State,
     int? ProgressPercent,
     string Message,
-    string? ErrorCode = null,
-    string? ErrorMessage = null,
-    string? CanceledBy = null,
-    string? ItemName = null,
-    AppCatalog.Action? Action = null,
+    string ItemName,
+    AppCatalog.Action Action,
     AppCatalog.Result? Result = null
 );
 

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolPayloads.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolPayloads.cs
@@ -21,11 +21,14 @@ public sealed record StreamOperationStatusResponse(bool StreamAccepted);
 
 public sealed record OperationStatusEventPayload(
     OperationState State,
-    int ProgressPercent,
+    int? ProgressPercent,
     string Message,
     string? ErrorCode = null,
     string? ErrorMessage = null,
-    string? CanceledBy = null
+    string? CanceledBy = null,
+    string? ItemName = null,
+    AppCatalog.Action? Action = null,
+    AppCatalog.Result? Result = null
 );
 
 public sealed record ErrorResponse(

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolPayloads.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolPayloads.cs
@@ -23,8 +23,8 @@ public sealed record OperationStatusEventPayload(
     OperationState State,
     int? ProgressPercent,
     string Message,
-    string ItemName,
-    AppCatalog.Action Action,
+    string? ItemName = null,
+    AppCatalog.Action? Action = null,
     AppCatalog.Result? Result = null
 );
 

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
@@ -61,12 +61,20 @@ public static class ProtocolValidation
             throw new ProtocolValidationException("action is required for operation status events.");
         }
 
-        if (payload.State == OperationState.Completed && payload.Result is null)
+        if (payload.State == OperationState.Completed)
         {
-            throw new ProtocolValidationException("result is required when state is Completed.");
+            if (payload.Result is null)
+            {
+                throw new ProtocolValidationException("result is required when state is Completed.");
+            }
+            if (string.IsNullOrWhiteSpace(payload.Result.Code))
+            {
+                throw new ProtocolValidationException("result.code is required when state is Completed.");
+            }
+            return;
         }
 
-        if (payload.State != OperationState.Completed && payload.Result is not null)
+        if (payload.Result is not null)
         {
             throw new ProtocolValidationException("result is only allowed when state is Completed.");
         }

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
@@ -51,14 +51,24 @@ public static class ProtocolValidation
             throw new ProtocolValidationException("progressPercent must be between 0 and 100 when provided.");
         }
 
-        if (payload.State == OperationState.Failed && string.IsNullOrWhiteSpace(payload.ErrorMessage))
+        if (string.IsNullOrWhiteSpace(payload.ItemName))
         {
-            throw new ProtocolValidationException("errorMessage is required when state is Failed.");
+            throw new ProtocolValidationException("itemName is required for operation status events.");
         }
 
-        if (payload.State == OperationState.Canceled && string.IsNullOrWhiteSpace(payload.CanceledBy))
+        if (payload.Action is null)
         {
-            throw new ProtocolValidationException("canceledBy is required when state is Canceled.");
+            throw new ProtocolValidationException("action is required for operation status events.");
+        }
+
+        if (payload.State == OperationState.Completed && payload.Result is null)
+        {
+            throw new ProtocolValidationException("result is required when state is Completed.");
+        }
+
+        if (payload.State != OperationState.Completed && payload.Result is not null)
+        {
+            throw new ProtocolValidationException("result is only allowed when state is Completed.");
         }
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/ProtocolValidation.cs
@@ -48,7 +48,7 @@ public static class ProtocolValidation
     {
         if (payload.ProgressPercent is < 0 or > 100)
         {
-            throw new ProtocolValidationException("progressPercent must be between 0 and 100.");
+            throw new ProtocolValidationException("progressPercent must be between 0 and 100 when provided.");
         }
 
         if (payload.State == OperationState.Failed && string.IsNullOrWhiteSpace(payload.ErrorMessage))

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -26,13 +26,32 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
 
     public bool IsInstalled { get; init; }
 
+    public bool InstallAllowed { get; init; }
+
+    public bool RemoveAllowed { get; init; }
+
+    public string InstallUnavailableReason { get; init; } = string.Empty;
+
+    public string RemoveUnavailableReason { get; init; } = string.Empty;
+
+    public bool CanInstall => InstallAllowed && !IsBusy;
+
+    public bool CanRemove => RemoveAllowed && !IsBusy;
+
     public bool IsBusy
     {
         get => _isBusy;
         set
         {
+            if (_isBusy == value)
+            {
+                return;
+            }
+
             _isBusy = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(CanInstall));
+            OnPropertyChanged(nameof(CanRemove));
         }
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -123,7 +123,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         CancellationToken cancellationToken
     )
     {
-        var terminalStateObserved = false;
+        var completedObserved = false;
         try
         {
             await _operationTracker.TrackAsync(
@@ -131,7 +131,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
                 update =>
                 {
                     ApplyOperationUpdate(item, expectedAction, update);
-                    terminalStateObserved |= IsTerminalState(update.State);
+                    completedObserved |= update.State == OperationState.Completed;
                 },
                 cancellationToken
             );
@@ -146,7 +146,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
             return;
         }
 
-        if (!terminalStateObserved)
+        if (!completedObserved)
         {
             return;
         }
@@ -177,33 +177,18 @@ public sealed class HomeViewModel : INotifyPropertyChanged
     {
         ValidateOperationIdentity(item, expectedAction, update);
 
-        if (update.Result is not null)
+        if (update.State == OperationState.Completed)
         {
-            ApplyAuthoritativeResult(item, update);
+            ApplyAuthoritativeResult(item, update.Result!);
             return;
         }
 
         item.Status = $"{update.State}: {update.Message}";
-
-        if (update.State is OperationState.Failed or OperationState.Canceled)
-        {
-            var details = string.IsNullOrWhiteSpace(update.ErrorMessage)
-                ? update.Message
-                : update.ErrorMessage;
-            WarningBanner = $"Operation for {item.DisplayName} ended with {update.State}: {details}";
-            return;
-        }
-
-        if (update.State is OperationState.Succeeded)
-        {
-            WarningBanner = string.Empty;
-        }
     }
 
-    private void ApplyAuthoritativeResult(UiOptionalInstallItem item, OperationStatusEvent update)
+    private void ApplyAuthoritativeResult(UiOptionalInstallItem item, Result result)
     {
-        var result = update.Result!;
-        var details = string.IsNullOrWhiteSpace(result.Message) ? update.Message : result.Message;
+        var details = string.IsNullOrWhiteSpace(result.Message) ? result.Code : result.Message;
         item.Status = $"{result.Outcome}: {details}";
 
         switch (result.Outcome)
@@ -226,25 +211,19 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         OperationStatusEvent update
     )
     {
-        if (!string.IsNullOrWhiteSpace(update.ItemName) &&
-            !string.Equals(update.ItemName, item.ItemName, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(update.ItemName, item.ItemName, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException(
                 $"Operation status identity mismatch. Expected item '{item.ItemName}', got '{update.ItemName}'."
             );
         }
 
-        if (update.Action is not null && update.Action != expectedAction)
+        if (update.Action != expectedAction)
         {
             throw new InvalidOperationException(
                 $"Operation status action mismatch. Expected '{expectedAction}', got '{update.Action}'."
             );
         }
-    }
-
-    private static bool IsTerminalState(OperationState state)
-    {
-        return state is OperationState.Succeeded or OperationState.Failed or OperationState.Canceled;
     }
 
     private void ApplyItems(IReadOnlyList<OptionalInstallItem> source)

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -5,6 +5,7 @@ using Gorilla.UI.Client;
 using Gorilla.UI.Client.AppCatalog;
 using Gorilla.UI.Core.Models;
 using Gorilla.UI.Core.Services;
+using AppCatalog = Gorilla.UI.Client.AppCatalog;
 
 namespace Gorilla.UI.Core.ViewModels;
 

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
 using Gorilla.UI.Core.Models;
 using Gorilla.UI.Core.Services;
 
@@ -53,6 +54,12 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     public async Task InstallAsync(UiOptionalInstallItem item, CancellationToken cancellationToken)
     {
+        if (!item.CanInstall)
+        {
+            WarningBanner = ActionUnavailableMessage("Install", item.DisplayName, item.InstallUnavailableReason);
+            return;
+        }
+
         item.IsBusy = true;
         try
         {
@@ -66,6 +73,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
             await TrackAndRefreshAsync(
                 item,
                 accepted.OperationId,
+                AppCatalog.Action.Install,
                 streamFailurePrefix: "Install queued, but live status stream failed",
                 cancellationToken
             );
@@ -78,6 +86,12 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     public async Task RemoveAsync(UiOptionalInstallItem item, CancellationToken cancellationToken)
     {
+        if (!item.CanRemove)
+        {
+            WarningBanner = ActionUnavailableMessage("Remove", item.DisplayName, item.RemoveUnavailableReason);
+            return;
+        }
+
         item.IsBusy = true;
         try
         {
@@ -91,6 +105,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
             await TrackAndRefreshAsync(
                 item,
                 accepted.OperationId,
+                AppCatalog.Action.Remove,
                 streamFailurePrefix: "Remove queued, but live status stream failed",
                 cancellationToken
             );
@@ -114,6 +129,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
     private async Task TrackAndRefreshAsync(
         UiOptionalInstallItem item,
         string operationId,
+        AppCatalog.Action expectedAction,
         string streamFailurePrefix,
         CancellationToken cancellationToken
     )
@@ -125,7 +141,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
                 operationId,
                 update =>
                 {
-                    ApplyOperationUpdate(item, update);
+                    ApplyOperationUpdate(item, expectedAction, update);
                     terminalStateObserved |= IsTerminalState(update.State);
                 },
                 cancellationToken
@@ -164,8 +180,20 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         }
     }
 
-    private void ApplyOperationUpdate(UiOptionalInstallItem item, OperationStatusEvent update)
+    private void ApplyOperationUpdate(
+        UiOptionalInstallItem item,
+        AppCatalog.Action expectedAction,
+        OperationStatusEvent update
+    )
     {
+        ValidateOperationIdentity(item, expectedAction, update);
+
+        if (update.Result is not null)
+        {
+            ApplyAuthoritativeResult(item, update);
+            return;
+        }
+
         item.Status = $"{update.State}: {update.Message}";
 
         if (update.State is OperationState.Failed or OperationState.Canceled)
@@ -180,6 +208,48 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         if (update.State is OperationState.Succeeded)
         {
             WarningBanner = string.Empty;
+        }
+    }
+
+    private void ApplyAuthoritativeResult(UiOptionalInstallItem item, OperationStatusEvent update)
+    {
+        var result = update.Result!;
+        var details = string.IsNullOrWhiteSpace(result.Message) ? update.Message : result.Message;
+        item.Status = $"{result.Outcome}: {details}";
+
+        switch (result.Outcome)
+        {
+            case Outcome.Succeeded:
+            case Outcome.AlreadySatisfied:
+                WarningBanner = string.Empty;
+                break;
+            case Outcome.Failed:
+            case Outcome.Unverified:
+            case Outcome.Interrupted:
+                WarningBanner = $"Operation for {item.DisplayName} ended with {result.Outcome}: {details}";
+                break;
+        }
+    }
+
+    private static void ValidateOperationIdentity(
+        UiOptionalInstallItem item,
+        AppCatalog.Action expectedAction,
+        OperationStatusEvent update
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(update.ItemName) &&
+            !string.Equals(update.ItemName, item.ItemName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Operation status identity mismatch. Expected item '{item.ItemName}', got '{update.ItemName}'."
+            );
+        }
+
+        if (update.Action is not null && update.Action != expectedAction)
+        {
+            throw new InvalidOperationException(
+                $"Operation status action mismatch. Expected '{expectedAction}', got '{update.Action}'."
+            );
         }
     }
 
@@ -200,8 +270,19 @@ public sealed class HomeViewModel : INotifyPropertyChanged
                 Version = item.Version,
                 Status = item.Status.ToString(),
                 IsInstalled = item.IsInstalled,
+                InstallAllowed = item.Actions?.Install.Allowed ?? false,
+                RemoveAllowed = item.Actions?.Remove.Allowed ?? false,
+                InstallUnavailableReason = item.Actions?.Install.Reason ?? "Refresh required before installing.",
+                RemoveUnavailableReason = item.Actions?.Remove.Reason ?? "Refresh required before removing.",
             });
         }
+    }
+
+    private static string ActionUnavailableMessage(string action, string displayName, string reason)
+    {
+        return string.IsNullOrWhiteSpace(reason)
+            ? $"{action} is not available for {displayName}."
+            : $"{action} is not available for {displayName}: {reason}";
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -55,12 +55,6 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     public async Task InstallAsync(UiOptionalInstallItem item, CancellationToken cancellationToken)
     {
-        if (!item.CanInstall)
-        {
-            WarningBanner = ActionUnavailableMessage("Install", item.DisplayName, item.InstallUnavailableReason);
-            return;
-        }
-
         item.IsBusy = true;
         try
         {
@@ -87,12 +81,6 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     public async Task RemoveAsync(UiOptionalInstallItem item, CancellationToken cancellationToken)
     {
-        if (!item.CanRemove)
-        {
-            WarningBanner = ActionUnavailableMessage("Remove", item.DisplayName, item.RemoveUnavailableReason);
-            return;
-        }
-
         item.IsBusy = true;
         try
         {
@@ -277,13 +265,6 @@ public sealed class HomeViewModel : INotifyPropertyChanged
                 RemoveUnavailableReason = item.Actions?.Remove.Reason ?? "Refresh required before removing.",
             });
         }
-    }
-
-    private static string ActionUnavailableMessage(string action, string displayName, string reason)
-    {
-        return string.IsNullOrWhiteSpace(reason)
-            ? $"{action} is not available for {displayName}."
-            : $"{action} is not available for {displayName}: {reason}";
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
@@ -5,6 +5,7 @@ namespace Gorilla.UI.App.WindowsUiTests;
 public sealed class CriticalPathTests
 {
     private const string FixtureItemName = "Ps1V1";
+    private const string FailureFixtureItemName = "Ps1Failure";
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
@@ -43,6 +44,29 @@ public sealed class CriticalPathTests
             Assert.False(home.HasOperationFailureText());
             Assert.DoesNotContain("failed", home.WarningText, StringComparison.OrdinalIgnoreCase);
             session.CaptureCheckpoint("after-remove");
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void DeliberateInstallerFailureIsDisplayedAsFailure()
+    {
+        RunWithDiagnostics(nameof(DeliberateInstallerFailureIsDisplayedAsFailure), session =>
+        {
+            var home = new HomePageDriver(session);
+
+            Assert.Equal("Available Software", home.Heading.Name);
+            _ = home.WaitForItem(FailureFixtureItemName);
+            home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled");
+            session.CaptureCheckpoint("failure-before-install", includeAutomationTree: true);
+
+            home.InstallButton(FailureFixtureItemName).Invoke();
+
+            home.WaitForWarningContaining("ended with Failed", TimeSpan.FromSeconds(60));
+            Assert.Contains("Intentional App Catalog E2E installer failure", home.WarningText, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Succeeded", home.WarningText, StringComparison.OrdinalIgnoreCase);
+            home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
+            session.CaptureCheckpoint("failure-after-install", includeAutomationTree: true);
         });
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
@@ -63,7 +63,7 @@ public sealed class CriticalPathTests
             home.InstallButton(FailureFixtureItemName).Invoke();
 
             home.WaitForWarningContaining("ended with Failed", TimeSpan.FromSeconds(60));
-            Assert.Contains("Intentional App Catalog E2E installer failure", home.WarningText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Installation error: exit status 7", home.WarningText, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("Succeeded", home.WarningText, StringComparison.OrdinalIgnoreCase);
             home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
             session.CaptureCheckpoint("failure-after-install", includeAutomationTree: true);

--- a/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Client.Tests/ContractsSmokeTests.cs
@@ -15,11 +15,13 @@ public class ContractsSmokeTests
     }
 
     [Fact]
-    public void OperationState_HasTerminalValues()
+    public void OperationState_UsesCompletedAsSoleTerminalState()
     {
-        Assert.Contains(OperationState.Succeeded, Enum.GetValues<OperationState>());
-        Assert.Contains(OperationState.Failed, Enum.GetValues<OperationState>());
-        Assert.Contains(OperationState.Canceled, Enum.GetValues<OperationState>());
+        var states = Enum.GetValues<OperationState>();
+        Assert.Contains(OperationState.Completed, states);
+        Assert.DoesNotContain("Succeeded", states.Select(state => state.ToString()));
+        Assert.DoesNotContain("Failed", states.Select(state => state.ToString()));
+        Assert.DoesNotContain("Canceled", states.Select(state => state.ToString()));
     }
 
     [Fact]
@@ -100,7 +102,6 @@ public class ContractsSmokeTests
         );
 
         var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateEnvelopeHeader(envelope));
-
         Assert.Contains("Unsupported operation", ex.Message);
     }
 
@@ -110,64 +111,41 @@ public class ContractsSmokeTests
         var payload = new OperationStatusEventPayload(
             State: OperationState.Downloading,
             ProgressPercent: 101,
-            Message: "Downloading package"
+            Message: "Downloading package",
+            ItemName: "Example",
+            Action: Gorilla.UI.Client.AppCatalog.Action.Install
         );
 
         var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
-
         Assert.Contains("progressPercent", ex.Message);
     }
 
     [Fact]
     public void ValidateOperationAccepted_RejectsMissingOperationIdWhenAccepted()
     {
-        var payload = new OperationAcceptedResponse(
-            Accepted: true,
-            QueuedAtUtc: DateTimeOffset.Parse("2026-02-14T18:10:00Z")
-        );
-
-        var ex = Assert.Throws<ProtocolValidationException>(
-            () => ProtocolValidation.ValidateOperationAccepted(string.Empty, payload)
-        );
-
+        var payload = new OperationAcceptedResponse(true, DateTimeOffset.Parse("2026-02-14T18:10:00Z"));
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateOperationAccepted(string.Empty, payload));
         Assert.Contains("operationId", ex.Message);
     }
 
     [Fact]
     public void ValidateOperationAccepted_RejectsMissingQueuedAtUtcWhenAccepted()
     {
-        var payload = new OperationAcceptedResponse(
-            Accepted: true,
-            QueuedAtUtc: default
-        );
-
-        var ex = Assert.Throws<ProtocolValidationException>(
-            () => ProtocolValidation.ValidateOperationAccepted("op-1", payload)
-        );
-
+        var payload = new OperationAcceptedResponse(true, default);
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateOperationAccepted("op-1", payload));
         Assert.Contains("queuedAtUtc", ex.Message);
     }
 
     [Fact]
     public void ValidateOperationAccepted_AllowsCompleteAcceptedResponse()
     {
-        var payload = new OperationAcceptedResponse(
-            Accepted: true,
-            QueuedAtUtc: DateTimeOffset.Parse("2026-02-14T18:10:00Z")
-        );
-
-        ProtocolValidation.ValidateOperationAccepted("op-1", payload);
+        ProtocolValidation.ValidateOperationAccepted("op-1", new OperationAcceptedResponse(true, DateTimeOffset.Parse("2026-02-14T18:10:00Z")));
     }
 
     [Fact]
     public void ValidateOperationAccepted_AllowsRejectedResponseWithoutOperationMetadata()
     {
-        var payload = new OperationAcceptedResponse(
-            Accepted: false,
-            QueuedAtUtc: default
-        );
-
-        ProtocolValidation.ValidateOperationAccepted(string.Empty, payload);
+        ProtocolValidation.ValidateOperationAccepted(string.Empty, new OperationAcceptedResponse(false, default));
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Client.Tests/OperationStatusContractTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Client.Tests/OperationStatusContractTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using Xunit;
+
+namespace Gorilla.UI.Client.Tests;
+
+public class OperationStatusContractTests
+{
+    [Fact]
+    public void StatusEvent_AllowsOmittedProgressForIndeterminateWork()
+    {
+        const string json = """
+        {
+          "state":"Installing",
+          "message":"Installing item via managed run",
+          "itemName":"Example",
+          "action":"Install"
+        }
+        """;
+
+        var payload = JsonSerializer.Deserialize<OperationStatusEventPayload>(json, ProtocolJson.Options)!;
+
+        ProtocolValidation.ValidateStatusEvent(payload);
+        Assert.Null(payload.ProgressPercent);
+        Assert.Equal("Example", payload.ItemName);
+        Assert.Equal(Gorilla.UI.Client.AppCatalog.Action.Install, payload.Action);
+    }
+
+    [Fact]
+    public void StatusEvent_DeserializesStructuredTerminalResult()
+    {
+        const string json = """
+        {
+          "state":"Failed",
+          "message":"Operation failed",
+          "errorCode":"postcondition_failed",
+          "errorMessage":"Installed state did not satisfy the selected requirement",
+          "itemName":"Example",
+          "action":"Install",
+          "result":{
+            "outcome":"Failed",
+            "code":"postcondition_failed",
+            "detailCode":"version_requirement_unsatisfied",
+            "message":"Installed state did not satisfy the selected requirement"
+          }
+        }
+        """;
+
+        var payload = JsonSerializer.Deserialize<OperationStatusEventPayload>(json, ProtocolJson.Options)!;
+
+        ProtocolValidation.ValidateStatusEvent(payload);
+        Assert.Null(payload.ProgressPercent);
+        Assert.Equal("Example", payload.ItemName);
+        Assert.Equal(Gorilla.UI.Client.AppCatalog.Action.Install, payload.Action);
+        Assert.NotNull(payload.Result);
+        Assert.Equal(Outcome.Failed, payload.Result!.Outcome);
+        Assert.Equal("postcondition_failed", payload.Result.Code);
+        Assert.Equal("version_requirement_unsatisfied", payload.Result.DetailCode);
+    }
+
+    [Fact]
+    public void StatusEvent_RejectsOutOfRangeMeasuredProgress()
+    {
+        var payload = new OperationStatusEventPayload(
+            State: OperationState.Downloading,
+            ProgressPercent: 101,
+            Message: "Downloading package"
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
+
+        Assert.Contains("progressPercent", ex.Message);
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.Client.Tests/OperationStatusContractTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Client.Tests/OperationStatusContractTests.cs
@@ -25,17 +25,16 @@ public class OperationStatusContractTests
         Assert.Null(payload.ProgressPercent);
         Assert.Equal("Example", payload.ItemName);
         Assert.Equal(Gorilla.UI.Client.AppCatalog.Action.Install, payload.Action);
+        Assert.Null(payload.Result);
     }
 
     [Fact]
-    public void StatusEvent_DeserializesStructuredTerminalResult()
+    public void StatusEvent_DeserializesStructuredCompletedResult()
     {
         const string json = """
         {
-          "state":"Failed",
-          "message":"Operation failed",
-          "errorCode":"postcondition_failed",
-          "errorMessage":"Installed state did not satisfy the selected requirement",
+          "state":"Completed",
+          "message":"Installed state did not satisfy the selected requirement",
           "itemName":"Example",
           "action":"Install",
           "result":{
@@ -51,6 +50,7 @@ public class OperationStatusContractTests
 
         ProtocolValidation.ValidateStatusEvent(payload);
         Assert.Null(payload.ProgressPercent);
+        Assert.Equal(OperationState.Completed, payload.State);
         Assert.Equal("Example", payload.ItemName);
         Assert.Equal(Gorilla.UI.Client.AppCatalog.Action.Install, payload.Action);
         Assert.NotNull(payload.Result);
@@ -65,11 +65,93 @@ public class OperationStatusContractTests
         var payload = new OperationStatusEventPayload(
             State: OperationState.Downloading,
             ProgressPercent: 101,
-            Message: "Downloading package"
+            Message: "Downloading package",
+            ItemName: "Example",
+            Action: Gorilla.UI.Client.AppCatalog.Action.Install
         );
 
         var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
 
         Assert.Contains("progressPercent", ex.Message);
+    }
+
+    [Fact]
+    public void StatusEvent_RejectsMissingItemIdentity()
+    {
+        var payload = new OperationStatusEventPayload(
+            State: OperationState.Installing,
+            ProgressPercent: null,
+            Message: "Installing",
+            Action: Gorilla.UI.Client.AppCatalog.Action.Install
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
+
+        Assert.Contains("itemName", ex.Message);
+    }
+
+    [Fact]
+    public void StatusEvent_RejectsMissingActionIdentity()
+    {
+        var payload = new OperationStatusEventPayload(
+            State: OperationState.Installing,
+            ProgressPercent: null,
+            Message: "Installing",
+            ItemName: "Example"
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
+
+        Assert.Contains("action", ex.Message);
+    }
+
+    [Fact]
+    public void StatusEvent_RejectsCompletedWithoutResult()
+    {
+        var payload = new OperationStatusEventPayload(
+            State: OperationState.Completed,
+            ProgressPercent: null,
+            Message: "Done",
+            ItemName: "Example",
+            Action: Gorilla.UI.Client.AppCatalog.Action.Install
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
+
+        Assert.Contains("result is required", ex.Message);
+    }
+
+    [Fact]
+    public void StatusEvent_RejectsResultBeforeCompleted()
+    {
+        var payload = new OperationStatusEventPayload(
+            State: OperationState.Installing,
+            ProgressPercent: null,
+            Message: "Installing",
+            ItemName: "Example",
+            Action: Gorilla.UI.Client.AppCatalog.Action.Install,
+            Result: new Result(Outcome.Succeeded, "completed")
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
+
+        Assert.Contains("only allowed", ex.Message);
+    }
+
+    [Fact]
+    public void StatusEvent_RejectsCompletedResultWithoutCode()
+    {
+        var payload = new OperationStatusEventPayload(
+            State: OperationState.Completed,
+            ProgressPercent: null,
+            Message: "Done",
+            ItemName: "Example",
+            Action: Gorilla.UI.Client.AppCatalog.Action.Install,
+            Result: new Result(Outcome.Succeeded, "")
+        );
+
+        var ex = Assert.Throws<ProtocolValidationException>(() => ProtocolValidation.ValidateStatusEvent(payload));
+
+        Assert.Contains("result.code", ex.Message);
     }
 }

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
@@ -1,10 +1,12 @@
 using System.Runtime.CompilerServices;
 using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
 using Gorilla.UI.Core;
 using Gorilla.UI.Core.Models;
 using Gorilla.UI.Core.Services;
 using Gorilla.UI.Core.ViewModels;
 using Xunit;
+using AppCatalog = Gorilla.UI.Client.AppCatalog;
 
 namespace Gorilla.UI.Core.Tests;
 
@@ -16,7 +18,6 @@ public class HomeViewModelMutationTests
     public void WarningBanner_InitiallyEmpty()
     {
         var viewModel = CreateViewModel(new FakeClient());
-
         Assert.Equal(string.Empty, viewModel.WarningBanner);
     }
 
@@ -26,24 +27,17 @@ public class HomeViewModelMutationTests
         var viewModel = CreateViewModel(new FakeClient());
         var propertyNames = new List<string?>();
         viewModel.PropertyChanged += (_, args) => propertyNames.Add(args.PropertyName);
-
         viewModel.SetWarningBanner("service unavailable");
-
         Assert.Contains(nameof(HomeViewModel.WarningBanner), propertyNames);
     }
 
     [Fact]
     public async Task InstallAsync_RejectedOperation_DoesNotTrackOrRefresh()
     {
-        var client = new FakeClient
-        {
-            InstallAsync = (_, _) => Task.FromResult(new OperationAccepted("op-1", false, Now)),
-        };
+        var client = new FakeClient { InstallAsync = (_, _) => Task.FromResult(new OperationAccepted("op-1", false, Now)) };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
-
         await viewModel.InstallAsync(item, CancellationToken.None);
-
         Assert.False(item.IsBusy);
         Assert.Equal("Install was not accepted for VLC.", viewModel.WarningBanner);
         Assert.Equal(0, client.StreamCalls);
@@ -53,15 +47,10 @@ public class HomeViewModelMutationTests
     [Fact]
     public async Task RemoveAsync_RejectedOperation_DoesNotTrackOrRefresh()
     {
-        var client = new FakeClient
-        {
-            RemoveAsync = (_, _) => Task.FromResult(new OperationAccepted("op-2", false, Now)),
-        };
+        var client = new FakeClient { RemoveAsync = (_, _) => Task.FromResult(new OperationAccepted("op-2", false, Now)) };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC", installed: true);
-
         await viewModel.RemoveAsync(item, CancellationToken.None);
-
         Assert.False(item.IsBusy);
         Assert.Equal("Remove was not accepted for VLC.", viewModel.WarningBanner);
         Assert.Equal(0, client.StreamCalls);
@@ -76,20 +65,16 @@ public class HomeViewModelMutationTests
         var client = new FakeClient
         {
             InstallAsync = (_, _) => Task.FromResult(new OperationAccepted("op-1", true, Now)),
-            StreamAsync = (_, _) => BlockingTerminalStream(streamStarted, releaseStream, OperationState.Succeeded),
+            StreamAsync = (_, _) => BlockingCompletedStream(streamStarted, releaseStream, AppCatalog.Action.Install),
             ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([]),
         };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
-
         var installTask = viewModel.InstallAsync(item, CancellationToken.None);
         await streamStarted.Task;
-
         Assert.True(item.IsBusy);
-
         releaseStream.TrySetResult(true);
         await installTask;
-
         Assert.False(item.IsBusy);
     }
 
@@ -101,20 +86,16 @@ public class HomeViewModelMutationTests
         var client = new FakeClient
         {
             RemoveAsync = (_, _) => Task.FromResult(new OperationAccepted("op-2", true, Now)),
-            StreamAsync = (_, _) => BlockingTerminalStream(streamStarted, releaseStream, OperationState.Succeeded),
+            StreamAsync = (_, _) => BlockingCompletedStream(streamStarted, releaseStream, AppCatalog.Action.Remove),
             ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([]),
         };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC", installed: true);
-
         var removeTask = viewModel.RemoveAsync(item, CancellationToken.None);
         await streamStarted.Task;
-
         Assert.True(item.IsBusy);
-
         releaseStream.TrySetResult(true);
         await removeTask;
-
         Assert.False(item.IsBusy);
     }
 
@@ -128,9 +109,7 @@ public class HomeViewModelMutationTests
         };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC", installed: true);
-
         await viewModel.RemoveAsync(item, CancellationToken.None);
-
         Assert.Contains("Remove queued, but live status stream failed:", viewModel.WarningBanner);
         Assert.Contains("pipe closed", viewModel.WarningBanner);
         Assert.Equal(0, client.ListCalls);
@@ -140,13 +119,9 @@ public class HomeViewModelMutationTests
     [Fact]
     public async Task FindItem_NoMatch_ReturnsNull()
     {
-        var client = new FakeClient
-        {
-            ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([MakeProtocolItem("GoogleChrome", false)]),
-        };
+        var client = new FakeClient { ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([MakeProtocolItem("GoogleChrome", false)]) };
         var viewModel = CreateViewModel(client);
         await viewModel.InitializeAsync(CancellationToken.None);
-
         Assert.Null(viewModel.FindItem("VLC"));
     }
 
@@ -163,14 +138,11 @@ public class HomeViewModelMutationTests
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
         viewModel.SetWarningBanner("existing warning");
-
         var installTask = viewModel.InstallAsync(item, cancellation.Token);
         await updateApplied.Task;
-
         Assert.Equal("Installing: Copying files", item.Status);
         Assert.Equal("existing warning", viewModel.WarningBanner);
         Assert.Equal(0, client.ListCalls);
-
         cancellation.Cancel();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => installTask);
     }
@@ -181,42 +153,34 @@ public class HomeViewModelMutationTests
         var client = new FakeClient
         {
             InstallAsync = (_, _) => Task.FromResult(new OperationAccepted("op-1", true, Now)),
-            StreamAsync = (_, _) => Stream(
-                new OperationStatusEvent("op-1", OperationState.Failed, 40, "Install failed", Now, "installer_failed", "exit code 1")
-            ),
+            StreamAsync = (_, _) => Stream(CompletedEvent(AppCatalog.Action.Install, Outcome.Failed, "execution_failed", "exit code 1")),
             ListAsync = _ => Task.FromException<IReadOnlyList<OptionalInstallItem>>(new IOException("refresh unavailable")),
         };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
-
         await viewModel.InstallAsync(item, CancellationToken.None);
-
         Assert.Equal("Operation for VLC ended with Failed: exit code 1", viewModel.WarningBanner);
         Assert.Equal(1, client.ListCalls);
     }
 
     [Theory]
-    [InlineData(OperationState.Failed, "Install failed", "exit code 1", "Operation for VLC ended with Failed: exit code 1")]
-    [InlineData(OperationState.Canceled, "Canceled by user", "", "Operation for VLC ended with Canceled: Canceled by user")]
-    public async Task InstallAsync_FailedOrCanceledOperation_UsesErrorMessageWithMessageFallback(
-        OperationState state,
+    [InlineData(Outcome.Failed, "execution_failed", "exit code 1", "Operation for VLC ended with Failed: exit code 1")]
+    [InlineData(Outcome.Interrupted, "execution_interrupted", "Canceled by service", "Operation for VLC ended with Interrupted: Canceled by service")]
+    public async Task InstallAsync_UnsuccessfulOutcome_UsesStructuredResult(
+        Outcome outcome,
+        string code,
         string message,
-        string errorMessage,
         string expectedWarning)
     {
         var client = new FakeClient
         {
             InstallAsync = (_, _) => Task.FromResult(new OperationAccepted("op-1", true, Now)),
-            StreamAsync = (_, _) => Stream(
-                new OperationStatusEvent("op-1", state, 100, message, Now, "operation_error", errorMessage)
-            ),
+            StreamAsync = (_, _) => Stream(CompletedEvent(AppCatalog.Action.Install, outcome, code, message)),
             ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([]),
         };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
-
         await viewModel.InstallAsync(item, CancellationToken.None);
-
         Assert.Equal(expectedWarning, viewModel.WarningBanner);
     }
 
@@ -232,11 +196,9 @@ public class HomeViewModelMutationTests
         };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
-
         var installTask = viewModel.InstallAsync(item, cancellation.Token);
         await streamStarted.Task;
         cancellation.Cancel();
-
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => installTask);
         Assert.False(item.IsBusy);
         Assert.Equal(0, client.ListCalls);
@@ -250,9 +212,7 @@ public class HomeViewModelMutationTests
         var client = new FakeClient
         {
             InstallAsync = (_, _) => Task.FromResult(new OperationAccepted("op-1", true, Now)),
-            StreamAsync = (_, _) => Stream(
-                new OperationStatusEvent("op-1", OperationState.Succeeded, 100, "Installed", Now)
-            ),
+            StreamAsync = (_, _) => Stream(CompletedEvent(AppCatalog.Action.Install, Outcome.Succeeded, "completed", "Installed")),
             ListAsync = async token =>
             {
                 refreshStarted.TrySetResult(true);
@@ -262,11 +222,9 @@ public class HomeViewModelMutationTests
         };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
-
         var installTask = viewModel.InstallAsync(item, cancellation.Token);
         await refreshStarted.Task;
         cancellation.Cancel();
-
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => installTask);
         Assert.False(item.IsBusy);
         Assert.Equal(1, client.ListCalls);
@@ -278,8 +236,7 @@ public class HomeViewModelMutationTests
         return new HomeViewModel(client, coordinator, new OperationTracker(client));
     }
 
-    private static TaskCompletionSource<bool> NewSignal() =>
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static TaskCompletionSource<bool> NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private static UiOptionalInstallItem MakeUiItem(string itemName, bool installed = false) => new()
     {
@@ -291,19 +248,13 @@ public class HomeViewModelMutationTests
     };
 
     private static OptionalInstallItem MakeProtocolItem(string itemName, bool installed) => new(
-        itemName,
-        itemName,
-        "1.0.0",
-        "testcatalog",
-        "nupkg",
-        itemName,
-        $"packages/{itemName}/{itemName}.nupkg",
-        true,
-        installed,
-        installed ? OptionalInstallStatus.Installed : OptionalInstallStatus.NotInstalled,
-        Now,
-        null
+        itemName, itemName, "1.0.0", "testcatalog", "nupkg", itemName,
+        $"packages/{itemName}/{itemName}.nupkg", true, installed,
+        installed ? OptionalInstallStatus.Installed : OptionalInstallStatus.NotInstalled, Now, null
     );
+
+    private static OperationStatusEvent CompletedEvent(AppCatalog.Action action, Outcome outcome, string code, string message) =>
+        new("op-1", OperationState.Completed, null, message, Now, "VLC", action, new Result(outcome, code, Message: message));
 
     private static async IAsyncEnumerable<OperationStatusEvent> Stream(params OperationStatusEvent[] events)
     {
@@ -314,21 +265,21 @@ public class HomeViewModelMutationTests
         }
     }
 
-    private static async IAsyncEnumerable<OperationStatusEvent> BlockingTerminalStream(
+    private static async IAsyncEnumerable<OperationStatusEvent> BlockingCompletedStream(
         TaskCompletionSource<bool> started,
         TaskCompletionSource<bool> release,
-        OperationState terminalState)
+        AppCatalog.Action action)
     {
         started.TrySetResult(true);
         await release.Task;
-        yield return new OperationStatusEvent("op", terminalState, 100, "done", Now);
+        yield return CompletedEvent(action, Outcome.Succeeded, "completed", "done");
     }
 
     private static async IAsyncEnumerable<OperationStatusEvent> ActiveNonTerminalStream(
         TaskCompletionSource<bool> updateApplied,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        yield return new OperationStatusEvent("op-1", OperationState.Installing, 50, "Copying files", Now);
+        yield return new OperationStatusEvent("op-1", OperationState.Installing, null, "Copying files", Now, "VLC", AppCatalog.Action.Install);
         updateApplied.TrySetResult(true);
         await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
     }
@@ -354,9 +305,7 @@ public class HomeViewModelMutationTests
     private sealed class InMemoryCacheStore : IOptionalInstallsCacheStore
     {
         private OptionalInstallsCacheDocument? _document;
-
         public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken) => Task.FromResult(_document);
-
         public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
         {
             _document = document;
@@ -370,19 +319,15 @@ public class HomeViewModelMutationTests
         public Func<string, CancellationToken, Task<OperationAccepted>> InstallAsync { get; init; } = (_, _) => Task.FromResult(new OperationAccepted("op-install", true, Now));
         public Func<string, CancellationToken, Task<OperationAccepted>> RemoveAsync { get; init; } = (_, _) => Task.FromResult(new OperationAccepted("op-remove", true, Now));
         public Func<string, CancellationToken, IAsyncEnumerable<OperationStatusEvent>> StreamAsync { get; init; } = (_, _) => Stream();
-
         public int ListCalls { get; private set; }
         public int StreamCalls { get; private set; }
-
         public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
         {
             ListCalls++;
             return ListAsync(cancellationToken);
         }
-
         public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken) => InstallAsync(itemName, cancellationToken);
         public Task<OperationAccepted> RemoveItemAsync(string itemName, CancellationToken cancellationToken) => RemoveAsync(itemName, cancellationToken);
-
         public IAsyncEnumerable<OperationStatusEvent> StreamOperationStatusAsync(string operationId, CancellationToken cancellationToken)
         {
             StreamCalls++;

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelOperationResultTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelOperationResultTests.cs
@@ -1,0 +1,229 @@
+using System.Runtime.CompilerServices;
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using Gorilla.UI.Core;
+using Gorilla.UI.Core.Models;
+using Gorilla.UI.Core.Services;
+using Gorilla.UI.Core.ViewModels;
+using Xunit;
+using AppCatalog = Gorilla.UI.Client.AppCatalog;
+
+namespace Gorilla.UI.Core.Tests;
+
+public class HomeViewModelOperationResultTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-09-09T19:45:00Z");
+
+    [Theory]
+    [InlineData(Outcome.Succeeded, OperationState.Succeeded, "Succeeded: Installed", "")]
+    [InlineData(Outcome.AlreadySatisfied, OperationState.Succeeded, "AlreadySatisfied: Already installed", "")]
+    [InlineData(Outcome.Failed, OperationState.Failed, "Failed: Installer exited with code 1", "Operation for VLC ended with Failed: Installer exited with code 1")]
+    [InlineData(Outcome.Unverified, OperationState.Failed, "Unverified: Unable to confirm installed state", "Operation for VLC ended with Unverified: Unable to confirm installed state")]
+    [InlineData(Outcome.Interrupted, OperationState.Canceled, "Interrupted: Service operation was interrupted", "Operation for VLC ended with Interrupted: Service operation was interrupted")]
+    public async Task InstallAsync_UsesAuthoritativeOutcomeInsteadOfCompatibilityState(
+        Outcome outcome,
+        OperationState compatibilityState,
+        string expectedStatus,
+        string expectedWarning)
+    {
+        var resultMessage = outcome switch
+        {
+            Outcome.Succeeded => "Installed",
+            Outcome.AlreadySatisfied => "Already installed",
+            Outcome.Failed => "Installer exited with code 1",
+            Outcome.Unverified => "Unable to confirm installed state",
+            Outcome.Interrupted => "Service operation was interrupted",
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
+        };
+
+        var client = new FakeClient
+        {
+            StreamAsync = (_, _) => Stream(new OperationStatusEvent(
+                OperationId: "op-1",
+                State: compatibilityState,
+                ProgressPercent: null,
+                Message: "compatibility message",
+                TimestampUtc: Now,
+                ItemName: "VLC",
+                Action: AppCatalog.Action.Install,
+                Result: new Result(outcome, OutcomeCode(outcome), Message: resultMessage)
+            )),
+        };
+        var viewModel = CreateViewModel(client);
+        var item = MakeUiItem();
+
+        await viewModel.InstallAsync(item, CancellationToken.None);
+
+        Assert.Equal(expectedStatus, item.Status);
+        Assert.Equal(expectedWarning, viewModel.WarningBanner);
+    }
+
+    [Fact]
+    public async Task InstallAsync_RejectsMismatchedStreamIdentityAsStatusFailure()
+    {
+        var client = new FakeClient
+        {
+            StreamAsync = (_, _) => Stream(new OperationStatusEvent(
+                OperationId: "op-1",
+                State: OperationState.Succeeded,
+                ProgressPercent: null,
+                Message: "Installed",
+                TimestampUtc: Now,
+                ItemName: "DifferentItem",
+                Action: AppCatalog.Action.Install,
+                Result: new Result(Outcome.Succeeded, "completed", Message: "Installed")
+            )),
+        };
+        var viewModel = CreateViewModel(client);
+        var item = MakeUiItem();
+
+        await viewModel.InstallAsync(item, CancellationToken.None);
+
+        Assert.Contains("Install queued, but live status stream failed", viewModel.WarningBanner);
+        Assert.Contains("identity mismatch", viewModel.WarningBanner);
+        Assert.Equal(0, client.ListCalls);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_UsesServiceOwnedActionAvailability()
+    {
+        var client = new FakeClient
+        {
+            ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([
+                MakeProtocolItem(
+                    install: new ActionDecision(false, "Already selected for installation"),
+                    remove: new ActionDecision(true, "")
+                )
+            ]),
+        };
+        var viewModel = CreateViewModel(client);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var item = Assert.Single(viewModel.Items);
+        Assert.False(item.InstallAllowed);
+        Assert.False(item.CanInstall);
+        Assert.Equal("Already selected for installation", item.InstallUnavailableReason);
+        Assert.True(item.RemoveAllowed);
+        Assert.True(item.CanRemove);
+
+        item.IsBusy = true;
+        Assert.False(item.CanInstall);
+        Assert.False(item.CanRemove);
+
+        item.IsBusy = false;
+        Assert.False(item.CanInstall);
+        Assert.True(item.CanRemove);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_MissingActionPolicyDoesNotGuessAvailability()
+    {
+        var item = MakeProtocolItem(
+            install: new ActionDecision(true, ""),
+            remove: new ActionDecision(false, "Not installed")
+        ) with { Actions = null };
+        var client = new FakeClient
+        {
+            ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([item]),
+        };
+        var viewModel = CreateViewModel(client);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var uiItem = Assert.Single(viewModel.Items);
+        Assert.False(uiItem.CanInstall);
+        Assert.False(uiItem.CanRemove);
+        Assert.Equal("Refresh required before installing.", uiItem.InstallUnavailableReason);
+        Assert.Equal("Refresh required before removing.", uiItem.RemoveUnavailableReason);
+    }
+
+    private static string OutcomeCode(Outcome outcome) => outcome switch
+    {
+        Outcome.Succeeded => "completed",
+        Outcome.AlreadySatisfied => "already_satisfied",
+        Outcome.Failed => "execution_failed",
+        Outcome.Unverified => "verification_unavailable",
+        Outcome.Interrupted => "interrupted",
+        _ => "unknown",
+    };
+
+    private static HomeViewModel CreateViewModel(FakeClient client)
+    {
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new InMemoryCacheStore());
+        return new HomeViewModel(client, coordinator, new OperationTracker(client));
+    }
+
+    private static UiOptionalInstallItem MakeUiItem() => new()
+    {
+        ItemName = "VLC",
+        DisplayName = "VLC",
+        Version = "1.0",
+        Status = "NotInstalled",
+        IsInstalled = false,
+        InstallAllowed = true,
+        RemoveAllowed = false,
+    };
+
+    private static OptionalInstallItem MakeProtocolItem(ActionDecision install, ActionDecision remove) => new(
+        ItemName: "VLC",
+        DisplayName: "VLC",
+        Version: "1.0",
+        Catalog: "test",
+        InstallerType: "msi",
+        InstallerPackageId: "VLC",
+        InstallerLocation: "vlc.msi",
+        IsManaged: true,
+        IsInstalled: true,
+        Status: OptionalInstallStatus.Installed,
+        StatusUpdatedAtUtc: Now,
+        LastOperationId: null,
+        Actions: new Actions(install, remove)
+    );
+
+    private static async IAsyncEnumerable<OperationStatusEvent> Stream(params OperationStatusEvent[] events)
+    {
+        foreach (var update in events)
+        {
+            await Task.Yield();
+            yield return update;
+        }
+    }
+
+    private sealed class InMemoryCacheStore : IOptionalInstallsCacheStore
+    {
+        private OptionalInstallsCacheDocument? _document;
+
+        public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken) => Task.FromResult(_document);
+
+        public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
+        {
+            _document = document;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeClient : IGorillaServiceClient
+    {
+        public Func<CancellationToken, Task<IReadOnlyList<OptionalInstallItem>>> ListAsync { get; init; } = _ =>
+            Task.FromResult<IReadOnlyList<OptionalInstallItem>>([]);
+        public Func<string, CancellationToken, IAsyncEnumerable<OperationStatusEvent>> StreamAsync { get; init; } = (_, _) => Stream();
+
+        public int ListCalls { get; private set; }
+
+        public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
+        {
+            ListCalls++;
+            return ListAsync(cancellationToken);
+        }
+
+        public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken) =>
+            Task.FromResult(new OperationAccepted("op-1", true, Now));
+
+        public Task<OperationAccepted> RemoveItemAsync(string itemName, CancellationToken cancellationToken) =>
+            Task.FromResult(new OperationAccepted("op-2", true, Now));
+
+        public IAsyncEnumerable<OperationStatusEvent> StreamOperationStatusAsync(string operationId, CancellationToken cancellationToken) =>
+            StreamAsync(operationId, cancellationToken);
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelOperationResultTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelOperationResultTests.cs
@@ -15,14 +15,13 @@ public class HomeViewModelOperationResultTests
     private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-09-09T19:45:00Z");
 
     [Theory]
-    [InlineData(Outcome.Succeeded, OperationState.Succeeded, "Succeeded: Installed", "")]
-    [InlineData(Outcome.AlreadySatisfied, OperationState.Succeeded, "AlreadySatisfied: Already installed", "")]
-    [InlineData(Outcome.Failed, OperationState.Failed, "Failed: Installer exited with code 1", "Operation for VLC ended with Failed: Installer exited with code 1")]
-    [InlineData(Outcome.Unverified, OperationState.Failed, "Unverified: Unable to confirm installed state", "Operation for VLC ended with Unverified: Unable to confirm installed state")]
-    [InlineData(Outcome.Interrupted, OperationState.Canceled, "Interrupted: Service operation was interrupted", "Operation for VLC ended with Interrupted: Service operation was interrupted")]
-    public async Task InstallAsync_UsesAuthoritativeOutcomeInsteadOfCompatibilityState(
+    [InlineData(Outcome.Succeeded, "Succeeded: Installed", "")]
+    [InlineData(Outcome.AlreadySatisfied, "AlreadySatisfied: Already installed", "")]
+    [InlineData(Outcome.Failed, "Failed: Installer exited with code 1", "Operation for VLC ended with Failed: Installer exited with code 1")]
+    [InlineData(Outcome.Unverified, "Unverified: Unable to confirm installed state", "Operation for VLC ended with Unverified: Unable to confirm installed state")]
+    [InlineData(Outcome.Interrupted, "Interrupted: Service operation was interrupted", "Operation for VLC ended with Interrupted: Service operation was interrupted")]
+    public async Task InstallAsync_UsesAuthoritativeOutcome(
         Outcome outcome,
-        OperationState compatibilityState,
         string expectedStatus,
         string expectedWarning)
     {
@@ -40,9 +39,9 @@ public class HomeViewModelOperationResultTests
         {
             StreamAsync = (_, _) => Stream(new OperationStatusEvent(
                 OperationId: "op-1",
-                State: compatibilityState,
+                State: OperationState.Completed,
                 ProgressPercent: null,
-                Message: "compatibility message",
+                Message: resultMessage,
                 TimestampUtc: Now,
                 ItemName: "VLC",
                 Action: AppCatalog.Action.Install,
@@ -65,7 +64,7 @@ public class HomeViewModelOperationResultTests
         {
             StreamAsync = (_, _) => Stream(new OperationStatusEvent(
                 OperationId: "op-1",
-                State: OperationState.Succeeded,
+                State: OperationState.Completed,
                 ProgressPercent: null,
                 Message: "Installed",
                 TimestampUtc: Now,
@@ -81,6 +80,32 @@ public class HomeViewModelOperationResultTests
 
         Assert.Contains("Install queued, but live status stream failed", viewModel.WarningBanner);
         Assert.Contains("identity mismatch", viewModel.WarningBanner);
+        Assert.Equal(0, client.ListCalls);
+    }
+
+    [Fact]
+    public async Task InstallAsync_RejectsMismatchedStreamActionAsStatusFailure()
+    {
+        var client = new FakeClient
+        {
+            StreamAsync = (_, _) => Stream(new OperationStatusEvent(
+                OperationId: "op-1",
+                State: OperationState.Completed,
+                ProgressPercent: null,
+                Message: "Installed",
+                TimestampUtc: Now,
+                ItemName: "VLC",
+                Action: AppCatalog.Action.Remove,
+                Result: new Result(Outcome.Succeeded, "completed", Message: "Installed")
+            )),
+        };
+        var viewModel = CreateViewModel(client);
+        var item = MakeUiItem();
+
+        await viewModel.InstallAsync(item, CancellationToken.None);
+
+        Assert.Contains("Install queued, but live status stream failed", viewModel.WarningBanner);
+        Assert.Contains("action mismatch", viewModel.WarningBanner);
         Assert.Equal(0, client.ListCalls);
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
@@ -1,9 +1,11 @@
 using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
 using Gorilla.UI.Core;
 using Gorilla.UI.Core.Models;
 using Gorilla.UI.Core.Services;
 using Gorilla.UI.Core.ViewModels;
 using Xunit;
+using AppCatalog = Gorilla.UI.Client.AppCatalog;
 
 namespace Gorilla.UI.Core.Tests;
 
@@ -52,8 +54,9 @@ public class HomeViewModelTests
         {
             InstallAsync = (itemName, _) => Task.FromResult(new OperationAccepted("op-1", true, Now)),
             StreamAsync = (_, _) => Stream(
-                new OperationStatusEvent("op-1", OperationState.Installing, 50, "Installing", Now),
-                new OperationStatusEvent("op-1", OperationState.Succeeded, 100, "Installed", Now)
+                new OperationStatusEvent("op-1", OperationState.Installing, 50, "Installing", Now, "VLC", AppCatalog.Action.Install),
+                new OperationStatusEvent("op-1", OperationState.Completed, null, "Installed", Now, "VLC", AppCatalog.Action.Install,
+                    new Result(Outcome.Succeeded, "completed", Message: "Installed"))
             ),
             ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([MakeProtocolItem("VLC", true)]),
         };
@@ -80,8 +83,9 @@ public class HomeViewModelTests
         {
             RemoveAsync = (itemName, _) => Task.FromResult(new OperationAccepted("op-2", true, Now)),
             StreamAsync = (_, _) => Stream(
-                new OperationStatusEvent("op-2", OperationState.Removing, 50, "Removing", Now),
-                new OperationStatusEvent("op-2", OperationState.Succeeded, 100, "Removed", Now)
+                new OperationStatusEvent("op-2", OperationState.Removing, 50, "Removing", Now, "VLC", AppCatalog.Action.Remove),
+                new OperationStatusEvent("op-2", OperationState.Completed, null, "Removed", Now, "VLC", AppCatalog.Action.Remove,
+                    new Result(Outcome.Succeeded, "completed", Message: "Removed"))
             ),
             ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([MakeProtocolItem("VLC", false)]),
         };
@@ -106,7 +110,8 @@ public class HomeViewModelTests
         {
             InstallAsync = (itemName, _) => Task.FromResult(new OperationAccepted("op-1", true, Now)),
             StreamAsync = (_, _) => Stream(
-                new OperationStatusEvent("op-1", OperationState.Failed, 40, "Install failed", Now, "installer_failed", "exit code 1")
+                new OperationStatusEvent("op-1", OperationState.Completed, null, "Install failed", Now, "VLC", AppCatalog.Action.Install,
+                    new Result(Outcome.Failed, "execution_failed", "installer_failed", "exit code 1"))
             ),
             ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([MakeProtocolItem("VLC", false)]),
         };
@@ -129,7 +134,8 @@ public class HomeViewModelTests
         {
             InstallAsync = (itemName, _) => Task.FromResult(new OperationAccepted("op-1", true, Now)),
             StreamAsync = (_, _) => Stream(
-                new OperationStatusEvent("op-1", OperationState.Succeeded, 100, "Installed", Now)
+                new OperationStatusEvent("op-1", OperationState.Completed, null, "Installed", Now, "VLC", AppCatalog.Action.Install,
+                    new Result(Outcome.Succeeded, "completed", Message: "Installed"))
             ),
             ListAsync = _ => Task.FromException<IReadOnlyList<OptionalInstallItem>>(new IOException("refresh unavailable")),
         };

--- a/integration/windows/run-ui-e2e.ps1
+++ b/integration/windows/run-ui-e2e.ps1
@@ -184,6 +184,33 @@ function Invoke-TestPhase {
     }
 }
 
+function Get-ManagedRunStartCount {
+    if (-not (Test-Path -LiteralPath $serviceLogPath)) {
+        return 0
+    }
+    return @(
+        Select-String -LiteralPath $serviceLogPath -SimpleMatch "Retrieving manifest:" -ErrorAction SilentlyContinue
+    ).Count
+}
+
+function Wait-ManagedRunStartCount {
+    param(
+        [Parameter(Mandatory)][int]$MinimumCount,
+        [int]$TimeoutSeconds = 30
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $count = Get-ManagedRunStartCount
+        if ($count -ge $MinimumCount) {
+            return
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Timed out waiting for managed run start count $MinimumCount. Actual: $(Get-ManagedRunStartCount)"
+}
+
 function Get-ManagedRunCompletionCount {
     if (-not (Test-Path -LiteralPath $serviceLogPath)) {
         return 0
@@ -228,8 +255,8 @@ function Assert-OneTimeRemovalSurvivesScheduledRun {
     }
 
     # Restart with a short interval so we can observe an actual ticker-triggered
-    # service run using only persisted policy. The immediate startup run happens
-    # first; the second completion after restart is necessarily timer-driven.
+    # service run using only persisted policy. Wait for the immediate startup run
+    # to finish before simulating the out-of-band reinstall.
     Stop-TestServiceProcess
     (Get-Content -LiteralPath $configPath -Raw).Replace("service_interval: 24h", "service_interval: 2s") |
         Set-Content -LiteralPath $configPath -NoNewline
@@ -248,7 +275,20 @@ function Assert-OneTimeRemovalSurvivesScheduledRun {
         throw "Out-of-band Ps1V1 reinstall did not create marker: $markerPath"
     }
 
-    Wait-ManagedRunCompletionCount -MinimumCount ($runsBeforeRestart + 2)
+    # Establish the run-start baseline only after the external reinstall has
+    # completed. Requiring a later start proves that a managed run begins after
+    # the reinstall rather than allowing an already-completed ticker run to
+    # satisfy the assertion.
+    $startsAfterReinstall = Get-ManagedRunStartCount
+    Wait-ManagedRunStartCount -MinimumCount ($startsAfterReinstall + 1)
+
+    # Once that post-reinstall run has definitely started, take a fresh
+    # completion baseline. If it already finished before this read, the next
+    # completion will come from an even later scheduled run; either way the
+    # completion we wait for necessarily occurs after the external reinstall.
+    $completionsAfterObservedStart = Get-ManagedRunCompletionCount
+    Wait-ManagedRunCompletionCount -MinimumCount ($completionsAfterObservedStart + 1)
+
     if (-not (Test-Path -LiteralPath $markerPath)) {
         throw "Scheduled Gorilla run re-enforced a stale App Catalog uninstall after external reinstall"
     }
@@ -261,7 +301,9 @@ function Assert-OneTimeRemovalSurvivesScheduledRun {
         "",
         "Managed runs before service restart: $runsBeforeRestart",
         "Verified startup completion: $($runsBeforeRestart + 1)",
-        "Verified scheduled completion: $($runsBeforeRestart + 2)",
+        "Run starts observed immediately after external reinstall: $startsAfterReinstall",
+        "Run starts after ordering assertion: $(Get-ManagedRunStartCount)",
+        "Completions after observed post-reinstall start: $(Get-ManagedRunCompletionCount)",
         "Marker present after scheduled run: $(Test-Path -LiteralPath $markerPath)"
     ) | Set-Content -LiteralPath (Join-Path $phaseDirectory "lifecycle.txt")
     Copy-PhaseServiceEvidence -PhaseDirectory $phaseDirectory

--- a/integration/windows/run-ui-e2e.ps1
+++ b/integration/windows/run-ui-e2e.ps1
@@ -27,6 +27,7 @@ $configPath = Join-Path $fixtureRoot "configs\ui-e2e.yaml"
 $serviceName = "gorilla-ui-e2e"
 $servicePipeName = "gorilla-ui-e2e"
 $markerPath = "C:\ProgramData\gorilla-it\ps1.txt"
+$failureMarkerPath = "C:\ProgramData\gorilla-it\ps1-failure.txt"
 $appDataPath = "C:\ProgramData\gorilla-ui-e2e"
 $serviceLogPath = Join-Path $appDataPath "gorilla.log"
 $uiCachePath = Join-Path $root "ui-state\optional-installs-cache.json"
@@ -43,10 +44,35 @@ if (-not (Test-Path -LiteralPath $serverExe) -or -not (Test-Path -LiteralPath $c
     }
 }
 
+$failureScriptPath = Join-Path $repoFixtureRoot "packages\scripts\intentional-failure.ps1"
+@'
+Write-Error "Intentional App Catalog E2E installer failure"
+exit 7
+'@ | Set-Content -LiteralPath $failureScriptPath -NoNewline
+$failureScriptHash = (Get-FileHash -LiteralPath $failureScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$catalogRaw = Get-Content -LiteralPath $catalogPath -Raw
+if ($catalogRaw -notmatch '(?m)^Ps1Failure:') {
+    @"
+
+Ps1Failure:
+  display_name: Ps1Failure
+  check:
+    file:
+      - path: '$failureMarkerPath'
+  installer:
+    type: ps1
+    location: packages/scripts/intentional-failure.ps1
+    hash: $failureScriptHash
+  version: 1.0.0
+"@ | Add-Content -LiteralPath $catalogPath -NoNewline
+}
+
 @'
 name: ui-e2e
 optional_installs:
   - Ps1V1
+  - Ps1Failure
 '@ | Set-Content -LiteralPath $manifestPath -NoNewline
 
 function Wait-ServiceState {
@@ -158,6 +184,7 @@ try {
     Remove-TestService
     Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $failureMarkerPath -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath (Split-Path -Parent $uiCachePath) -Recurse -Force -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Path (Split-Path -Parent $configPath), $evidenceRoot -Force | Out-Null
 

--- a/integration/windows/run-ui-e2e.ps1
+++ b/integration/windows/run-ui-e2e.ps1
@@ -30,6 +30,8 @@ $markerPath = "C:\ProgramData\gorilla-it\ps1.txt"
 $failureMarkerPath = "C:\ProgramData\gorilla-it\ps1-failure.txt"
 $appDataPath = "C:\ProgramData\gorilla-ui-e2e"
 $serviceLogPath = Join-Path $appDataPath "gorilla.log"
+$serviceManifestPath = Join-Path $appDataPath "service-manifest.yaml"
+$externalInstallScriptPath = Join-Path $repoFixtureRoot "packages\scripts\marker-install-v1.ps1"
 $uiCachePath = Join-Path $root "ui-state\optional-installs-cache.json"
 $evidenceRoot = Join-Path $root "ui-evidence"
 
@@ -135,8 +137,11 @@ function Copy-PhaseServiceEvidence {
         if (Test-Path -LiteralPath $serviceLogPath) {
             Copy-Item -LiteralPath $serviceLogPath -Destination (Join-Path $PhaseDirectory "gorilla.log") -Force
         }
+        if (Test-Path -LiteralPath $serviceManifestPath) {
+            Copy-Item -LiteralPath $serviceManifestPath -Destination (Join-Path $PhaseDirectory "service-manifest.yaml") -Force
+        }
     } catch {
-        Write-Warning "Unable to copy Gorilla service log: $_"
+        Write-Warning "Unable to copy Gorilla service evidence: $_"
     }
 
     try {
@@ -177,6 +182,89 @@ function Invoke-TestPhase {
         Copy-PhaseServiceEvidence -PhaseDirectory $phaseDirectory
         Remove-Item Env:GORILLA_UI_LOG_PATH -ErrorAction SilentlyContinue
     }
+}
+
+function Get-ManagedRunCompletionCount {
+    if (-not (Test-Path -LiteralPath $serviceLogPath)) {
+        return 0
+    }
+    return @(
+        Select-String -LiteralPath $serviceLogPath -SimpleMatch "Done!" -ErrorAction SilentlyContinue
+    ).Count
+}
+
+function Wait-ManagedRunCompletionCount {
+    param(
+        [Parameter(Mandatory)][int]$MinimumCount,
+        [int]$TimeoutSeconds = 30
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $count = Get-ManagedRunCompletionCount
+        if ($count -ge $MinimumCount) {
+            return
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Timed out waiting for managed run completion count $MinimumCount. Actual: $(Get-ManagedRunCompletionCount)"
+}
+
+function Assert-OneTimeRemovalSurvivesScheduledRun {
+    if (Test-Path -LiteralPath $markerPath) {
+        throw "Expected Ps1V1 to be absent after App Catalog removal before lifecycle validation"
+    }
+    if (-not (Test-Path -LiteralPath $serviceManifestPath)) {
+        throw "Expected service-managed manifest after App Catalog mutation: $serviceManifestPath"
+    }
+
+    $persistentManifest = Get-Content -LiteralPath $serviceManifestPath -Raw
+    if ($persistentManifest -match '(?m)^\s*uninstalls\s*:') {
+        throw "App Catalog removal persisted an uninstall policy: $serviceManifestPath"
+    }
+    if ($persistentManifest -match '(?m)^\s*-\s*Ps1V1\s*$') {
+        throw "Ps1V1 remained in persistent service-managed selections after removal: $serviceManifestPath"
+    }
+
+    # Restart with a short interval so we can observe an actual ticker-triggered
+    # service run using only persisted policy. The immediate startup run happens
+    # first; the second completion after restart is necessarily timer-driven.
+    Stop-TestServiceProcess
+    (Get-Content -LiteralPath $configPath -Raw).Replace("service_interval: 24h", "service_interval: 2s") |
+        Set-Content -LiteralPath $configPath -NoNewline
+
+    $runsBeforeRestart = Get-ManagedRunCompletionCount
+    & $GorillaExePath -config $configPath -integration-test-service-identity $serviceName -servicestart | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Failed to restart source-built Gorilla service for scheduled-run validation" }
+    Wait-ServiceState -Expected "Running"
+    Wait-ManagedRunCompletionCount -MinimumCount ($runsBeforeRestart + 1)
+
+    if (-not (Test-Path -LiteralPath $externalInstallScriptPath)) {
+        throw "External install fixture not found: $externalInstallScriptPath"
+    }
+    & $externalInstallScriptPath
+    if (-not (Test-Path -LiteralPath $markerPath)) {
+        throw "Out-of-band Ps1V1 reinstall did not create marker: $markerPath"
+    }
+
+    Wait-ManagedRunCompletionCount -MinimumCount ($runsBeforeRestart + 2)
+    if (-not (Test-Path -LiteralPath $markerPath)) {
+        throw "Scheduled Gorilla run re-enforced a stale App Catalog uninstall after external reinstall"
+    }
+
+    $phaseDirectory = Join-Path $evidenceRoot "one-time-removal"
+    New-Item -ItemType Directory -Path $phaseDirectory -Force | Out-Null
+    @(
+        "Persistent manifest after remove:",
+        $persistentManifest.TrimEnd(),
+        "",
+        "Managed runs before service restart: $runsBeforeRestart",
+        "Verified startup completion: $($runsBeforeRestart + 1)",
+        "Verified scheduled completion: $($runsBeforeRestart + 2)",
+        "Marker present after scheduled run: $(Test-Path -LiteralPath $markerPath)"
+    ) | Set-Content -LiteralPath (Join-Path $phaseDirectory "lifecycle.txt")
+    Copy-PhaseServiceEvidence -PhaseDirectory $phaseDirectory
 }
 
 $serverProc = $null
@@ -220,6 +308,7 @@ debug: true
     Wait-ServiceState -Expected "Running"
 
     Invoke-TestPhase -Phase "healthy" -Filter "E2EPhase=Healthy|FullyQualifiedName~AppLaunchSmokeTests"
+    Assert-OneTimeRemovalSurvivesScheduledRun
 
     # The unavailable-service workflow deliberately terminates the real service process.
     # This avoids coupling E2E reliability to graceful SCM shutdown while still proving

--- a/pkg/service/operation_events.go
+++ b/pkg/service/operation_events.go
@@ -23,32 +23,13 @@ func appCatalogAction(action string) appcatalog.Action {
 }
 
 func operationTerminalEvent(itemName, action string, result operationResultPayload) operationStatusEventPayload {
-	state := "Failed"
-	switch result.Outcome {
-	case appcatalog.Succeeded, appcatalog.AlreadySatisfied:
-		state = "Succeeded"
-	case appcatalog.Interrupted:
-		state = "Canceled"
-	}
-
-	event := operationStatusEventPayload{
-		State:    state,
+	return operationStatusEventPayload{
+		State:    "Completed",
 		Message:  result.Message,
 		ItemName: itemName,
 		Action:   appCatalogAction(action),
 		Result:   &result,
 	}
-	if result.Outcome == appcatalog.Failed || result.Outcome == appcatalog.Unverified {
-		event.ErrorCode = result.Code
-		if result.DetailCode != "" {
-			event.ErrorCode = result.DetailCode
-		}
-		event.ErrorMessage = result.Message
-	}
-	if result.Outcome == appcatalog.Interrupted {
-		event.CanceledBy = "service"
-	}
-	return event
 }
 
 func managedRunFailureResult(err error) operationResultPayload {

--- a/pkg/service/operation_events_test.go
+++ b/pkg/service/operation_events_test.go
@@ -17,28 +17,31 @@ func TestOperationTerminalEventCarriesStructuredResultWithoutSyntheticProgress(t
 	}
 	event := operationTerminalEvent("Example", actionInstallItem, result)
 
-	if event.State != "Failed" || event.ItemName != "Example" || event.Action != appcatalog.InstallAction || event.Result == nil {
+	if event.State != "Completed" || event.ItemName != "Example" || event.Action != appcatalog.InstallAction || event.Result == nil {
 		t.Fatalf("terminal event lost operation identity/result: %+v", event)
 	}
 	if event.Result.Outcome != appcatalog.Unverified || event.Result.Code != "verification_unavailable" {
 		t.Fatalf("unexpected structured result: %+v", event.Result)
-	}
-	if event.ErrorCode != "check_failed" {
-		t.Fatalf("legacy error code should preserve actionable detail, got %q", event.ErrorCode)
 	}
 
 	encoded, err := json.Marshal(event)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(encoded), "progressPercent") {
-		t.Fatalf("unmeasured progress must be omitted from transitional v1 event: %s", encoded)
+	encodedText := string(encoded)
+	if strings.Contains(encodedText, "progressPercent") {
+		t.Fatalf("unmeasured progress must be omitted from event: %s", encodedText)
+	}
+	for _, legacyField := range []string{"errorCode", "errorMessage", "canceledBy"} {
+		if strings.Contains(encodedText, legacyField) {
+			t.Fatalf("legacy terminal field %q must not be emitted: %s", legacyField, encodedText)
+		}
 	}
 }
 
-func TestInterruptedOperationMapsToCanceledCompatibilityState(t *testing.T) {
+func TestInterruptedOperationUsesCompletedWithStructuredOutcome(t *testing.T) {
 	event := operationTerminalEvent("Example", actionRemoveItem, interruptedOperationResult())
-	if event.State != "Canceled" || event.CanceledBy != "service" || event.Result == nil || event.Result.Outcome != appcatalog.Interrupted || event.Result.Code != "execution_interrupted" {
+	if event.State != "Completed" || event.Result == nil || event.Result.Outcome != appcatalog.Interrupted || event.Result.Code != "execution_interrupted" {
 		t.Fatalf("unexpected interrupted event: %+v", event)
 	}
 }

--- a/pkg/service/operation_result.go
+++ b/pkg/service/operation_result.go
@@ -86,10 +86,10 @@ func classifyOperationResult(action, itemName string, execution installer.Result
 		switch item.Observation.InstallRequirement {
 		case appcatalog.RequirementSatisfied:
 			if execution.Outcome == installer.OutcomeSucceeded {
-				return operationResultPayload{Outcome: appcatalog.Succeeded, Message: "Install requirement is satisfied"}
+				return operationResultPayload{Outcome: appcatalog.Succeeded, Code: "succeeded", Message: "Install requirement is satisfied"}
 			}
 			if execution.Outcome == installer.OutcomeAlreadyCurrent || execution.Outcome == "" {
-				return operationResultPayload{Outcome: appcatalog.AlreadySatisfied, Message: "Install requirement was already satisfied"}
+				return operationResultPayload{Outcome: appcatalog.AlreadySatisfied, Code: "already_satisfied", Message: "Install requirement was already satisfied"}
 			}
 			return operationResultPayload{Outcome: appcatalog.Unverified, Code: "execution_unknown", Message: "Install requirement is satisfied but execution evidence is unknown"}
 		case appcatalog.RequirementNotSatisfied:
@@ -132,10 +132,10 @@ func classifyOperationResult(action, itemName string, execution installer.Result
 		switch item.Observation.State {
 		case appcatalog.Absent:
 			if execution.Outcome == installer.OutcomeSucceeded {
-				return operationResultPayload{Outcome: appcatalog.Succeeded, Message: "Item is absent and local selection is cleared"}
+				return operationResultPayload{Outcome: appcatalog.Succeeded, Code: "succeeded", Message: "Item is absent and local selection is cleared"}
 			}
 			if execution.Outcome == installer.OutcomeAlreadyCurrent || execution.Outcome == "" {
-				return operationResultPayload{Outcome: appcatalog.AlreadySatisfied, Message: "Item was already absent and local selection is cleared"}
+				return operationResultPayload{Outcome: appcatalog.AlreadySatisfied, Code: "already_satisfied", Message: "Item was already absent and local selection is cleared"}
 			}
 			return operationResultPayload{Outcome: appcatalog.Unverified, Code: "execution_unknown", Message: "Remove postcondition is satisfied but execution evidence is unknown"}
 		case appcatalog.Unknown, appcatalog.DetectionFailed:

--- a/pkg/service/operation_result_test.go
+++ b/pkg/service/operation_result_test.go
@@ -31,6 +31,7 @@ func TestClassifyInstallOperationResult(t *testing.T) {
 			item:      satisfied,
 			selection: selected,
 			want:      appcatalog.Succeeded,
+			wantCode:  "succeeded",
 		},
 		{
 			name:      "already current and verified",
@@ -38,12 +39,14 @@ func TestClassifyInstallOperationResult(t *testing.T) {
 			item:      satisfied,
 			selection: selected,
 			want:      appcatalog.AlreadySatisfied,
+			wantCode:  "already_satisfied",
 		},
 		{
 			name:      "no execution needed and verified",
 			item:      satisfied,
 			selection: selected,
 			want:      appcatalog.AlreadySatisfied,
+			wantCode:  "already_satisfied",
 		},
 		{
 			name:       "execution failure wins over observation",
@@ -133,12 +136,14 @@ func TestClassifyRemoveOperationResult(t *testing.T) {
 			item:      absent,
 			selection: cleared,
 			want:      appcatalog.Succeeded,
+			wantCode:  "succeeded",
 		},
 		{
 			name:      "already absent and forgotten",
 			item:      absent,
 			selection: cleared,
 			want:      appcatalog.AlreadySatisfied,
+			wantCode:  "already_satisfied",
 		},
 		{
 			name:       "absence cannot be established",

--- a/pkg/service/pipe_protocol.go
+++ b/pkg/service/pipe_protocol.go
@@ -71,21 +71,16 @@ type streamOperationStatusAckResponse struct {
 	StreamAccepted bool `json:"streamAccepted"`
 }
 
-// operationStatusEventPayload keeps the v1 envelope during the Stage 3
-// transition, while adding authoritative item/action/result fields. Progress is
-// omitted unless measured so the service no longer emits synthetic milestones;
-// the nullable v2 client representation is activated with the coordinated client
-// protocol transition.
+// operationStatusEventPayload uses state only for lifecycle. Every event carries
+// item/action identity, terminal Completed events carry the authoritative result,
+// and progress is omitted unless it is genuinely measured.
 type operationStatusEventPayload struct {
 	State           string                  `json:"state"`
 	ProgressPercent int                     `json:"progressPercent,omitempty"`
 	Message         string                  `json:"message"`
-	ItemName        string                  `json:"itemName,omitempty"`
-	Action          appcatalog.Action       `json:"action,omitempty"`
+	ItemName        string                  `json:"itemName"`
+	Action          appcatalog.Action       `json:"action"`
 	Result          *operationResultPayload `json:"result,omitempty"`
-	ErrorCode       string                  `json:"errorCode,omitempty"`
-	ErrorMessage    string                  `json:"errorMessage,omitempty"`
-	CanceledBy      string                  `json:"canceledBy,omitempty"`
 }
 
 type errorResponsePayload struct {

--- a/pkg/service/run_item_windows_test.go
+++ b/pkg/service/run_item_windows_test.go
@@ -66,7 +66,7 @@ func TestScheduleRunAfterMutationCarriesVerifiedRequestedItemResult(t *testing.T
 		}
 	}
 	terminal := events[len(events)-1]
-	if terminal.State != "Succeeded" || terminal.Result == nil || terminal.Result.Outcome != appcatalog.Succeeded {
+	if terminal.State != "Completed" || terminal.Result == nil || terminal.Result.Outcome != appcatalog.Succeeded {
 		t.Fatalf("unexpected terminal result: %+v", terminal)
 	}
 }
@@ -121,7 +121,7 @@ func TestExecuteManagedItemOperationSerializesVerificationWithExecution(t *testi
 	}
 }
 
-func TestExecuteManagedItemOperationFallsBackToLegacyManagedRun(t *testing.T) {
+func TestExecuteManagedItemOperationFallsBackToManagedRun(t *testing.T) {
 	cfg := config.Configuration{AppDataPath: t.TempDir()}
 	stubOptionalCatalog(t,
 		[]manifest.Item{{OptionalInstalls: []string{"Example"}}},
@@ -149,7 +149,7 @@ func TestExecuteManagedItemOperationFallsBackToLegacyManagedRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !called {
-		t.Fatal("legacy managed run fallback was not called")
+		t.Fatal("managed run fallback was not called")
 	}
 	if result.Outcome != appcatalog.AlreadySatisfied {
 		t.Fatalf("fallback full run should rely on verified no-op evidence, got %+v", result)

--- a/pkg/service/run_windows.go
+++ b/pkg/service/run_windows.go
@@ -655,7 +655,7 @@ func (sr *serviceRunner) appendOperationEvent(operationID string, event operatio
 	now := time.Now()
 	op.events = append(op.events, event)
 	op.lastUpdated = now
-	if event.State == "Succeeded" || event.State == "Failed" || event.State == "Canceled" {
+	if event.State == "Completed" {
 		op.done = true
 		op.completedAt = now
 	}

--- a/pkg/service/run_windows_test.go
+++ b/pkg/service/run_windows_test.go
@@ -306,7 +306,9 @@ func mustInstallAndGetOperationID(t *testing.T, cfg config.Configuration, seq in
 		RequestID:    fmt.Sprintf("req-install-%d", seq),
 		OperationID:  "",
 		TimestampUTC: nowRFC3339UTC(),
-		Payload: installItemRequest{ItemName: "Slack"},
+		Payload: installItemRequest{
+			ItemName: "Slack",
+		},
 	}
 
 	response := sendOneRequest(t, cfg, request)
@@ -339,7 +341,9 @@ func mustStreamAndReceiveTerminalState(t *testing.T, cfg config.Configuration, o
 	if err != nil {
 		t.Fatalf("failed to open service pipe: %v", err)
 	}
-	defer func() { _ = conn.Close() }()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	request := serviceEnvelope[streamOperationStatusRequest]{
 		Version:      pipeProtocolVersion,
@@ -409,7 +413,9 @@ func sendOneRequest[T any](t *testing.T, cfg config.Configuration, req serviceEn
 	if err != nil {
 		t.Fatalf("failed to open service pipe: %v", err)
 	}
-	defer func() { _ = conn.Close() }()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		t.Fatalf("failed to encode request: %v", err)

--- a/pkg/service/run_windows_test.go
+++ b/pkg/service/run_windows_test.go
@@ -184,11 +184,11 @@ func TestStreamOperationStatusFailedLifecycle(t *testing.T) {
 
 	operationID := mustInstallAndGetOperationID(t, cfg, 0)
 	terminal := mustStreamAndReceiveTerminalState(t, cfg, operationID, 0)
-	if terminal.State != "Failed" {
-		t.Fatalf("expected terminal state Failed, got %s", terminal.State)
+	if terminal.State != "Completed" {
+		t.Fatalf("expected terminal state Completed, got %s", terminal.State)
 	}
-	if terminal.ErrorCode != "managed_run_failed" {
-		t.Fatalf("expected errorCode managed_run_failed, got %s", terminal.ErrorCode)
+	if terminal.Result == nil || terminal.Result.Outcome != appcatalog.Failed || terminal.Result.DetailCode != "managed_run_failed" {
+		t.Fatalf("expected structured managed-run failure, got %+v", terminal.Result)
 	}
 }
 
@@ -203,7 +203,7 @@ func stubOptionalSlack(t *testing.T) {
 	)
 }
 
-func TestScheduleRunAfterMutationEmitsCanceledTerminalEvent(t *testing.T) {
+func TestScheduleRunAfterMutationEmitsInterruptedResult(t *testing.T) {
 	sr := newServiceRunner(config.Configuration{}, func(config.Configuration) error { return nil })
 	operationID := "op-canceled"
 	sr.registerTrackedOperation(operationID)
@@ -222,11 +222,11 @@ func TestScheduleRunAfterMutationEmitsCanceledTerminalEvent(t *testing.T) {
 		t.Fatalf("expected tracked operation to be marked done")
 	}
 	last := events[len(events)-1]
-	if last.State != "Canceled" {
-		t.Fatalf("expected terminal state Canceled, got %s", last.State)
+	if last.State != "Completed" {
+		t.Fatalf("expected terminal state Completed, got %s", last.State)
 	}
-	if last.CanceledBy != "service" {
-		t.Fatalf("expected canceledBy=service, got %s", last.CanceledBy)
+	if last.Result == nil || last.Result.Outcome != appcatalog.Interrupted || last.Result.DetailCode != "service_canceled" {
+		t.Fatalf("expected structured interrupted result, got %+v", last.Result)
 	}
 }
 
@@ -329,8 +329,8 @@ func mustStreamAndReceiveTerminalEvent(t *testing.T, cfg config.Configuration, o
 	t.Helper()
 
 	terminal := mustStreamAndReceiveTerminalState(t, cfg, operationID, seq)
-	if terminal.State != "Succeeded" {
-		t.Fatalf("expected terminal state Succeeded, got %s", terminal.State)
+	if terminal.State != "Completed" || terminal.Result == nil || terminal.Result.Outcome != appcatalog.Succeeded {
+		t.Fatalf("expected completed successful result, got %+v", terminal)
 	}
 }
 
@@ -391,7 +391,7 @@ func mustStreamAndReceiveTerminalState(t *testing.T, cfg config.Configuration, o
 			t.Fatalf("expected stream event operationId=%s, got %s", operationID, event.OperationID)
 		}
 		states = append(states, event.Payload.State)
-		if event.Payload.State == "Succeeded" || event.Payload.State == "Failed" || event.Payload.State == "Canceled" {
+		if event.Payload.State == "Completed" {
 			terminal = event.Payload
 			break
 		}
@@ -444,14 +444,14 @@ func TestTrackedOperationPruningDropsOldCompletedEntries(t *testing.T) {
 	for i := 0; i < trackedOperationsMaxCount+50; i++ {
 		id := fmt.Sprintf("done-%d", i)
 		sr.operations[id] = &trackedOperation{
-			events:      []operationStatusEventPayload{{State: "Succeeded", ProgressPercent: 100, Message: "done"}},
+			events:      []operationStatusEventPayload{{State: "Completed", Message: "done"}},
 			done:        true,
 			lastUpdated: now.Add(-time.Duration(i) * time.Minute),
 			completedAt: now.Add(-time.Duration(i) * time.Minute),
 		}
 	}
 	sr.operations["active-op"] = &trackedOperation{
-		events:      []operationStatusEventPayload{{State: "Installing", ProgressPercent: 60, Message: "running"}},
+		events:      []operationStatusEventPayload{{State: "Installing", Message: "running"}},
 		done:        false,
 		lastUpdated: now,
 	}

--- a/pkg/service/run_windows_test.go
+++ b/pkg/service/run_windows_test.go
@@ -306,9 +306,7 @@ func mustInstallAndGetOperationID(t *testing.T, cfg config.Configuration, seq in
 		RequestID:    fmt.Sprintf("req-install-%d", seq),
 		OperationID:  "",
 		TimestampUTC: nowRFC3339UTC(),
-		Payload: installItemRequest{
-			ItemName: "Slack",
-		},
+		Payload: installItemRequest{ItemName: "Slack"},
 	}
 
 	response := sendOneRequest(t, cfg, request)
@@ -329,7 +327,7 @@ func mustStreamAndReceiveTerminalEvent(t *testing.T, cfg config.Configuration, o
 	t.Helper()
 
 	terminal := mustStreamAndReceiveTerminalState(t, cfg, operationID, seq)
-	if terminal.State != "Completed" || terminal.Result == nil || terminal.Result.Outcome != appcatalog.Succeeded {
+	if terminal.State != "Completed" || terminal.Result == nil || (terminal.Result.Outcome != appcatalog.Succeeded && terminal.Result.Outcome != appcatalog.AlreadySatisfied) {
 		t.Fatalf("expected completed successful result, got %+v", terminal)
 	}
 }
@@ -341,9 +339,7 @@ func mustStreamAndReceiveTerminalState(t *testing.T, cfg config.Configuration, o
 	if err != nil {
 		t.Fatalf("failed to open service pipe: %v", err)
 	}
-	defer func() {
-		_ = conn.Close()
-	}()
+	defer func() { _ = conn.Close() }()
 
 	request := serviceEnvelope[streamOperationStatusRequest]{
 		Version:      pipeProtocolVersion,
@@ -413,9 +409,7 @@ func sendOneRequest[T any](t *testing.T, cfg config.Configuration, req serviceEn
 	if err != nil {
 		t.Fatalf("failed to open service pipe: %v", err)
 	}
-	defer func() {
-		_ = conn.Close()
-	}()
+	defer func() { _ = conn.Close() }()
 
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		t.Fatalf("failed to encode request: %v", err)


### PR DESCRIPTION
Continues #208 Stage 3 after #212 by making the existing C# client/Core/WinUI path consume and present the truthful per-app operation contract emitted by the Go service, and by validating the one-time removal lifecycle through a real scheduled service run.

## What changed

- Preserve indeterminate progress across the client boundary.
  - `progressPercent` is nullable in the wire DTO and public event model.
  - Omitted service progress remains `null` instead of becoming an invented `0%`.
  - Range validation still applies when measured progress is present.
- Make operation status lifecycle and outcome separate concepts.
  - Status `state` is lifecycle-only (`Queued`, in-progress states such as `Installing`/`Removing`, and terminal `Completed`).
  - `Succeeded`, `AlreadySatisfied`, `Failed`, `Unverified`, and `Interrupted` exist only as authoritative `result.outcome` values.
  - The old terminal `Succeeded`/`Failed`/`Canceled` state compatibility path is removed.
  - Status-event `errorCode`, `errorMessage`, and `canceledBy` compatibility fields are removed; structured `result` is the sole terminal truth.
- Require operation identity and a complete structured terminal result.
  - Every streamed status event must carry `itemName` and `action`.
  - `Completed` must carry `result`, including a non-empty stable `result.code`.
  - `result` is rejected on non-completed lifecycle events instead of being ambiguously interpreted.
  - The public C# event model exposes non-null item/action identity only after wire validation.
- Carry structured results through the C# client and Core without fallback inference.
  - `NamedPipeGorillaServiceClient` maps item/action/result into the public event and stops only on `Completed`.
  - Core derives terminal meaning solely from `result.outcome`.
  - `Succeeded` and `AlreadySatisfied` are successful outcomes; `Failed`, `Unverified`, and `Interrupted` remain distinct user-visible outcomes.
  - Item/action identity is checked before applying streamed updates so a mismatched event cannot silently mutate the wrong item UI state.
- Bind the existing UI to service-owned action policy and operation busy state.
  - Install/Remove enablement comes from the `Actions` returned by the service rather than client-side installed-state inference.
  - Both actions are disabled while that item has an in-flight operation.
  - Cached entries without action-policy data remain non-actionable until refreshed instead of guessing policy locally.
- Keep observed state and operation outcome separate.
  - During an operation, the row can show the authoritative terminal outcome.
  - After terminal completion, catalog refresh restores the row to fresh observed state while an operation failure remains visibly reported in the warning banner.
- Extend the real Windows UI fixture with `Ps1Failure`, whose installer deliberately exits non-zero.
  - FlaUI clicks Install through the actual service boundary.
  - The test requires a visible `Failed` result with the concrete `Installation error: exit status 7` detail.
  - It then verifies fresh observation still reports the item `NotInstalled` rather than presenting a failed install as success.
- Validate one-time App Catalog removal across a later scheduled managed run.
  - After the real UI removes `Ps1V1`, the harness verifies the persistent service manifest contains neither the install selection nor an `uninstalls` policy.
  - The service is restarted with a short test-only interval and its immediate startup convergence is allowed to finish.
  - The existing fixture installer is then run directly, outside Gorilla, to simulate an external/manual reinstall.
  - The harness takes its managed-run start baseline only after that reinstall, requires a later timer-triggered run to begin, waits for a completion after that observed start, and verifies the externally reinstalled app remains installed.
  - Lifecycle evidence captures the persistent manifest and run-order counters for diagnosis.

## Deterministic coverage

Client/Core/service tests establish:

- omitted progress remains indeterminate and measured progress is range checked;
- every operation event requires item/action identity;
- only `Completed` may carry `result`, and `Completed` requires a structured result with a stable code;
- legacy terminal state values and duplicate terminal error fields are no longer part of the operation-status contract;
- all five terminal outcomes are interpreted solely from the authoritative result;
- mismatched item or action identity is rejected as a stream/status failure;
- service-owned action availability drives `CanInstall`/`CanRemove` and busy state disables both;
- the service operation tracker treats `Completed` as the terminal lifecycle state;
- named-pipe lifecycle tests assert failure/interruption through structured results;
- repeated successful install requests accept both `Succeeded` and `AlreadySatisfied` as the two successful terminal outcomes.

The Windows UI E2E path establishes:

- successful install/remove convergence through the real UI/service boundary;
- a deliberate installer failure remains visibly failed with concrete execution detail;
- observation refresh does not turn a failed operation into apparent success;
- Remove is one-time: an external reinstall survives a subsequent real timer-triggered managed run.

## Scope

This PR deliberately updates the existing App Catalog UI only enough to consume truthful state/results and expose correct actions. It does not begin the Stage 5 store redesign or Stage 4 reconnect/recovery/deduplication work.

## Validation

Exact head: `9ec983b22df82474bc8e7537d137904ed65c5d0d`

Exact-head workflows:

- Go Tests — run 523 — passed
- UI Client Tests — run 386 — passed
- Windows Integration — run 563 — passed
- Released-Binary Integration — run 424 — running
- Windows UI Tests — run 391 — running

All five exact-head workflows must be green before merge.

Part of #208 Stage 3.