### PR TITLE
Close Stage 4 recovery documentation and boundary coverage

### DIFF
--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -1,6 +1,6 @@
 # Windows service
 
-The [App Catalog contract](../gorilla-ui/docs/app-catalog-contract.md) defines state, action, and CLI changes. Stage 2 keeps the v1 envelope while returning real catalog metadata, shared Go observations, policy, and service-owned allowed actions. The complete v2 operation lifecycle follows in stage 3.
+The [App Catalog contract](../gorilla-ui/docs/app-catalog-contract.md) defines the state, policy, action, and result model used by the live v1 protocol. [App Catalog operation recovery](../gorilla-ui/docs/app-catalog-recovery.md) documents mutation identity, bounded in-memory operation retention, reconnect behavior, and service-restart semantics.
 
 The Gorilla service runs managed application processing on a schedule and exposes a named-pipe endpoint for App Catalog and command-line requests.
 
@@ -32,48 +32,3 @@ gorilla.exe -c C:\ProgramData\gorilla\config.yaml -servicestatus
 gorilla.exe -c C:\ProgramData\gorilla\config.yaml -servicestop
 gorilla.exe -c C:\ProgramData\gorilla\config.yaml -serviceremove
 ```
-
-Run the service loop in the foreground for troubleshooting:
-
-```powershell
-gorilla.exe -c C:\ProgramData\gorilla\config.yaml -service
-```
-
-## Service commands
-
-Use `-S` or `-servicecmd` to communicate with the running service:
-
-```powershell
-gorilla.exe -S ListOptionalInstalls
-gorilla.exe -S InstallItem:VLC
-gorilla.exe -S RemoveItem:VLC
-gorilla.exe -S StreamOperationStatus:<operationId>
-```
-
-Process logs are written to `<app_data_path>\gorilla.log`, which defaults to `%ProgramData%\gorilla\gorilla.log`.
-
-`ListOptionalInstalls` resolves effective optional assignments using manifest and
-catalog precedence. Missing or invalid entries remain visible with an unknown
-state and disabled actions. Detection failures remain distinct from absence.
-Multiple plausible registry substring matches are reported as unknown without
-an installed version instead of exposing a map-order-dependent match.
-`installRequirement` separately carries the selected check's Satisfied or
-NotSatisfied result. This allows script-check items to remain installable without
-claiming that the script proved physical presence or a version. Gorilla's
-script-first check precedence is unchanged.
-`InstallItem` and `RemoveItem` re-resolve policy before changing local selection,
-so the same restrictions apply to App Catalog and direct command-line requests.
-Install authorization validates the complete dependency graph and rejects
-missing or invalid dependencies, cycles, and dependencies assigned to managed
-uninstall. Before each scheduled or requested managed run, the service removes
-local install selections superseded by administrator-managed uninstall policy.
-
-Installing adds a persistent local managed install. Removing clears that
-selection and supplies a service-owned temporary uninstall manifest to the next
-serialized managed run. The temporary manifest is removed after the run and is
-not added to configured local manifests. Old `managed_uninstalls` written inside
-`service-manifest.yaml` are cleared when the service starts; administrator-owned
-managed uninstalls in other manifests are unchanged. This automatic migration
-prevents an old UI removal request from repeatedly uninstalling software. If the
-service-owned manifest cannot be read, parsed, or rewritten, startup stops with
-the manifest path, reason for the migration, and underlying filesystem/YAML error.

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -32,3 +32,48 @@ gorilla.exe -c C:\ProgramData\gorilla\config.yaml -servicestatus
 gorilla.exe -c C:\ProgramData\gorilla\config.yaml -servicestop
 gorilla.exe -c C:\ProgramData\gorilla\config.yaml -serviceremove
 ```
+
+Run the service loop in the foreground for troubleshooting:
+
+```powershell
+gorilla.exe -c C:\ProgramData\gorilla\config.yaml -service
+```
+
+## Service commands
+
+Use `-S` or `-servicecmd` to communicate with the running service:
+
+```powershell
+gorilla.exe -S ListOptionalInstalls
+gorilla.exe -S InstallItem:VLC
+gorilla.exe -S RemoveItem:VLC
+gorilla.exe -S StreamOperationStatus:<operationId>
+```
+
+Process logs are written to `<app_data_path>\gorilla.log`, which defaults to `%ProgramData%\gorilla\gorilla.log`.
+
+`ListOptionalInstalls` resolves effective optional assignments using manifest and
+catalog precedence. Missing or invalid entries remain visible with an unknown
+state and disabled actions. Detection failures remain distinct from absence.
+Multiple plausible registry substring matches are reported as unknown without
+an installed version instead of exposing a map-order-dependent match.
+`installRequirement` separately carries the selected check's Satisfied or
+NotSatisfied result. This allows script-check items to remain installable without
+claiming that the script proved physical presence or a version. Gorilla's
+script-first check precedence is unchanged.
+`InstallItem` and `RemoveItem` re-resolve policy before changing local selection,
+so the same restrictions apply to App Catalog and direct command-line requests.
+Install authorization validates the complete dependency graph and rejects
+missing or invalid dependencies, cycles, and dependencies assigned to managed
+uninstall. Before each scheduled or requested managed run, the service removes
+local install selections superseded by administrator-managed uninstall policy.
+
+Installing adds a persistent local managed install. Removing clears that
+selection and supplies a service-owned temporary uninstall manifest to the next
+serialized managed run. The temporary manifest is removed after the run and is
+not added to configured local manifests. Old `managed_uninstalls` written inside
+`service-manifest.yaml` are cleared when the service starts; administrator-owned
+managed uninstalls in other manifests are unchanged. This automatic migration
+prevents an old UI removal request from repeatedly uninstalling software. If the
+service-owned manifest cannot be read, parsed, or rewritten, startup stops with
+the manifest path, reason for the migration, and underlying filesystem/YAML error.

--- a/gorilla-ui/docs/app-catalog-recovery.md
+++ b/gorilla-ui/docs/app-catalog-recovery.md
@@ -1,0 +1,50 @@
+# App Catalog operation recovery
+
+This document records the Stage 4 recovery decisions for [#208](https://github.com/1dustindavis/gorilla/issues/208).
+
+## Mutation identity and duplicate handling
+
+Install and Remove requests carry a caller-generated `mutationId` that is stable for one logical user action. The service is authoritative for admission:
+
+- the same `mutationId` for the same item/action resolves to the original operation;
+- reusing a `mutationId` for a different item/action is rejected;
+- a different mutation that conflicts with an active operation for the same item is rejected;
+- installer execution remains serialized.
+
+The UI may retry an acknowledgement whose outcome is uncertain, but it must reuse the same `mutationId`. It must not create a new mutation merely because the acknowledgement or connection was lost.
+
+## Operation tracking and retention
+
+Operation tracking is service-process state, independent of page or card instances. The service keeps a bounded in-memory registry of operations and exposes it through `ListOperations` so the UI can recover after navigation, relaunch, or a transient pipe disconnect.
+
+Retention is intentionally bounded:
+
+- at most 512 tracked operations are retained;
+- completed operations expire after 24 hours;
+- active operations are retained while the service process remains alive;
+- pruning also removes the mutation-to-operation admission entry associated with a removed operation.
+
+This registry is not persisted to disk. A service restart therefore ends historical operation tracking and starts with an empty operation registry.
+
+## Service restart semantics
+
+A service restart must not replay an App Catalog operation merely because it was previously active. After restart, Gorilla resumes its normal managed-state convergence from persistent configuration and fresh detection.
+
+That distinction matters for the two mutation types:
+
+- Install persists the user's managed-install selection before execution. A later scheduled or startup convergence may therefore install the app if detection still says work is needed. That is normal desired-state convergence, not replay of the interrupted operation.
+- Remove is one-time behavior. It clears the local install selection and does not persist user-requested managed-uninstall policy, so an interrupted historical Remove is not automatically repeated after restart.
+
+Observed state after restart cannot prove whether the historical operation succeeded or failed. The UI must treat lost tracking as uncertainty, refresh current observed state, and avoid inventing a terminal result.
+
+## Connection recovery
+
+The client tracks operation state independently of catalog card instances. A status stream gets one reconnect attempt per recovery cycle. If both attempts fail, the UI reconciles with `ListOperations`:
+
+- terminal operation found: project the terminal result and refresh catalog state;
+- active operation found: preserve busy state, wait briefly, and begin another bounded recovery cycle;
+- operation no longer retained: report tracking loss separately from installation failure and refresh current observed state.
+
+Catalog refreshes may replace item/card objects, but active operation state is projected back onto the replacement item.
+
+These rules deliberately keep connection/status uncertainty separate from installer failure. A broken status channel does not mean installation failed, and UI cancellation only stops the UI wait; it does not cancel service-side installer work.

--- a/gorilla-ui/docs/app-catalog-recovery.md
+++ b/gorilla-ui/docs/app-catalog-recovery.md
@@ -17,11 +17,11 @@ The UI may retry an acknowledgement whose outcome is uncertain, but it must reus
 
 Operation tracking is service-process state, independent of page or card instances. The service keeps a bounded in-memory registry of operations and exposes it through `ListOperations` so the UI can recover after navigation, relaunch, or a transient pipe disconnect.
 
-Retention is intentionally bounded:
+Retention is intentionally bounded for completed history while preserving all active work:
 
-- at most 512 tracked operations are retained;
-- completed operations expire after 24 hours;
-- active operations are retained while the service process remains alive;
+- completed operations are pruned as needed to target a maximum registry size of 512 entries;
+- completed operations also expire after 24 hours;
+- active operations are never pruned solely to satisfy the 512-entry target and remain retained while the service process is alive, so the registry can temporarily exceed 512 entries if more than 512 operations are simultaneously active;
 - pruning also removes the mutation-to-operation admission entry associated with a removed operation.
 
 This registry is not persisted to disk. A service restart therefore ends historical operation tracking and starts with an empty operation registry.

--- a/pkg/appcatalog/state.go
+++ b/pkg/appcatalog/state.go
@@ -1,5 +1,6 @@
-// Package appcatalog defines the next App Catalog contract and pure decisions.
-// It is not wired into the v1 service; see gorilla-ui/docs/app-catalog-contract.md.
+// Package appcatalog defines App Catalog state, policy, action, and result contracts.
+// These types are used by the live v1 service protocol; see
+// gorilla-ui/docs/app-catalog-contract.md and app-catalog-recovery.md.
 package appcatalog
 
 import "time"
@@ -110,8 +111,8 @@ type Operation struct {
 	Result          *Result        `json:"result"`
 }
 
-// Item is the planned v2 list item. Nil fields serialize as null intentionally
-// so unknown evidence is distinguishable from a supplied value.
+// Item is the App Catalog list item contract. Nil fields serialize as null
+// intentionally so unknown evidence is distinguishable from a supplied value.
 // TargetVersion is catalog display metadata, not a detection or verification
 // threshold. The selected pkg/status check owns version requirements.
 type Item struct {

--- a/pkg/service/operation_recovery_pipe_windows_test.go
+++ b/pkg/service/operation_recovery_pipe_windows_test.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1dustindavis/gorilla/pkg/config"
+)
+
+func TestNamedPipeDuplicateMutationReturnsOriginalOperation(t *testing.T) {
+	stubOptionalSlack(t)
+	cfg := config.Configuration{
+		AppDataPath:     t.TempDir(),
+		ServicePipeName: fmt.Sprintf("gorilla-stage4-recovery-%d", time.Now().UnixNano()),
+		ServiceInterval: "1h",
+		ServiceMode:     true,
+		ServiceName:     "gorilla-test",
+	}
+
+	sr := newServiceRunner(cfg, func(config.Configuration) error { return nil })
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := sr.start(ctx); err != nil {
+		t.Fatalf("service start failed: %v", err)
+	}
+	defer func() {
+		cancel()
+		bestEffortUnblockPipeListener(cfg)
+		sr.stop(context.Background())
+	}()
+
+	const mutationID = "mutation-stage4-recovery"
+	request := func(requestID string) serviceEnvelope[installItemRequest] {
+		return serviceEnvelope[installItemRequest]{
+			Version:      pipeProtocolVersion,
+			MessageType:  messageTypeRequest,
+			Operation:    actionInstallItem,
+			RequestID:    requestID,
+			TimestampUTC: nowRFC3339UTC(),
+			Payload: installItemRequest{
+				ItemName:   "Slack",
+				MutationID: mutationID,
+			},
+		}
+	}
+
+	first := sendOneRequest(t, cfg, request("req-stage4-first"))
+	if first.MessageType != messageTypeResponse {
+		t.Fatalf("first request: expected %s, got %s", messageTypeResponse, first.MessageType)
+	}
+	if strings.TrimSpace(first.OperationID) == "" {
+		t.Fatal("first request returned empty operationId")
+	}
+
+	second := sendOneRequest(t, cfg, request("req-stage4-retry"))
+	if second.MessageType != messageTypeResponse {
+		t.Fatalf("retry request: expected %s, got %s", messageTypeResponse, second.MessageType)
+	}
+	if second.OperationID != first.OperationID {
+		t.Fatalf("retry with same mutationId created a different operation: first=%s retry=%s", first.OperationID, second.OperationID)
+	}
+
+	sr.operationsMu.Lock()
+	trackedCount := len(sr.operations)
+	sr.operationsMu.Unlock()
+	if trackedCount != 1 {
+		t.Fatalf("expected exactly one tracked operation after duplicate mutation, got %d", trackedCount)
+	}
+}


### PR DESCRIPTION
## Summary

- document Stage 4 mutation identity, bounded in-memory operation retention, reconnect behavior, and service-restart semantics
- align App Catalog contract comments and Windows service docs with the live v1 protocol
- add a Windows-only real named-pipe regression test proving a repeated Install request with the same `mutationId` resolves to the original operation instead of creating a second tracked operation

## Why

This closes the remaining Stage 4 documentation and representative real-boundary validation gaps from #208 after #216.

## Validation

The new test runs in the existing Windows Go test path and reuses the real service/named-pipe fixture rather than adding a parallel test harness.