### PR TITLE
Build Core App Catalog presentation model

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -1,64 +1,241 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using CatalogAction = Gorilla.UI.Client.AppCatalog.Action;
 
 namespace Gorilla.UI.Core.Models;
 
+// This is a presentation projection of service-owned catalog and operation truth.
+// It deliberately does not decide whether an action is allowed or derive software
+// state by comparing versions.
 public sealed class UiOptionalInstallItem : INotifyPropertyChanged
 {
-    private string _status = string.Empty;
+    private string _displayName = string.Empty;
+    private string? _description;
+    private string? _targetVersion;
+    private Observation _observation = new(ObservedState.Unknown, null, null, string.Empty, RequirementState.Unknown);
+    private ActionDecision _installDecision = new(false, "Refresh required before installing.");
+    private ActionDecision _removeDecision = new(false, "Refresh required before removing.");
+    private UiOperationPresentation? _activeOperation;
+    private UiOperationPresentation? _latestOperation;
     private bool _isBusy;
+    private string? _legacyStatus;
 
     public required string ItemName { get; init; }
 
-    public required string DisplayName { get; init; }
-
-    public required string Version { get; init; }
-
-    public required string Status
+    public string DisplayName
     {
-        get => _status;
+        get => _displayName;
+        set => SetField(ref _displayName, value);
+    }
+
+    public string? Description
+    {
+        get => _description;
+        set => SetField(ref _description, value);
+    }
+
+    public string? TargetVersion
+    {
+        get => _targetVersion;
         set
         {
-            _status = value;
-            OnPropertyChanged();
+            if (SetField(ref _targetVersion, value))
+            {
+                OnPropertyChanged(nameof(Version));
+            }
         }
     }
 
-    public bool IsInstalled { get; init; }
+    // Compatibility alias for the existing Stage 4 surface. Version is target/offered
+    // metadata, never an inferred installed version.
+    public string Version
+    {
+        get => TargetVersion ?? string.Empty;
+        set => TargetVersion = value;
+    }
 
-    public bool InstallAllowed { get; init; }
+    public Observation Observation
+    {
+        get => _observation;
+        set
+        {
+            if (SetField(ref _observation, value))
+            {
+                _legacyStatus = null;
+                OnPropertyChanged(nameof(ObservedState));
+                OnPropertyChanged(nameof(InstalledVersion));
+                OnPropertyChanged(nameof(IsInstalled));
+                OnPropertyChanged(nameof(Status));
+            }
+        }
+    }
 
-    public bool RemoveAllowed { get; init; }
+    public ObservedState ObservedState => Observation.State;
 
-    public string InstallUnavailableReason { get; init; } = string.Empty;
+    public string? InstalledVersion => Observation.InstalledVersion;
 
-    public string RemoveUnavailableReason { get; init; } = string.Empty;
+    public ActionDecision InstallDecision
+    {
+        get => _installDecision;
+        set
+        {
+            if (SetField(ref _installDecision, value))
+            {
+                OnPropertyChanged(nameof(InstallAllowed));
+                OnPropertyChanged(nameof(InstallUnavailableReason));
+                OnPropertyChanged(nameof(CanInstall));
+            }
+        }
+    }
 
-    public bool CanInstall => InstallAllowed && !IsBusy;
+    public ActionDecision RemoveDecision
+    {
+        get => _removeDecision;
+        set
+        {
+            if (SetField(ref _removeDecision, value))
+            {
+                OnPropertyChanged(nameof(RemoveAllowed));
+                OnPropertyChanged(nameof(RemoveUnavailableReason));
+                OnPropertyChanged(nameof(CanRemove));
+            }
+        }
+    }
 
-    public bool CanRemove => RemoveAllowed && !IsBusy;
+    public bool InstallAllowed
+    {
+        get => InstallDecision.Allowed;
+        set => InstallDecision = InstallDecision with { Allowed = value };
+    }
+
+    public bool RemoveAllowed
+    {
+        get => RemoveDecision.Allowed;
+        set => RemoveDecision = RemoveDecision with { Allowed = value };
+    }
+
+    public string InstallUnavailableReason
+    {
+        get => InstallDecision.Reason;
+        set => InstallDecision = InstallDecision with { Reason = value };
+    }
+
+    public string RemoveUnavailableReason
+    {
+        get => RemoveDecision.Reason;
+        set => RemoveDecision = RemoveDecision with { Reason = value };
+    }
+
+    public UiOperationPresentation? ActiveOperation
+    {
+        get => _activeOperation;
+        set
+        {
+            if (SetField(ref _activeOperation, value))
+            {
+                OnPropertyChanged(nameof(Status));
+            }
+        }
+    }
+
+    // The latest retained terminal operation. This remains separate from both
+    // ActiveOperation and Observation.
+    public UiOperationPresentation? LatestOperation
+    {
+        get => _latestOperation;
+        set
+        {
+            if (SetField(ref _latestOperation, value))
+            {
+                OnPropertyChanged(nameof(Status));
+            }
+        }
+    }
+
+    public bool IsInstalled
+    {
+        get => Observation.State is ObservedState.Installed or ObservedState.UpdateAvailable;
+        // Compatibility for existing callers that construct presentation items
+        // directly. Service snapshots always set Observation instead.
+        set => Observation = Observation with
+        {
+            State = value ? ObservedState.Installed : ObservedState.Absent,
+        };
+    }
+
+    public bool CanInstall => InstallDecision.Allowed && !IsBusy;
+
+    public bool CanRemove => RemoveDecision.Allowed && !IsBusy;
+
+    // Transitional compatibility state for the existing Stage 4 ListView. New UI
+    // should bind the typed Observation/ActiveOperation/LatestOperation properties.
+    public string Status
+    {
+        get => ActiveOperation is not null
+        ? $"{ActiveOperation.State}: {ActiveOperation.Message}"
+        : LatestOperation?.Result is { } result
+            ? $"{result.Outcome}: {OperationDisplay.Details(result)}"
+            : _legacyStatus ?? Observation.State.ToString();
+        set
+        {
+            _legacyStatus = value;
+            OnPropertyChanged();
+        }
+    }
 
     public bool IsBusy
     {
         get => _isBusy;
         set
         {
-            if (_isBusy == value)
+            if (SetField(ref _isBusy, value))
             {
-                return;
+                OnPropertyChanged(nameof(CanInstall));
+                OnPropertyChanged(nameof(CanRemove));
             }
-
-            _isBusy = value;
-            OnPropertyChanged();
-            OnPropertyChanged(nameof(CanInstall));
-            OnPropertyChanged(nameof(CanRemove));
         }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
     }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+
+public sealed record UiOperationPresentation(
+    string OperationId,
+    CatalogAction Action,
+    OperationState State,
+    int? ProgressPercent,
+    Result? Result,
+    string Message,
+    DateTimeOffset TimestampUtc
+)
+{
+    public OperationPhase Phase => State switch
+    {
+        OperationState.Queued => OperationPhase.Queued,
+        OperationState.Completed => OperationPhase.Completed,
+        _ => OperationPhase.Running,
+    };
+}
+
+internal static class OperationDisplay
+{
+    public static string Details(Result result)
+        => string.IsNullOrWhiteSpace(result.Message) ? result.Code : result.Message;
 }

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -21,6 +21,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     private UiOperationPresentation? _latestOperation;
     private bool _isBusy;
     private string? _legacyStatus;
+    private bool _preferObservedStatus;
 
     public required string ItemName { get; init; }
 
@@ -175,13 +176,33 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     {
         get => ActiveOperation is not null
         ? $"{ActiveOperation.State}: {ActiveOperation.Message}"
-        : LatestOperation?.Result is { } result
+        : !_preferObservedStatus && LatestOperation?.Result is { } result
             ? $"{result.Outcome}: {OperationDisplay.Details(result)}"
             : _legacyStatus ?? Observation.State.ToString();
         set
         {
             _legacyStatus = value;
             OnPropertyChanged();
+        }
+    }
+
+    // Keeps the legacy Stage 4 status binding tied to the refreshed catalog
+    // observation while LatestOperation remains available as separate typed state.
+    internal void PreferObservedStatus()
+    {
+        if (!_preferObservedStatus)
+        {
+            _preferObservedStatus = true;
+            OnPropertyChanged(nameof(Status));
+        }
+    }
+
+    internal void PreferOperationStatus()
+    {
+        if (_preferObservedStatus)
+        {
+            _preferObservedStatus = false;
+            OnPropertyChanged(nameof(Status));
         }
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -15,6 +15,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     private string? _description;
     private string? _targetVersion;
     private Observation _observation = new(ObservedState.Unknown, null, null, string.Empty, RequirementState.Unknown);
+    private Policy? _policy;
     private ActionDecision _installDecision = new(false, "Refresh required before installing.");
     private ActionDecision _removeDecision = new(false, "Refresh required before removing.");
     private UiOperationPresentation? _activeOperation;
@@ -76,6 +77,12 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     public ObservedState ObservedState => Observation.State;
 
     public string? InstalledVersion => Observation.InstalledVersion;
+
+    public Policy? Policy
+    {
+        get => _policy;
+        set => SetField(ref _policy, value);
+    }
 
     public ActionDecision InstallDecision
     {

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -178,7 +178,11 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
         ? $"{ActiveOperation.State}: {ActiveOperation.Message}"
         : !_preferObservedStatus && LatestOperation?.Result is { } result
             ? $"{result.Outcome}: {OperationDisplay.Details(result)}"
-            : _legacyStatus ?? Observation.State.ToString();
+            : _legacyStatus ?? Observation.State switch
+            {
+                ObservedState.Absent => "NotInstalled",
+                _ => Observation.State.ToString(),
+            };
         set
         {
             _legacyStatus = value;

--- a/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
@@ -52,8 +52,25 @@ public sealed class OperationTracker
             .Where(operation => operation.State != OperationState.Completed)
             .Where(operation => string.Equals(operation.ItemName, itemName, StringComparison.OrdinalIgnoreCase))
             .OrderByDescending(operation => operation.TimestampUtc)
+            .ThenByDescending(operation => operation.OperationId, StringComparer.Ordinal)
             .FirstOrDefault();
     }
+
+    public OperationStatusEvent? GetLatestTerminalForItem(string itemName)
+    {
+        return _latest.Values
+            .Where(operation => operation.State == OperationState.Completed)
+            .Where(operation => string.Equals(operation.ItemName, itemName, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(operation => operation.TimestampUtc)
+            .ThenByDescending(operation => operation.OperationId, StringComparer.Ordinal)
+            .FirstOrDefault();
+    }
+
+    // This is an item-oriented projection over the operation-ID registry. The
+    // registry itself remains keyed by operation ID so replay and reconciliation
+    // semantics do not depend on catalog objects.
+    public OperationStatusEvent? GetCurrentOrLatestForItem(string itemName)
+        => GetActiveForItem(itemName) ?? GetLatestTerminalForItem(itemName);
 
     public IReadOnlyList<OperationStatusEvent> GetActiveOperations()
     {

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -18,8 +18,11 @@ public sealed class HomeViewModel : INotifyPropertyChanged
     private readonly OptionalInstallsStartupLoader _startupLoader;
     private readonly OperationTracker _operationTracker;
     private readonly ConcurrentDictionary<string, byte> _recoveryTracking = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, UiOptionalInstallItem> _catalogItems = new(StringComparer.OrdinalIgnoreCase);
 
     private string _warningBanner = string.Empty;
+    private string _searchQuery = string.Empty;
+    private string? _selectedItemName;
 
     public HomeViewModel(
         IGorillaServiceClient client,
@@ -34,6 +37,43 @@ public sealed class HomeViewModel : INotifyPropertyChanged
     }
 
     public ObservableCollection<UiOptionalInstallItem> Items { get; } = [];
+
+    // Items is the ordered, searchable presentation projection. _catalogItems is
+    // the canonical catalog and remains the source of selection and reconciliation.
+    public string SearchQuery
+    {
+        get => _searchQuery;
+        set
+        {
+            var normalized = value ?? string.Empty;
+            if (string.Equals(_searchQuery, normalized, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _searchQuery = normalized;
+            OnPropertyChanged();
+            RebuildVisibleItems();
+        }
+    }
+
+    public string? SelectedItemName
+    {
+        get => _selectedItemName;
+        private set
+        {
+            if (string.Equals(_selectedItemName, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _selectedItemName = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(SelectedItem));
+        }
+    }
+
+    public UiOptionalInstallItem? SelectedItem => SelectedItemName is null ? null : FindItem(SelectedItemName);
 
     public string WarningBanner
     {
@@ -58,10 +98,13 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         try
         {
             var operations = await _operationTracker.RefreshKnownOperationsAsync(cancellationToken);
-            foreach (var operation in operations.Where(operation => operation.State != OperationState.Completed))
+            foreach (var operation in operations)
             {
                 ProjectOperation(operation);
-                StartRecoveredTracking(operation, cancellationToken);
+                if (operation.State != OperationState.Completed)
+                {
+                    StartRecoveredTracking(operation, cancellationToken);
+                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -148,7 +191,31 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     public UiOptionalInstallItem? FindItem(string itemName)
     {
+        if (_catalogItems.TryGetValue(itemName, out var item))
+        {
+            return item;
+        }
+
+        // Supports the existing Stage 4 action entry points while callers migrate
+        // from manually supplied list items to canonical catalog state.
         return Items.FirstOrDefault(i => string.Equals(i.ItemName, itemName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public bool SelectItem(string? itemName)
+    {
+        if (string.IsNullOrWhiteSpace(itemName))
+        {
+            SelectedItemName = null;
+            return true;
+        }
+
+        if (!_catalogItems.ContainsKey(itemName))
+        {
+            return false;
+        }
+
+        SelectedItemName = _catalogItems[itemName].ItemName;
+        return true;
     }
 
     public void SetWarningBanner(string message)
@@ -340,21 +407,16 @@ public sealed class HomeViewModel : INotifyPropertyChanged
             return;
         }
 
+        ReprojectOperation(item);
         if (update.State == OperationState.Completed)
         {
-            item.IsBusy = false;
             ApplyAuthoritativeResult(item, update.Result!);
-            return;
         }
-
-        item.IsBusy = true;
-        item.Status = $"{update.State}: {update.Message}";
     }
 
     private void ApplyAuthoritativeResult(UiOptionalInstallItem item, Result result)
     {
-        var details = string.IsNullOrWhiteSpace(result.Message) ? result.Code : result.Message;
-        item.Status = $"{result.Outcome}: {details}";
+        var details = OperationDisplay.Details(result);
 
         switch (result.Outcome)
         {
@@ -393,29 +455,129 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     private void ApplyItems(IReadOnlyList<OptionalInstallItem> source)
     {
-        Items.Clear();
-        foreach (var item in source)
-        {
-            var uiItem = new UiOptionalInstallItem
-            {
-                ItemName = item.ItemName,
-                DisplayName = item.DisplayName,
-                Version = item.Version,
-                Status = item.Status.ToString(),
-                IsInstalled = item.IsInstalled,
-                InstallAllowed = item.Actions?.Install.Allowed ?? false,
-                RemoveAllowed = item.Actions?.Remove.Allowed ?? false,
-                InstallUnavailableReason = item.Actions?.Install.Reason ?? "Refresh required before installing.",
-                RemoveUnavailableReason = item.Actions?.Remove.Reason ?? "Refresh required before removing.",
-            };
-            Items.Add(uiItem);
+        var incoming = source.ToDictionary(item => item.ItemName, StringComparer.OrdinalIgnoreCase);
 
-            var active = _operationTracker.GetActiveForItem(item.ItemName);
-            if (active is not null)
+        foreach (var itemName in _catalogItems.Keys.Where(itemName => !incoming.ContainsKey(itemName)).ToArray())
+        {
+            _catalogItems.Remove(itemName);
+        }
+
+        foreach (var snapshot in incoming.Values)
+        {
+            if (!_catalogItems.TryGetValue(snapshot.ItemName, out var item))
             {
-                ProjectOperation(active);
+                item = new UiOptionalInstallItem { ItemName = snapshot.ItemName };
+                _catalogItems.Add(snapshot.ItemName, item);
+            }
+
+            ApplyCatalogSnapshot(item, snapshot);
+            ReprojectOperation(item);
+        }
+
+        if (SelectedItemName is not null && !_catalogItems.ContainsKey(SelectedItemName))
+        {
+            SelectedItemName = null;
+        }
+        else
+        {
+            OnPropertyChanged(nameof(SelectedItem));
+        }
+
+        RebuildVisibleItems();
+    }
+
+    private static void ApplyCatalogSnapshot(UiOptionalInstallItem item, OptionalInstallItem snapshot)
+    {
+        item.DisplayName = snapshot.DisplayName;
+        item.Description = snapshot.Description;
+        item.TargetVersion = snapshot.TargetVersion ??
+            (string.IsNullOrEmpty(snapshot.Version) ? null : snapshot.Version);
+        item.Observation = snapshot.Observation ?? LegacyObservation(snapshot);
+        item.InstallDecision = snapshot.Actions?.Install ?? new AppCatalog.ActionDecision(false, "Refresh required before installing.");
+        item.RemoveDecision = snapshot.Actions?.Remove ?? new AppCatalog.ActionDecision(false, "Refresh required before removing.");
+    }
+
+    private static AppCatalog.Observation LegacyObservation(OptionalInstallItem item)
+    {
+        var state = item.Status switch
+        {
+            OptionalInstallStatus.Installed => AppCatalog.ObservedState.Installed,
+            OptionalInstallStatus.UpdateAvailable => AppCatalog.ObservedState.UpdateAvailable,
+            OptionalInstallStatus.NotInstalled => AppCatalog.ObservedState.Absent,
+            _ => AppCatalog.ObservedState.Unknown,
+        };
+        return new AppCatalog.Observation(
+            state,
+            InstalledVersion: null,
+            CheckedAtUtc: item.StatusUpdatedAtUtc,
+            DetailCode: string.Empty,
+            InstallRequirement: AppCatalog.RequirementState.Unknown
+        );
+    }
+
+    private void ReprojectOperation(UiOptionalInstallItem item)
+    {
+        var active = _operationTracker.GetActiveForItem(item.ItemName);
+        var latest = _operationTracker.GetLatestTerminalForItem(item.ItemName);
+        item.ActiveOperation = active is null ? null : ToPresentation(active);
+        item.LatestOperation = latest is null ? null : ToPresentation(latest);
+        item.IsBusy = active is not null;
+    }
+
+    private static UiOperationPresentation ToPresentation(OperationStatusEvent operation) => new(
+        operation.OperationId,
+        operation.Action,
+        operation.State,
+        operation.ProgressPercent,
+        operation.Result,
+        operation.Message,
+        operation.TimestampUtc
+    );
+
+    private void RebuildVisibleItems()
+    {
+        var query = SearchQuery;
+        var desired = _catalogItems.Values
+            .Where(item => MatchesSearch(item, query))
+            .OrderBy(item => item.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.ItemName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.ItemName, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var existing in Items.Where(item => !desired.Contains(item)).ToArray())
+        {
+            Items.Remove(existing);
+        }
+
+        for (var index = 0; index < desired.Length; index++)
+        {
+            if (index < Items.Count && ReferenceEquals(Items[index], desired[index]))
+            {
+                continue;
+            }
+
+            var existingIndex = Items.IndexOf(desired[index]);
+            if (existingIndex >= 0)
+            {
+                Items.Move(existingIndex, index);
+            }
+            else
+            {
+                Items.Insert(index, desired[index]);
             }
         }
+    }
+
+    private static bool MatchesSearch(UiOptionalInstallItem item, string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return true;
+        }
+
+        return item.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || item.ItemName.Contains(query, StringComparison.OrdinalIgnoreCase)
+            || (!string.IsNullOrEmpty(item.Description) && item.Description.Contains(query, StringComparison.OrdinalIgnoreCase));
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -407,6 +407,11 @@ public sealed class HomeViewModel : INotifyPropertyChanged
             return;
         }
 
+        if (update.State == OperationState.Completed)
+        {
+            item.PreferOperationStatus();
+        }
+
         ReprojectOperation(item);
         if (update.State == OperationState.Completed)
         {
@@ -472,6 +477,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
             ApplyCatalogSnapshot(item, snapshot);
             ReprojectOperation(item);
+            item.PreferObservedStatus();
         }
 
         if (SelectedItemName is not null && !_catalogItems.ContainsKey(SelectedItemName))

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -209,12 +209,12 @@ public sealed class HomeViewModel : INotifyPropertyChanged
             return true;
         }
 
-        if (!_catalogItems.ContainsKey(itemName))
+        if (!_catalogItems.TryGetValue(itemName, out var item))
         {
             return false;
         }
 
-        SelectedItemName = _catalogItems[itemName].ItemName;
+        SelectedItemName = item.ItemName;
         return true;
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -499,6 +499,7 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         item.TargetVersion = snapshot.TargetVersion ??
             (string.IsNullOrEmpty(snapshot.Version) ? null : snapshot.Version);
         item.Observation = snapshot.Observation ?? LegacyObservation(snapshot);
+        item.Policy = snapshot.Policy;
         item.InstallDecision = snapshot.Actions?.Install ?? new AppCatalog.ActionDecision(false, "Refresh required before installing.");
         item.RemoveDecision = snapshot.Actions?.Remove ?? new AppCatalog.ActionDecision(false, "Refresh required before removing.");
     }

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelCatalogPresentationTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelCatalogPresentationTests.cs
@@ -1,0 +1,298 @@
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using Gorilla.UI.Core;
+using Gorilla.UI.Core.Services;
+using Gorilla.UI.Core.ViewModels;
+using Xunit;
+using AppCatalog = Gorilla.UI.Client.AppCatalog;
+
+namespace Gorilla.UI.Core.Tests;
+
+public class HomeViewModelCatalogPresentationTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-09-11T05:00:00Z");
+
+    [Fact]
+    public async Task InitializeAsync_OrdersItemsDeterministicallyByDisplayNameThenItemName()
+    {
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [[
+                Item("Zulu", "Zulu"), Item("alpha", "alpha"), Item("Beta", "Beta"),
+                Item("z-last", "Same"), Item("A-first", "Same"),
+            ]],
+        });
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal(["alpha", "Beta", "A-first", "z-last", "Zulu"], viewModel.Items.Select(item => item.ItemName));
+    }
+
+    [Fact]
+    public async Task Search_MatchesOnlyDisplayNameItemNameAndDescription()
+    {
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [[
+                Item("GoogleChrome", "Chrome", description: "A secure web browser."),
+                Item("VLC", "Media player", catalog: "browser-only-catalog", installerLocation: "browser.msi"),
+            ]],
+        });
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        viewModel.SearchQuery = "CHROME";
+        Assert.Equal("GoogleChrome", Assert.Single(viewModel.Items).ItemName);
+
+        viewModel.SearchQuery = "secure";
+        Assert.Equal("GoogleChrome", Assert.Single(viewModel.Items).ItemName);
+
+        viewModel.SearchQuery = "browser-only-catalog";
+        Assert.Empty(viewModel.Items);
+
+        viewModel.SearchQuery = "browser.msi";
+        Assert.Empty(viewModel.Items);
+    }
+
+    [Fact]
+    public async Task Refresh_ReconcilesInPlacePreservesQueryAndUpdatesSearchMetadata()
+    {
+        var client = new FakeClient
+        {
+            Catalogs = [
+                [Item("Example", "Old name", description: "Editor", targetVersion: "1.0")],
+                [Item("Example", "New name", description: "Web browser", targetVersion: "2.0", observation: Observation(ObservedState.UpdateAvailable, "1.7"))],
+            ],
+        };
+        var viewModel = CreateViewModel(client);
+        await viewModel.InitializeAsync(CancellationToken.None);
+        var before = Assert.Single(viewModel.Items);
+
+        viewModel.SearchQuery = "browser";
+        Assert.Empty(viewModel.Items);
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var after = Assert.Single(viewModel.Items);
+        Assert.Same(before, after);
+        Assert.Equal("browser", viewModel.SearchQuery);
+        Assert.Equal("New name", after.DisplayName);
+        Assert.Equal("Web browser", after.Description);
+        Assert.Equal("2.0", after.TargetVersion);
+        Assert.Equal("1.7", after.InstalledVersion);
+        Assert.Equal(ObservedState.UpdateAvailable, after.ObservedState);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_KeepsTargetAndInstalledVersionsDistinctIncludingMissingInstalledVersion()
+    {
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example", targetVersion: "2.0", observation: Observation(ObservedState.UpdateAvailable, null))]],
+        });
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var item = Assert.Single(viewModel.Items);
+        Assert.Equal("2.0", item.TargetVersion);
+        Assert.Null(item.InstalledVersion);
+        Assert.Equal(ObservedState.UpdateAvailable, item.ObservedState);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_AllowsMissingTargetVersion()
+    {
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example", targetVersion: null, legacyVersion: "")]],
+        });
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        Assert.Null(Assert.Single(viewModel.Items).TargetVersion);
+    }
+
+    [Fact]
+    public async Task Refresh_AddsAndRemovesItemsAndSelectionUsesCanonicalIdentity()
+    {
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [
+                [Item("Example", "Example"), Item("Gone", "Gone")],
+                [Item("Example", "Example"), Item("New", "New")],
+                [Item("New", "New")],
+            ],
+        });
+        await viewModel.InitializeAsync(CancellationToken.None);
+        Assert.True(viewModel.SelectItem("Example"));
+
+        viewModel.SearchQuery = "new";
+        Assert.Empty(viewModel.Items);
+        Assert.Equal("Example", viewModel.SelectedItemName);
+        Assert.Equal("Example", viewModel.SelectedItem?.ItemName);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+        Assert.Equal(["New"], viewModel.Items.Select(item => item.ItemName));
+        Assert.Equal("Example", viewModel.SelectedItemName);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+        Assert.Null(viewModel.SelectedItemName);
+        Assert.Null(viewModel.SelectedItem);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public async Task InitializeAsync_PreservesBothServiceActionDecisions(bool installAllowed, bool removeAllowed)
+    {
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [[Item(
+                "Example", "Example", observation: Observation(ObservedState.Installed, "1.7"),
+                install: new ActionDecision(installAllowed, "install_reason"),
+                remove: new ActionDecision(removeAllowed, "remove_reason"))]],
+        });
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var item = Assert.Single(viewModel.Items);
+        Assert.Equal(installAllowed, item.InstallDecision.Allowed);
+        Assert.Equal(removeAllowed, item.RemoveDecision.Allowed);
+        Assert.Equal("install_reason", item.InstallDecision.Reason);
+        Assert.Equal("remove_reason", item.RemoveDecision.Reason);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ProjectsActiveOperationSeparatelyFromObservation()
+    {
+        var active = new OperationStatusEvent("op-1", OperationState.Removing, 50, "Removing", Now, "Example", AppCatalog.Action.Remove);
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example", observation: Observation(ObservedState.Installed, "1.7"))]],
+            Operations = [active],
+        });
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var item = Assert.Single(viewModel.Items);
+        Assert.Equal(ObservedState.Installed, item.ObservedState);
+        Assert.Equal("1.7", item.InstalledVersion);
+        Assert.Equal("op-1", item.ActiveOperation?.OperationId);
+        Assert.Equal(AppCatalog.Action.Remove, item.ActiveOperation?.Action);
+        Assert.Equal(OperationState.Removing, item.ActiveOperation?.State);
+        Assert.Null(item.LatestOperation);
+    }
+
+    [Fact]
+    public async Task Refresh_PreservesActiveOperationOnTheReconciledItem()
+    {
+        var active = new OperationStatusEvent("op-1", OperationState.Installing, 30, "Installing", Now, "Example", AppCatalog.Action.Install);
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [
+                [Item("Example", "Example", description: "Old")],
+                [Item("Example", "Example updated", description: "New")],
+            ],
+            Operations = [active],
+        });
+        await viewModel.InitializeAsync(CancellationToken.None);
+        var before = Assert.Single(viewModel.Items);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var after = Assert.Single(viewModel.Items);
+        Assert.Same(before, after);
+        Assert.Equal("Example updated", after.DisplayName);
+        Assert.Equal("op-1", after.ActiveOperation?.OperationId);
+        Assert.Equal(OperationState.Installing, after.ActiveOperation?.State);
+    }
+
+    [Theory]
+    [InlineData(Outcome.Succeeded)]
+    [InlineData(Outcome.Failed)]
+    [InlineData(Outcome.Unverified)]
+    [InlineData(Outcome.Interrupted)]
+    public async Task TerminalOperation_RetainsExactStructuredOutcome(Outcome outcome)
+    {
+        var client = new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example")], [Item("Example", "Example")]],
+            StreamAsync = (_, _) => StatusStream(new OperationStatusEvent(
+                "op-1", OperationState.Completed, null, "Done", Now, "Example", AppCatalog.Action.Install,
+                new Result(outcome, $"{outcome}_code", Message: "Done"))),
+        };
+        var viewModel = CreateViewModel(client);
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        await viewModel.InstallAsync(Assert.Single(viewModel.Items), CancellationToken.None);
+
+        var item = Assert.Single(viewModel.Items);
+        Assert.Null(item.ActiveOperation);
+        Assert.Equal(outcome, item.LatestOperation?.Result?.Outcome);
+        Assert.Equal($"{outcome}_code", item.LatestOperation?.Result?.Code);
+    }
+
+    private static HomeViewModel CreateViewModel(FakeClient client)
+        => new(client, new OptionalInstallsCacheCoordinator(client, new InMemoryCacheStore()), new OperationTracker(client));
+
+    private static OptionalInstallItem Item(
+        string itemName,
+        string displayName,
+        string? description = null,
+        string catalog = "catalog",
+        string installerLocation = "installer.msi",
+        string? targetVersion = "2.0",
+        string legacyVersion = "legacy-version",
+        Observation? observation = null,
+        ActionDecision? install = null,
+        ActionDecision? remove = null)
+        => new(itemName, displayName, legacyVersion, catalog, "msi", "package", installerLocation,
+            true, false, OptionalInstallStatus.NotInstalled, Now, null, targetVersion, observation,
+            Actions: new Actions(install ?? new ActionDecision(true, ""), remove ?? new ActionDecision(false, "not_installed")),
+            Description: description);
+
+    private static Observation Observation(ObservedState state, string? installedVersion)
+        => new(state, installedVersion, Now, "detail_code", RequirementState.Unknown);
+
+    private static async IAsyncEnumerable<OperationStatusEvent> StatusStream(params OperationStatusEvent[] events)
+    {
+        foreach (var operation in events)
+        {
+            await Task.Yield();
+            yield return operation;
+        }
+    }
+
+    private sealed class InMemoryCacheStore : IOptionalInstallsCacheStore
+    {
+        private OptionalInstallsCacheDocument? _document;
+        public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken) => Task.FromResult(_document);
+        public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
+        {
+            _document = document;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeClient : IGorillaServiceClient
+    {
+        private int _catalogCall;
+        public IReadOnlyList<IReadOnlyList<OptionalInstallItem>> Catalogs { get; init; } = [[]];
+        public IReadOnlyList<OperationStatusEvent> Operations { get; init; } = [];
+        public Func<string, CancellationToken, IAsyncEnumerable<OperationStatusEvent>> StreamAsync { get; init; } = (_, _) => StatusStream();
+
+        public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
+        {
+            var index = Math.Min(_catalogCall++, Catalogs.Count - 1);
+            return Task.FromResult(Catalogs[index]);
+        }
+
+        public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken)
+            => Task.FromResult(new OperationAccepted("op-1", true, Now));
+        public Task<OperationAccepted> RemoveItemAsync(string itemName, CancellationToken cancellationToken)
+            => Task.FromResult(new OperationAccepted("op-2", true, Now));
+        public Task<IReadOnlyList<OperationStatusEvent>> ListOperationsAsync(CancellationToken cancellationToken) => Task.FromResult(Operations);
+        public IAsyncEnumerable<OperationStatusEvent> StreamOperationStatusAsync(string operationId, CancellationToken cancellationToken)
+            => StreamAsync(operationId, cancellationToken);
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelCatalogPresentationTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelCatalogPresentationTests.cs
@@ -163,6 +163,31 @@ public class HomeViewModelCatalogPresentationTests
     }
 
     [Fact]
+    public async Task InitializeAsync_PreservesServicePolicyWithoutInference()
+    {
+        var policy = new Policy(
+            Optional: false,
+            RequiredInstall: true,
+            RequiredUninstall: true,
+            RequiredDependency: true,
+            Selection: Selection.Install
+        );
+        var viewModel = CreateViewModel(new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example", policy: policy)]],
+        });
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var item = Assert.Single(viewModel.Items);
+        Assert.Equal(policy, item.Policy);
+        Assert.True(item.Policy!.RequiredInstall);
+        Assert.True(item.Policy.RequiredUninstall);
+        Assert.True(item.Policy.RequiredDependency);
+        Assert.Equal(Selection.Install, item.Policy.Selection);
+    }
+
+    [Fact]
     public async Task InitializeAsync_ProjectsActiveOperationSeparatelyFromObservation()
     {
         var active = new OperationStatusEvent("op-1", OperationState.Removing, 50, "Removing", Now, "Example", AppCatalog.Action.Remove);
@@ -244,10 +269,11 @@ public class HomeViewModelCatalogPresentationTests
         string? targetVersion = "2.0",
         string legacyVersion = "legacy-version",
         Observation? observation = null,
+        Policy? policy = null,
         ActionDecision? install = null,
         ActionDecision? remove = null)
         => new(itemName, displayName, legacyVersion, catalog, "msi", "package", installerLocation,
-            true, false, OptionalInstallStatus.NotInstalled, Now, null, targetVersion, observation,
+            true, false, OptionalInstallStatus.NotInstalled, Now, null, targetVersion, observation, Policy: policy,
             Actions: new Actions(install ?? new ActionDecision(true, ""), remove ?? new ActionDecision(false, "not_installed")),
             Description: description);
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
@@ -73,7 +73,8 @@ public class HomeViewModelTests
         var refreshedItem = Assert.Single(viewModel.Items);
         Assert.Equal("VLC", refreshedItem.ItemName);
         Assert.True(refreshedItem.IsInstalled);
-        Assert.Equal("Installed", refreshedItem.Status);
+        Assert.Equal("Succeeded: Installed", refreshedItem.Status);
+        Assert.Equal(Outcome.Succeeded, refreshedItem.LatestOperation?.Result?.Outcome);
     }
 
     [Fact]
@@ -100,7 +101,8 @@ public class HomeViewModelTests
         var refreshedItem = Assert.Single(viewModel.Items);
         Assert.Equal("VLC", refreshedItem.ItemName);
         Assert.False(refreshedItem.IsInstalled);
-        Assert.Equal("NotInstalled", refreshedItem.Status);
+        Assert.Equal("Succeeded: Removed", refreshedItem.Status);
+        Assert.Equal(Outcome.Succeeded, refreshedItem.LatestOperation?.Result?.Outcome);
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
@@ -73,7 +73,7 @@ public class HomeViewModelTests
         var refreshedItem = Assert.Single(viewModel.Items);
         Assert.Equal("VLC", refreshedItem.ItemName);
         Assert.True(refreshedItem.IsInstalled);
-        Assert.Equal("Succeeded: Installed", refreshedItem.Status);
+        Assert.Equal("Installed", refreshedItem.Status);
         Assert.Equal(Outcome.Succeeded, refreshedItem.LatestOperation?.Result?.Outcome);
     }
 
@@ -101,7 +101,7 @@ public class HomeViewModelTests
         var refreshedItem = Assert.Single(viewModel.Items);
         Assert.Equal("VLC", refreshedItem.ItemName);
         Assert.False(refreshedItem.IsInstalled);
-        Assert.Equal("Succeeded: Removed", refreshedItem.Status);
+        Assert.Equal("NotInstalled", refreshedItem.Status);
         Assert.Equal(Outcome.Succeeded, refreshedItem.LatestOperation?.Result?.Outcome);
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/OperationTrackerRecoveryTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/OperationTrackerRecoveryTests.cs
@@ -51,6 +51,35 @@ public class OperationTrackerRecoveryTests
         Assert.False(tracker.TryGetLatest("op-1", out _));
     }
 
+    [Fact]
+    public async Task ItemLookup_PrefersActiveAndKeepsLatestTerminalSeparate()
+    {
+        var terminal = new OperationStatusEvent(
+            "op-old", OperationState.Completed, null, "Old install", Now, "VLC", AppCatalog.Action.Install,
+            new Result(Outcome.Failed, "execution_failed")
+        );
+        var active = new OperationStatusEvent(
+            "op-current", OperationState.Removing, 50, "Removing", Now.AddSeconds(1), "VLC", AppCatalog.Action.Remove
+        );
+        var other = new OperationStatusEvent(
+            "op-other", OperationState.Installing, null, "Installing", Now.AddSeconds(2), "Other", AppCatalog.Action.Install
+        );
+        var client = new FakeClient
+        {
+            ListOperationsAsyncImpl = _ => Task.FromResult<IReadOnlyList<OperationStatusEvent>>([terminal, active, other]),
+        };
+        var tracker = new OperationTracker(client);
+
+        await tracker.RefreshKnownOperationsAsync(CancellationToken.None);
+
+        Assert.Equal("op-current", tracker.GetCurrentOrLatestForItem("VLC")?.OperationId);
+        Assert.Equal("op-current", tracker.GetActiveForItem("VLC")?.OperationId);
+        Assert.Equal("op-old", tracker.GetLatestTerminalForItem("VLC")?.OperationId);
+        Assert.Equal("op-other", tracker.GetCurrentOrLatestForItem("Other")?.OperationId);
+        Assert.True(tracker.TryGetLatest("op-old", out var byId));
+        Assert.Equal("op-old", byId?.OperationId);
+    }
+
     private static async IAsyncEnumerable<OperationStatusEvent> DroppedStream()
     {
         yield return Event(OperationState.Queued, "Operation queued");


### PR DESCRIPTION
Builds the Stage 5 Core App Catalog presentation model on top of the existing service-authoritative contract.

- Adds keyed catalog reconciliation, deterministic display ordering, local search, and selection identity.
- Projects description, target/installed version data, typed observation, both action decisions, and separate active/latest operation state.
- Adds portable Core coverage for search, refresh, selection, action combinations, version handling, and operation lookup/projection.

This prepares the portable Core state model for the later card-grid and details UI; it does not implement the new WinUI presentation or navigation.

Validation: `make ui-test` could not run in this Linux worktree because no functional .NET SDK was available; Windows validation remains for CI.