### PR TITLE
Build store-style App Catalog grid and search UI

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/Converters/BooleanToVisibilityConverter.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,14 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace Gorilla.UI.App.Converters;
+
+public sealed class BooleanToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+        => value is true ? Visibility.Visible : Visibility.Collapsed;
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
+}

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -131,7 +131,9 @@
                                     Spacing="8"
                                     VerticalAlignment="Center"
                                     Visibility="{Binding CardPresentation.HasOperation, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                    AutomationProperties.AutomationId="CatalogOperation">
+                                    AutomationProperties.AutomationId="CatalogOperation"
+                                    AutomationProperties.Name="{Binding CardPresentation.OperationText}"
+                                    AutomationProperties.LiveSetting="Polite">
                                     <ProgressRing
                                         Width="18"
                                         Height="18"

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -11,7 +11,7 @@
         <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </Page.Resources>
 
-    <Grid Padding="24" RowDefinitions="Auto,Auto,Auto,*">
+    <Grid Padding="20" RowDefinitions="Auto,Auto,Auto,*">
         <TextBlock
             Text="Available Software"
             FontSize="28"
@@ -21,7 +21,7 @@
 
         <TextBox
             Grid.Row="1"
-            Margin="0,16,0,0"
+            Margin="0,12,0,0"
             MaxWidth="520"
             HorizontalAlignment="Left"
             PlaceholderText="Search apps"
@@ -31,7 +31,7 @@
 
         <TextBlock
             Grid.Row="2"
-            Margin="0,12,0,0"
+            Margin="0,10,0,0"
             x:Name="ServiceWarning"
             Text="{Binding WarningBanner}"
             Foreground="DarkOrange"
@@ -39,7 +39,7 @@
             AutomationProperties.AutomationId="ServiceWarning"
             AutomationProperties.LiveSetting="Polite" />
 
-        <Grid Grid.Row="3" Margin="0,20,0,0">
+        <Grid Grid.Row="3" Margin="0,14,0,0">
             <GridView
                 x:Name="CatalogItems"
                 ItemsSource="{Binding Items}"
@@ -54,12 +54,12 @@
                 AutomationProperties.Name="Available software">
                 <GridView.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <ItemsWrapGrid Orientation="Horizontal" ItemWidth="320" />
+                        <ItemsWrapGrid Orientation="Horizontal" ItemWidth="250" />
                     </ItemsPanelTemplate>
                 </GridView.ItemsPanel>
                 <GridView.ItemContainerStyle>
                     <Style TargetType="GridViewItem">
-                        <Setter Property="Margin" Value="0,0,16,16" />
+                        <Setter Property="Margin" Value="0,0,10,10" />
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <Setter Property="VerticalContentAlignment" Value="Stretch" />
                         <Setter Property="AutomationProperties.AutomationId" Value="{Binding ItemName}" />
@@ -69,33 +69,33 @@
                 <GridView.ItemTemplate>
                     <DataTemplate>
                         <Border
-                            Padding="20"
-                            MinHeight="280"
+                            Padding="14"
+                            MinHeight="220"
                             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                             BorderThickness="1"
                             CornerRadius="8"
                             AutomationProperties.AutomationId="CatalogCard"
                             AutomationProperties.Name="{Binding DisplayName}">
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto">
+                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
                                 <Border
-                                    Width="44"
-                                    Height="44"
-                                    CornerRadius="8"
+                                    Width="36"
+                                    Height="36"
+                                    CornerRadius="7"
                                     Background="{ThemeResource AccentFillColorSecondaryBrush}">
                                     <FontIcon
                                         Glyph="&#xE71D;"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                        FontSize="22"
+                                        FontSize="18"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center" />
                                 </Border>
 
                                 <TextBlock
                                     Grid.Row="1"
-                                    Margin="0,14,0,0"
+                                    Margin="0,10,0,0"
                                     Text="{Binding DisplayName}"
-                                    FontSize="18"
+                                    FontSize="16"
                                     FontWeight="SemiBold"
                                     TextWrapping="WrapWholeWords"
                                     MaxLines="2"
@@ -103,7 +103,7 @@
 
                                 <TextBlock
                                     Grid.Row="2"
-                                    Margin="0,6,0,0"
+                                    Margin="0,4,0,0"
                                     Text="{Binding Description}"
                                     TextWrapping="WrapWholeWords"
                                     TextTrimming="CharacterEllipsis"
@@ -112,7 +112,7 @@
                                     Visibility="{Binding CardPresentation.HasDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
                                     AutomationProperties.AutomationId="CatalogDescription" />
 
-                                <StackPanel Grid.Row="3" Margin="0,14,0,0" Spacing="3">
+                                <StackPanel Grid.Row="3" Margin="0,10,0,0" Spacing="2">
                                     <TextBlock
                                         Text="{Binding CardPresentation.ObservationText}"
                                         FontWeight="SemiBold"
@@ -126,17 +126,17 @@
 
                                 <StackPanel
                                     Grid.Row="4"
-                                    Margin="0,12,0,0"
+                                    Margin="0,8,0,0"
                                     Orientation="Horizontal"
-                                    Spacing="8"
+                                    Spacing="6"
                                     VerticalAlignment="Center"
                                     Visibility="{Binding CardPresentation.HasOperation, Converter={StaticResource BooleanToVisibilityConverter}}"
                                     AutomationProperties.AutomationId="CatalogOperation"
                                     AutomationProperties.Name="{Binding CardPresentation.OperationText}"
                                     AutomationProperties.LiveSetting="Polite">
                                     <ProgressRing
-                                        Width="18"
-                                        Height="18"
+                                        Width="16"
+                                        Height="16"
                                         IsActive="{Binding CardPresentation.HasOperation}"
                                         IsIndeterminate="{Binding CardPresentation.IsProgressIndeterminate}"
                                         Value="{Binding CardPresentation.ProgressValue}" />
@@ -145,11 +145,24 @@
                                         VerticalAlignment="Center" />
                                 </StackPanel>
 
+                                <TextBlock
+                                    Grid.Row="5"
+                                    Margin="0,8,0,0"
+                                    Text="{Binding CardPresentation.TerminalFeedbackText}"
+                                    TextWrapping="WrapWholeWords"
+                                    MaxLines="3"
+                                    FontWeight="SemiBold"
+                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                    Visibility="{Binding CardPresentation.HasTerminalFeedback, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    AutomationProperties.AutomationId="CatalogTerminalFeedback"
+                                    AutomationProperties.Name="{Binding CardPresentation.TerminalFeedbackText}"
+                                    AutomationProperties.LiveSetting="Polite" />
+
                                 <StackPanel
-                                    Grid.Row="6"
-                                    Margin="0,18,0,0"
+                                    Grid.Row="7"
+                                    Margin="0,12,0,0"
                                     Orientation="Horizontal"
-                                    Spacing="8">
+                                    Spacing="6">
                                     <Button
                                         Content="{Binding CardPresentation.PrimaryAction.Label}"
                                         Tag="{Binding CardPresentation.PrimaryAction.Kind}"

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -54,7 +54,7 @@
                 AutomationProperties.Name="Available software">
                 <GridView.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <ItemsWrapGrid Orientation="Horizontal" ItemWidth="250" />
+                        <ItemsWrapGrid Orientation="Horizontal" ItemWidth="320" />
                     </ItemsPanelTemplate>
                 </GridView.ItemsPanel>
                 <GridView.ItemContainerStyle>
@@ -70,99 +70,97 @@
                     <DataTemplate>
                         <Border
                             Padding="14"
-                            MinHeight="220"
+                            Height="204"
                             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                             BorderThickness="1"
                             CornerRadius="8"
                             AutomationProperties.AutomationId="CatalogCard"
                             AutomationProperties.Name="{Binding DisplayName}">
-                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
-                                <Border
-                                    Width="36"
-                                    Height="36"
-                                    CornerRadius="7"
-                                    Background="{ThemeResource AccentFillColorSecondaryBrush}">
-                                    <FontIcon
-                                        Glyph="&#xE71D;"
-                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                        FontSize="18"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center" />
-                                </Border>
+                            <Grid RowDefinitions="Auto,Auto,38,*,Auto">
+                                <Grid ColumnDefinitions="Auto,*">
+                                    <Border
+                                        Width="38"
+                                        Height="38"
+                                        CornerRadius="7"
+                                        Background="{ThemeResource AccentFillColorSecondaryBrush}">
+                                        <FontIcon
+                                            Glyph="&#xE71D;"
+                                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                            FontSize="19"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center" />
+                                    </Border>
 
-                                <TextBlock
-                                    Grid.Row="1"
-                                    Margin="0,10,0,0"
-                                    Text="{Binding DisplayName}"
-                                    FontSize="16"
-                                    FontWeight="SemiBold"
-                                    TextWrapping="WrapWholeWords"
-                                    MaxLines="2"
-                                    AutomationProperties.AutomationId="CatalogDisplayName" />
+                                    <TextBlock
+                                        Grid.Column="1"
+                                        Margin="10,0,0,0"
+                                        Text="{Binding DisplayName}"
+                                        FontSize="17"
+                                        FontWeight="SemiBold"
+                                        TextWrapping="WrapWholeWords"
+                                        TextTrimming="CharacterEllipsis"
+                                        MaxLines="2"
+                                        VerticalAlignment="Center"
+                                        AutomationProperties.AutomationId="CatalogDisplayName" />
+                                </Grid>
 
-                                <TextBlock
-                                    Grid.Row="2"
-                                    Margin="0,4,0,0"
-                                    Text="{Binding Description}"
-                                    TextWrapping="WrapWholeWords"
-                                    TextTrimming="CharacterEllipsis"
-                                    MaxLines="2"
-                                    Opacity="0.72"
-                                    Visibility="{Binding CardPresentation.HasDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                    AutomationProperties.AutomationId="CatalogDescription" />
-
-                                <StackPanel Grid.Row="3" Margin="0,10,0,0" Spacing="2">
+                                <StackPanel Grid.Row="1" Margin="0,9,0,0" Spacing="1">
                                     <TextBlock
                                         Text="{Binding CardPresentation.ObservationText}"
+                                        FontSize="14"
                                         FontWeight="SemiBold"
                                         AutomationProperties.AutomationId="CatalogObservation" />
                                     <TextBlock
                                         Text="{Binding CardPresentation.VersionText}"
+                                        FontSize="13"
                                         Opacity="0.68"
                                         Visibility="{Binding CardPresentation.HasVersion, Converter={StaticResource BooleanToVisibilityConverter}}"
                                         AutomationProperties.AutomationId="CatalogVersion" />
                                 </StackPanel>
 
+                                <Grid Grid.Row="2" Margin="0,6,0,0">
+                                    <StackPanel
+                                        Orientation="Horizontal"
+                                        Spacing="6"
+                                        VerticalAlignment="Top"
+                                        Visibility="{Binding CardPresentation.HasOperation, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        AutomationProperties.AutomationId="CatalogOperation"
+                                        AutomationProperties.Name="{Binding CardPresentation.OperationText}"
+                                        AutomationProperties.LiveSetting="Polite">
+                                        <ProgressRing
+                                            Width="15"
+                                            Height="15"
+                                            Margin="0,1,0,0"
+                                            IsActive="{Binding CardPresentation.HasOperation}"
+                                            IsIndeterminate="{Binding CardPresentation.IsProgressIndeterminate}"
+                                            Value="{Binding CardPresentation.ProgressValue}" />
+                                        <TextBlock
+                                            Text="{Binding CardPresentation.OperationText}"
+                                            FontSize="13"
+                                            TextWrapping="WrapWholeWords"
+                                            TextTrimming="CharacterEllipsis"
+                                            MaxLines="2" />
+                                    </StackPanel>
+
+                                    <TextBlock
+                                        Text="{Binding CardPresentation.TerminalFeedbackText}"
+                                        FontSize="13"
+                                        TextWrapping="WrapWholeWords"
+                                        TextTrimming="CharacterEllipsis"
+                                        MaxLines="2"
+                                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                        Visibility="{Binding CardPresentation.HasTerminalFeedback, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        AutomationProperties.AutomationId="CatalogTerminalFeedback"
+                                        AutomationProperties.Name="{Binding CardPresentation.TerminalFeedbackText}"
+                                        AutomationProperties.LiveSetting="Polite" />
+                                </Grid>
+
                                 <StackPanel
                                     Grid.Row="4"
-                                    Margin="0,8,0,0"
                                     Orientation="Horizontal"
                                     Spacing="6"
-                                    VerticalAlignment="Center"
-                                    Visibility="{Binding CardPresentation.HasOperation, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                    AutomationProperties.AutomationId="CatalogOperation"
-                                    AutomationProperties.Name="{Binding CardPresentation.OperationText}"
-                                    AutomationProperties.LiveSetting="Polite">
-                                    <ProgressRing
-                                        Width="16"
-                                        Height="16"
-                                        IsActive="{Binding CardPresentation.HasOperation}"
-                                        IsIndeterminate="{Binding CardPresentation.IsProgressIndeterminate}"
-                                        Value="{Binding CardPresentation.ProgressValue}" />
-                                    <TextBlock
-                                        Text="{Binding CardPresentation.OperationText}"
-                                        VerticalAlignment="Center" />
-                                </StackPanel>
-
-                                <TextBlock
-                                    Grid.Row="5"
-                                    Margin="0,8,0,0"
-                                    Text="{Binding CardPresentation.TerminalFeedbackText}"
-                                    TextWrapping="WrapWholeWords"
-                                    MaxLines="3"
-                                    FontWeight="SemiBold"
-                                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                    Visibility="{Binding CardPresentation.HasTerminalFeedback, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                    AutomationProperties.AutomationId="CatalogTerminalFeedback"
-                                    AutomationProperties.Name="{Binding CardPresentation.TerminalFeedbackText}"
-                                    AutomationProperties.LiveSetting="Polite" />
-
-                                <StackPanel
-                                    Grid.Row="7"
-                                    Margin="0,12,0,0"
-                                    Orientation="Horizontal"
-                                    Spacing="6">
+                                    VerticalAlignment="Bottom">
                                     <Button
                                         Content="{Binding CardPresentation.PrimaryAction.Label}"
                                         Tag="{Binding CardPresentation.PrimaryAction.Kind}"

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -2,11 +2,16 @@
     x:Class="Gorilla.UI.App.Views.HomePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Gorilla.UI.App.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Padding="24" RowDefinitions="Auto,Auto,*">
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Page.Resources>
+
+    <Grid Padding="24" RowDefinitions="Auto,Auto,Auto,*">
         <TextBlock
             Text="Available Software"
             FontSize="28"
@@ -14,61 +19,172 @@
             AutomationProperties.AutomationId="HomeHeading"
             AutomationProperties.HeadingLevel="Level1" />
 
-        <TextBlock
+        <TextBox
             Grid.Row="1"
-            Margin="0,8,0,0"
+            Margin="0,16,0,0"
+            MaxWidth="520"
+            HorizontalAlignment="Left"
+            PlaceholderText="Search apps"
+            Text="{Binding SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            AutomationProperties.AutomationId="CatalogSearchBox"
+            AutomationProperties.Name="Search apps" />
+
+        <TextBlock
+            Grid.Row="2"
+            Margin="0,12,0,0"
             x:Name="ServiceWarning"
             Text="{Binding WarningBanner}"
             Foreground="DarkOrange"
+            TextWrapping="Wrap"
             AutomationProperties.AutomationId="ServiceWarning"
             AutomationProperties.LiveSetting="Polite" />
 
-        <ListView
-            Grid.Row="2"
-            Margin="0,16,0,0"
-            x:Name="ItemsList"
-            ItemsSource="{Binding Items}"
-            ContainerContentChanging="ItemsList_ContainerContentChanging"
-            AutomationProperties.AutomationId="ItemsList"
-            AutomationProperties.Name="Available software">
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <Setter Property="AutomationProperties.AutomationId" Value="{Binding ItemName}" />
-                    <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}" />
-                </Style>
-            </ListView.ItemContainerStyle>
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Grid ColumnDefinitions="*,Auto,Auto" Padding="0,8">
-                        <StackPanel>
-                            <TextBlock Text="{Binding DisplayName}" FontSize="18" FontWeight="SemiBold" />
-                            <TextBlock Text="{Binding Version}" Opacity="0.7" />
-                            <TextBlock
-                                Text="{Binding Status}"
-                                Opacity="0.7"
-                                AutomationProperties.AutomationId="ItemStatus" />
-                        </StackPanel>
-                        <Button
-                            Grid.Column="1"
-                            Margin="12,0,0,0"
-                            Content="Install"
-                            Tag="{Binding ItemName}"
-                            IsEnabled="{Binding CanInstall}"
-                            ToolTipService.ToolTip="{Binding InstallUnavailableReason}"
-                            Click="InstallButton_Click"
-                            AutomationProperties.AutomationId="InstallButton" />
-                        <Button
-                            Grid.Column="2"
-                            Margin="8,0,0,0"
-                            Content="Remove"
-                            Tag="{Binding ItemName}"
-                            IsEnabled="{Binding CanRemove}"
-                            ToolTipService.ToolTip="{Binding RemoveUnavailableReason}"
-                            Click="RemoveButton_Click"
-                            AutomationProperties.AutomationId="RemoveButton" />
-                    </Grid>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <Grid Grid.Row="3" Margin="0,20,0,0">
+            <GridView
+                x:Name="CatalogItems"
+                ItemsSource="{Binding Items}"
+                SelectionMode="None"
+                IsItemClickEnabled="False"
+                HorizontalContentAlignment="Stretch"
+                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                ScrollViewer.HorizontalScrollMode="Disabled"
+                ContainerContentChanging="CatalogItems_ContainerContentChanging"
+                SizeChanged="CatalogItems_SizeChanged"
+                AutomationProperties.AutomationId="CatalogItems"
+                AutomationProperties.Name="Available software">
+                <GridView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <ItemsWrapGrid Orientation="Horizontal" ItemWidth="320" />
+                    </ItemsPanelTemplate>
+                </GridView.ItemsPanel>
+                <GridView.ItemContainerStyle>
+                    <Style TargetType="GridViewItem">
+                        <Setter Property="Margin" Value="0,0,16,16" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+                        <Setter Property="AutomationProperties.AutomationId" Value="{Binding ItemName}" />
+                        <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}" />
+                    </Style>
+                </GridView.ItemContainerStyle>
+                <GridView.ItemTemplate>
+                    <DataTemplate>
+                        <Border
+                            Padding="20"
+                            MinHeight="280"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            AutomationProperties.AutomationId="CatalogCard"
+                            AutomationProperties.Name="{Binding DisplayName}">
+                            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto">
+                                <Border
+                                    Width="44"
+                                    Height="44"
+                                    CornerRadius="8"
+                                    Background="{ThemeResource AccentFillColorSecondaryBrush}">
+                                    <FontIcon
+                                        Glyph="&#xE71D;"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="22"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center" />
+                                </Border>
+
+                                <TextBlock
+                                    Grid.Row="1"
+                                    Margin="0,14,0,0"
+                                    Text="{Binding DisplayName}"
+                                    FontSize="18"
+                                    FontWeight="SemiBold"
+                                    TextWrapping="WrapWholeWords"
+                                    MaxLines="2"
+                                    AutomationProperties.AutomationId="CatalogDisplayName" />
+
+                                <TextBlock
+                                    Grid.Row="2"
+                                    Margin="0,6,0,0"
+                                    Text="{Binding Description}"
+                                    TextWrapping="WrapWholeWords"
+                                    TextTrimming="CharacterEllipsis"
+                                    MaxLines="2"
+                                    Opacity="0.72"
+                                    Visibility="{Binding CardPresentation.HasDescription, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    AutomationProperties.AutomationId="CatalogDescription" />
+
+                                <StackPanel Grid.Row="3" Margin="0,14,0,0" Spacing="3">
+                                    <TextBlock
+                                        Text="{Binding CardPresentation.ObservationText}"
+                                        FontWeight="SemiBold"
+                                        AutomationProperties.AutomationId="CatalogObservation" />
+                                    <TextBlock
+                                        Text="{Binding CardPresentation.VersionText}"
+                                        Opacity="0.68"
+                                        Visibility="{Binding CardPresentation.HasVersion, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        AutomationProperties.AutomationId="CatalogVersion" />
+                                </StackPanel>
+
+                                <StackPanel
+                                    Grid.Row="4"
+                                    Margin="0,12,0,0"
+                                    Orientation="Horizontal"
+                                    Spacing="8"
+                                    VerticalAlignment="Center"
+                                    Visibility="{Binding CardPresentation.HasOperation, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    AutomationProperties.AutomationId="CatalogOperation">
+                                    <ProgressRing
+                                        Width="18"
+                                        Height="18"
+                                        IsActive="{Binding CardPresentation.HasOperation}"
+                                        IsIndeterminate="{Binding CardPresentation.IsProgressIndeterminate}"
+                                        Value="{Binding CardPresentation.ProgressValue}" />
+                                    <TextBlock
+                                        Text="{Binding CardPresentation.OperationText}"
+                                        VerticalAlignment="Center" />
+                                </StackPanel>
+
+                                <StackPanel
+                                    Grid.Row="6"
+                                    Margin="0,18,0,0"
+                                    Orientation="Horizontal"
+                                    Spacing="8">
+                                    <Button
+                                        Content="{Binding CardPresentation.PrimaryAction.Label}"
+                                        Tag="{Binding CardPresentation.PrimaryAction.Kind}"
+                                        IsEnabled="{Binding CardPresentation.PrimaryAction.Enabled}"
+                                        Visibility="{Binding CardPresentation.HasPrimaryAction, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        Click="ActionButton_Click"
+                                        AutomationProperties.AutomationId="PrimaryActionButton" />
+                                    <Button
+                                        Content="{Binding CardPresentation.SecondaryAction.Label}"
+                                        Tag="{Binding CardPresentation.SecondaryAction.Kind}"
+                                        IsEnabled="{Binding CardPresentation.SecondaryAction.Enabled}"
+                                        Visibility="{Binding CardPresentation.HasSecondaryAction, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Click="ActionButton_Click"
+                                        AutomationProperties.AutomationId="SecondaryActionButton" />
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+            </GridView>
+
+            <TextBlock
+                x:Name="SearchNoResults"
+                Visibility="Collapsed"
+                FontSize="18"
+                TextWrapping="Wrap"
+                AutomationProperties.AutomationId="SearchNoResults"
+                AutomationProperties.LiveSetting="Polite" />
+
+            <TextBlock
+                x:Name="CatalogEmpty"
+                Visibility="Collapsed"
+                Text="No software is currently available."
+                FontSize="18"
+                TextWrapping="Wrap"
+                AutomationProperties.AutomationId="CatalogEmpty" />
+        </Grid>
     </Grid>
 </Page>

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -17,7 +17,6 @@ public sealed partial class HomePage : Page, IDisposable
     private CancellationTokenSource? _cts;
     private long _serviceWarningTextChangedToken;
     private bool _hasInitialized;
-    private UiOptionalInstallItem? _pendingActionItem;
 
     public HomeViewModel ViewModel { get; }
 
@@ -57,19 +56,6 @@ public sealed partial class HomePage : Page, IDisposable
         if (e.PropertyName == nameof(HomeViewModel.SearchQuery))
         {
             UpdateEmptyStates();
-            return;
-        }
-
-        if (e.PropertyName == nameof(HomeViewModel.WarningBanner) && _pendingActionItem is { } item)
-        {
-            var installRejected = $"Install was not accepted for {item.DisplayName}.";
-            var removeRejected = $"Remove was not accepted for {item.DisplayName}.";
-            if (string.Equals(ViewModel.WarningBanner, installRejected, StringComparison.Ordinal)
-                || string.Equals(ViewModel.WarningBanner, removeRejected, StringComparison.Ordinal))
-            {
-                item.TransientFeedback = ViewModel.WarningBanner;
-                ViewModel.SetWarningBanner(string.Empty);
-            }
         }
     }
 
@@ -184,23 +170,14 @@ public sealed partial class HomePage : Page, IDisposable
             return;
         }
 
-        item.TransientFeedback = null;
-        _pendingActionItem = item;
-        try
+        switch (action.Value)
         {
-            switch (action.Value)
-            {
-                case CatalogCardActionKind.Install:
-                    await RunSafelyAsync(() => ViewModel.InstallAsync(item, _cts.Token));
-                    break;
-                case CatalogCardActionKind.Remove:
-                    await RunSafelyAsync(() => ViewModel.RemoveAsync(item, _cts.Token));
-                    break;
-            }
-        }
-        finally
-        {
-            _pendingActionItem = null;
+            case CatalogCardActionKind.Install:
+                await RunSafelyAsync(() => ViewModel.InstallAsync(item, _cts.Token));
+                break;
+            case CatalogCardActionKind.Remove:
+                await RunSafelyAsync(() => ViewModel.RemoveAsync(item, _cts.Token));
+                break;
         }
     }
 
@@ -230,7 +207,7 @@ public sealed partial class HomePage : Page, IDisposable
         {
             ServiceWarning.UnregisterPropertyChangedCallback(
                 TextBlock.TextProperty,
-                _serviceWarningTextChangedToken
+                ServiceWarning_TextChanged
             );
             _serviceWarningTextChangedToken = 0;
         }

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class HomePage : Page, IDisposable
             return;
         }
 
-        var query = ViewModel.SearchQuery.Trim();
+        var query = ViewModel.SearchQuery;
         var noVisibleItems = ViewModel.Items.Count == 0;
         var hasSearch = !string.IsNullOrWhiteSpace(query);
 
@@ -157,7 +157,12 @@ public sealed partial class HomePage : Page, IDisposable
             return;
         }
 
-        var currentAction = ReferenceEquals(button, FindPrimaryActionButton(button))
+        var isPrimary = string.Equals(
+            AutomationProperties.GetAutomationId(button),
+            "PrimaryActionButton",
+            StringComparison.Ordinal
+        );
+        var currentAction = isPrimary
             ? item.CardPresentation.PrimaryAction
             : item.CardPresentation.SecondaryAction;
         if (currentAction is null || !currentAction.Enabled || currentAction.Kind != action)
@@ -174,11 +179,6 @@ public sealed partial class HomePage : Page, IDisposable
                 await RunSafelyAsync(() => ViewModel.RemoveAsync(item, _cts.Token));
                 break;
         }
-    }
-
-    private static Button? FindPrimaryActionButton(Button button)
-    {
-        return AutomationProperties.GetAutomationId(button) == "PrimaryActionButton" ? button : null;
     }
 
     private async Task RunSafelyAsync(Func<Task> action)

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Gorilla.UI.Core.Models;
@@ -14,6 +16,7 @@ public sealed partial class HomePage : Page, IDisposable
 {
     private CancellationTokenSource? _cts;
     private long _serviceWarningTextChangedToken;
+    private bool _hasInitialized;
 
     public HomeViewModel ViewModel { get; }
 
@@ -24,10 +27,13 @@ public sealed partial class HomePage : Page, IDisposable
         DataContext = ViewModel;
         Loaded += HomePage_Loaded;
         Unloaded += HomePage_Unloaded;
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+        ViewModel.Items.CollectionChanged += Items_CollectionChanged;
         _serviceWarningTextChangedToken = ServiceWarning.RegisterPropertyChangedCallback(
             TextBlock.TextProperty,
             ServiceWarning_TextChanged
         );
+        UpdateEmptyStates();
     }
 
     private async void HomePage_Loaded(object sender, RoutedEventArgs e)
@@ -35,11 +41,50 @@ public sealed partial class HomePage : Page, IDisposable
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
         await RunSafelyAsync(() => ViewModel.InitializeAsync(_cts.Token));
+        _hasInitialized = true;
+        UpdateEmptyStates();
+        UpdateCardWidths(CatalogItems.ActualWidth);
     }
 
     private void HomePage_Unloaded(object sender, RoutedEventArgs e)
     {
         ResetCancellation();
+    }
+
+    private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(HomeViewModel.SearchQuery))
+        {
+            UpdateEmptyStates();
+        }
+    }
+
+    private void Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        UpdateEmptyStates();
+    }
+
+    private void UpdateEmptyStates()
+    {
+        if (!_hasInitialized)
+        {
+            SearchNoResults.Visibility = Visibility.Collapsed;
+            CatalogEmpty.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var query = ViewModel.SearchQuery.Trim();
+        var noVisibleItems = ViewModel.Items.Count == 0;
+        var hasSearch = !string.IsNullOrWhiteSpace(query);
+
+        SearchNoResults.Visibility = hasSearch && noVisibleItems
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        SearchNoResults.Text = hasSearch ? $"No apps match \"{query}\"." : string.Empty;
+
+        CatalogEmpty.Visibility = !hasSearch && noVisibleItems
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     private void ServiceWarning_TextChanged(DependencyObject sender, DependencyProperty dp)
@@ -54,12 +99,12 @@ public sealed partial class HomePage : Page, IDisposable
         peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
     }
 
-    private void ItemsList_ContainerContentChanging(
+    private void CatalogItems_ContainerContentChanging(
         ListViewBase sender,
         ContainerContentChangingEventArgs args
     )
     {
-        if (!ReferenceEquals(sender, ItemsList))
+        if (!ReferenceEquals(sender, CatalogItems))
         {
             return;
         }
@@ -72,46 +117,68 @@ public sealed partial class HomePage : Page, IDisposable
         AutomationProperties.SetName(args.ItemContainer, item.DisplayName);
     }
 
-    private async void InstallButton_Click(object sender, RoutedEventArgs e)
+    private void CatalogItems_SizeChanged(object sender, SizeChangedEventArgs e)
     {
-        if (sender is not Button button || button.Tag is not string itemName)
-        {
-            return;
-        }
-
-        var item = ViewModel.FindItem(itemName);
-        if (item is null)
-        {
-            return;
-        }
-
-        if (_cts is null)
-        {
-            return;
-        }
-
-        await RunSafelyAsync(() => ViewModel.InstallAsync(item, _cts.Token));
+        UpdateCardWidths(e.NewSize.Width);
     }
 
-    private async void RemoveButton_Click(object sender, RoutedEventArgs e)
+    private void UpdateCardWidths(double availableWidth)
     {
-        if (sender is not Button button || button.Tag is not string itemName)
+        if (availableWidth <= 0 || CatalogItems.ItemsPanelRoot is not ItemsWrapGrid panel)
         {
             return;
         }
 
-        var item = ViewModel.FindItem(itemName);
-        if (item is null)
+        const double minimumCardWidth = 280;
+        const double maximumCardWidth = 360;
+        var columns = Math.Max(1, (int)Math.Floor(availableWidth / minimumCardWidth));
+        panel.ItemWidth = Math.Max(1, Math.Min(maximumCardWidth, availableWidth / columns));
+    }
+
+    private async void ActionButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.DataContext is not UiOptionalInstallItem item)
         {
             return;
         }
-
         if (_cts is null)
         {
             return;
         }
 
-        await RunSafelyAsync(() => ViewModel.RemoveAsync(item, _cts.Token));
+        var action = button.Tag switch
+        {
+            CatalogCardActionKind kind => kind,
+            string text when Enum.TryParse<CatalogCardActionKind>(text, out var parsed) => parsed,
+            _ => (CatalogCardActionKind?)null,
+        };
+        if (action is null)
+        {
+            return;
+        }
+
+        var currentAction = ReferenceEquals(button, FindPrimaryActionButton(button))
+            ? item.CardPresentation.PrimaryAction
+            : item.CardPresentation.SecondaryAction;
+        if (currentAction is null || !currentAction.Enabled || currentAction.Kind != action)
+        {
+            return;
+        }
+
+        switch (action.Value)
+        {
+            case CatalogCardActionKind.Install:
+                await RunSafelyAsync(() => ViewModel.InstallAsync(item, _cts.Token));
+                break;
+            case CatalogCardActionKind.Remove:
+                await RunSafelyAsync(() => ViewModel.RemoveAsync(item, _cts.Token));
+                break;
+        }
+    }
+
+    private static Button? FindPrimaryActionButton(Button button)
+    {
+        return AutomationProperties.GetAutomationId(button) == "PrimaryActionButton" ? button : null;
     }
 
     private async Task RunSafelyAsync(Func<Task> action)
@@ -134,6 +201,8 @@ public sealed partial class HomePage : Page, IDisposable
     {
         Loaded -= HomePage_Loaded;
         Unloaded -= HomePage_Unloaded;
+        ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        ViewModel.Items.CollectionChanged -= Items_CollectionChanged;
         if (_serviceWarningTextChangedToken != 0)
         {
             ServiceWarning.UnregisterPropertyChangedCallback(

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -129,8 +129,8 @@ public sealed partial class HomePage : Page, IDisposable
             return;
         }
 
-        const double minimumCardWidth = 220;
-        const double maximumCardWidth = 280;
+        const double minimumCardWidth = 300;
+        const double maximumCardWidth = 340;
         var columns = Math.Max(1, (int)Math.Floor(availableWidth / minimumCardWidth));
         panel.ItemWidth = Math.Max(1, Math.Min(maximumCardWidth, availableWidth / columns));
     }

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -129,8 +129,8 @@ public sealed partial class HomePage : Page, IDisposable
             return;
         }
 
-        const double minimumCardWidth = 280;
-        const double maximumCardWidth = 360;
+        const double minimumCardWidth = 220;
+        const double maximumCardWidth = 280;
         var columns = Math.Max(1, (int)Math.Floor(availableWidth / minimumCardWidth));
         panel.ItemWidth = Math.Max(1, Math.Min(maximumCardWidth, availableWidth / columns));
     }

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -207,7 +207,7 @@ public sealed partial class HomePage : Page, IDisposable
         {
             ServiceWarning.UnregisterPropertyChangedCallback(
                 TextBlock.TextProperty,
-                ServiceWarning_TextChanged
+                _serviceWarningTextChangedToken
             );
             _serviceWarningTextChangedToken = 0;
         }

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -17,6 +17,7 @@ public sealed partial class HomePage : Page, IDisposable
     private CancellationTokenSource? _cts;
     private long _serviceWarningTextChangedToken;
     private bool _hasInitialized;
+    private UiOptionalInstallItem? _pendingActionItem;
 
     public HomeViewModel ViewModel { get; }
 
@@ -56,6 +57,19 @@ public sealed partial class HomePage : Page, IDisposable
         if (e.PropertyName == nameof(HomeViewModel.SearchQuery))
         {
             UpdateEmptyStates();
+            return;
+        }
+
+        if (e.PropertyName == nameof(HomeViewModel.WarningBanner) && _pendingActionItem is { } item)
+        {
+            var installRejected = $"Install was not accepted for {item.DisplayName}.";
+            var removeRejected = $"Remove was not accepted for {item.DisplayName}.";
+            if (string.Equals(ViewModel.WarningBanner, installRejected, StringComparison.Ordinal)
+                || string.Equals(ViewModel.WarningBanner, removeRejected, StringComparison.Ordinal))
+            {
+                item.TransientFeedback = ViewModel.WarningBanner;
+                ViewModel.SetWarningBanner(string.Empty);
+            }
         }
     }
 
@@ -170,14 +184,23 @@ public sealed partial class HomePage : Page, IDisposable
             return;
         }
 
-        switch (action.Value)
+        item.TransientFeedback = null;
+        _pendingActionItem = item;
+        try
         {
-            case CatalogCardActionKind.Install:
-                await RunSafelyAsync(() => ViewModel.InstallAsync(item, _cts.Token));
-                break;
-            case CatalogCardActionKind.Remove:
-                await RunSafelyAsync(() => ViewModel.RemoveAsync(item, _cts.Token));
-                break;
+            switch (action.Value)
+            {
+                case CatalogCardActionKind.Install:
+                    await RunSafelyAsync(() => ViewModel.InstallAsync(item, _cts.Token));
+                    break;
+                case CatalogCardActionKind.Remove:
+                    await RunSafelyAsync(() => ViewModel.RemoveAsync(item, _cts.Token));
+                    break;
+            }
+        }
+        finally
+        {
+            _pendingActionItem = null;
         }
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
+++ b/gorilla-ui/src/Gorilla.UI.Client/NamedPipeGorillaServiceClient.cs
@@ -128,6 +128,7 @@ public sealed partial class NamedPipeGorillaServiceClient : IGorillaServiceClien
         var duration = Stopwatch.StartNew();
         var completed = false;
         var terminalState = string.Empty;
+        var terminalOutcome = string.Empty;
         var result = "error";
         ClientDiagnostics.Log($"stream:begin operationId={operationId}");
         try
@@ -230,22 +231,35 @@ public sealed partial class NamedPipeGorillaServiceClient : IGorillaServiceClien
                     Result: eventEnvelope.Payload.Result
                 );
 
-                yield return ev;
-                ClientDiagnostics.Log(
-                    $"stream:event operationId={ev.OperationId} itemName={ev.ItemName} action={ev.Action} state={ev.State} progress={ev.ProgressPercent} outcome={ev.Result?.Outcome}"
-                );
-
-                if (ev.State == OperationState.Completed)
+                var isTerminal = ev.State == OperationState.Completed;
+                if (isTerminal)
                 {
-                    ClientDiagnostics.Log($"stream:end operationId={ev.OperationId} outcome={ev.Result!.Outcome}");
+                    // Record lifecycle truth before yielding. Consumers intentionally
+                    // stop enumeration after Completed, which disposes this iterator
+                    // without executing statements after the yield.
                     completed = true;
                     terminalState = ev.State.ToString();
+                    terminalOutcome = ev.Result!.Outcome.ToString();
                     result = ev.Result.Outcome switch
                     {
                         AppCatalog.Outcome.Succeeded or AppCatalog.Outcome.AlreadySatisfied => "ok",
                         AppCatalog.Outcome.Interrupted => "canceled",
                         _ => "error"
                     };
+                }
+
+                ClientDiagnostics.Log(
+                    $"stream:event operationId={ev.OperationId} itemName={ev.ItemName} action={ev.Action} state={ev.State} progress={ev.ProgressPercent} outcome={ev.Result?.Outcome}"
+                );
+                if (isTerminal)
+                {
+                    ClientDiagnostics.Log($"stream:end operationId={ev.OperationId} outcome={ev.Result!.Outcome}");
+                }
+
+                yield return ev;
+
+                if (isTerminal)
+                {
                     yield break;
                 }
             }
@@ -258,7 +272,7 @@ public sealed partial class NamedPipeGorillaServiceClient : IGorillaServiceClien
             }
 
             ClientDiagnostics.Log(
-                $"stream:lifecycle operationId={operationId} state={terminalState} result={result} durationMs={duration.ElapsedMilliseconds}"
+                $"stream:lifecycle operationId={operationId} state={terminalState} outcome={terminalOutcome} result={result} durationMs={duration.ElapsedMilliseconds}"
             );
         }
     }

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
@@ -21,6 +21,7 @@ public sealed record CatalogCardPresentation(
     bool HasDescription,
     string? VersionText,
     string? OperationText,
+    string? TerminalFeedbackText,
     int? ProgressPercent,
     CatalogCardActionPresentation? PrimaryAction,
     CatalogCardActionPresentation? SecondaryAction
@@ -28,6 +29,7 @@ public sealed record CatalogCardPresentation(
 {
     public bool HasVersion => !string.IsNullOrWhiteSpace(VersionText);
     public bool HasOperation => !string.IsNullOrWhiteSpace(OperationText);
+    public bool HasTerminalFeedback => !string.IsNullOrWhiteSpace(TerminalFeedbackText);
     public bool IsProgressIndeterminate => ProgressPercent is null;
     public double ProgressValue => ProgressPercent ?? 0;
     public bool HasPrimaryAction => PrimaryAction is not null;
@@ -44,6 +46,7 @@ public static class CatalogCardPresentationMapper
             HasDescription: !string.IsNullOrWhiteSpace(item.Description),
             VersionText: VersionText(item),
             OperationText: OperationText(item.ActiveOperation),
+            TerminalFeedbackText: TerminalFeedbackText(item),
             ProgressPercent: item.ActiveOperation?.ProgressPercent,
             PrimaryAction: primary,
             SecondaryAction: secondary
@@ -138,6 +141,26 @@ public static class CatalogCardPresentationMapper
             OperationState.Removing => "Removing…",
             OperationState.Completed => operation.Action == CatalogAction.Remove ? "Removing…" : "Installing…",
             _ => "Working…",
+        };
+    }
+
+    private static string? TerminalFeedbackText(UiOptionalInstallItem item)
+    {
+        // A new active attempt supersedes retained terminal feedback from the prior
+        // operation. Once the new operation becomes terminal, LatestOperation will
+        // replace it with the new authoritative result.
+        if (item.ActiveOperation is not null || item.LatestOperation?.Result is not { } result)
+        {
+            return null;
+        }
+
+        var details = OperationDisplay.Details(result);
+        return result.Outcome switch
+        {
+            Outcome.Failed => $"Failed: {details}",
+            Outcome.Unverified => $"Unable to verify: {details}",
+            Outcome.Interrupted => $"Interrupted: {details}",
+            _ => null,
         };
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
@@ -144,10 +144,19 @@ public static class CatalogCardPresentationMapper
 
     private static string? TerminalFeedbackText(UiOptionalInstallItem item)
     {
-        // A new active attempt supersedes retained terminal feedback from the prior
-        // operation. Once the new operation becomes terminal, LatestOperation will
-        // replace it with the new authoritative result.
-        if (item.ActiveOperation is not null || item.LatestOperation?.Result is not { } result)
+        // Active work supersedes both transient admission feedback and retained
+        // terminal feedback from a prior operation.
+        if (item.ActiveOperation is not null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(item.TransientFeedback))
+        {
+            return item.TransientFeedback;
+        }
+
+        if (item.LatestOperation?.Result is not { } result)
         {
             return null;
         }

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
@@ -18,7 +18,6 @@ public sealed record CatalogCardActionPresentation(
 
 public sealed record CatalogCardPresentation(
     string ObservationText,
-    bool HasDescription,
     string? VersionText,
     string? OperationText,
     string? TerminalFeedbackText,
@@ -43,7 +42,6 @@ public static class CatalogCardPresentationMapper
         var (primary, secondary) = MapActions(item);
         return new CatalogCardPresentation(
             ObservationText: ObservationText(item.ObservedState),
-            HasDescription: !string.IsNullOrWhiteSpace(item.Description),
             VersionText: VersionText(item),
             OperationText: OperationText(item.ActiveOperation),
             TerminalFeedbackText: TerminalFeedbackText(item),

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogCardPresentation.cs
@@ -1,0 +1,143 @@
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using CatalogAction = Gorilla.UI.Client.AppCatalog.Action;
+
+namespace Gorilla.UI.Core.Models;
+
+public enum CatalogCardActionKind
+{
+    Install,
+    Remove,
+}
+
+public sealed record CatalogCardActionPresentation(
+    CatalogCardActionKind Kind,
+    string Label,
+    bool Enabled
+);
+
+public sealed record CatalogCardPresentation(
+    string ObservationText,
+    bool HasDescription,
+    string? VersionText,
+    string? OperationText,
+    int? ProgressPercent,
+    CatalogCardActionPresentation? PrimaryAction,
+    CatalogCardActionPresentation? SecondaryAction
+)
+{
+    public bool HasVersion => !string.IsNullOrWhiteSpace(VersionText);
+    public bool HasOperation => !string.IsNullOrWhiteSpace(OperationText);
+    public bool IsProgressIndeterminate => ProgressPercent is null;
+    public double ProgressValue => ProgressPercent ?? 0;
+    public bool HasPrimaryAction => PrimaryAction is not null;
+    public bool HasSecondaryAction => SecondaryAction is not null;
+}
+
+public static class CatalogCardPresentationMapper
+{
+    public static CatalogCardPresentation Map(UiOptionalInstallItem item)
+    {
+        var (primary, secondary) = MapActions(item);
+        return new CatalogCardPresentation(
+            ObservationText: ObservationText(item.ObservedState),
+            HasDescription: !string.IsNullOrWhiteSpace(item.Description),
+            VersionText: VersionText(item),
+            OperationText: OperationText(item.ActiveOperation),
+            ProgressPercent: item.ActiveOperation?.ProgressPercent,
+            PrimaryAction: primary,
+            SecondaryAction: secondary
+        );
+    }
+
+    private static (CatalogCardActionPresentation? Primary, CatalogCardActionPresentation? Secondary) MapActions(
+        UiOptionalInstallItem item
+    )
+    {
+        var install = item.InstallAllowed
+            ? new CatalogCardActionPresentation(
+                CatalogCardActionKind.Install,
+                InstallLabel(item),
+                item.CanInstall
+            )
+            : null;
+        var remove = item.RemoveAllowed
+            ? new CatalogCardActionPresentation(
+                CatalogCardActionKind.Remove,
+                "Remove",
+                item.CanRemove
+            )
+            : null;
+
+        if (install is null)
+        {
+            return (remove, null);
+        }
+        if (remove is null)
+        {
+            return (install, null);
+        }
+
+        // Allowedness is service-owned. This only chooses presentation hierarchy
+        // between two actions the service already authorized.
+        return (install, remove);
+    }
+
+    private static string InstallLabel(UiOptionalInstallItem item)
+    {
+        if (item.ObservedState == ObservedState.UpdateAvailable)
+        {
+            return "Update";
+        }
+
+        if (item.ObservedState == ObservedState.Installed && item.Policy?.Selection == Selection.None)
+        {
+            return "Keep Installed";
+        }
+
+        return "Install";
+    }
+
+    private static string ObservationText(ObservedState state) => state switch
+    {
+        ObservedState.Absent => "Not installed",
+        ObservedState.Installed => "Installed",
+        ObservedState.UpdateAvailable => "Update available",
+        ObservedState.Unknown => "Status unavailable",
+        ObservedState.DetectionFailed => "Unable to determine status",
+        _ => "Status unavailable",
+    };
+
+    private static string? VersionText(UiOptionalInstallItem item)
+    {
+        if (string.IsNullOrWhiteSpace(item.TargetVersion))
+        {
+            return null;
+        }
+
+        if (item.ObservedState == ObservedState.UpdateAvailable && !string.IsNullOrWhiteSpace(item.InstalledVersion))
+        {
+            return $"{item.InstalledVersion} → {item.TargetVersion}";
+        }
+
+        return $"Version {item.TargetVersion}";
+    }
+
+    private static string? OperationText(UiOperationPresentation? operation)
+    {
+        if (operation is null)
+        {
+            return null;
+        }
+
+        return operation.State switch
+        {
+            OperationState.Queued or OperationState.Validating => "Preparing…",
+            OperationState.Downloading => "Downloading…",
+            OperationState.Installing => "Installing…",
+            OperationState.Removing => "Removing…",
+            OperationState.Completed => operation.Action == CatalogAction.Remove ? "Removing…" : "Installing…",
+            _ => "Working…",
+        };
+    }
+}

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -20,6 +20,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     private ActionDecision _removeDecision = new(false, "Refresh required before removing.");
     private UiOperationPresentation? _activeOperation;
     private UiOperationPresentation? _latestOperation;
+    private string? _transientFeedback;
     private bool _isBusy;
     private string? _legacyStatus;
     private bool _preferObservedStatus;
@@ -181,6 +182,20 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
             if (SetField(ref _latestOperation, value))
             {
                 OnPropertyChanged(nameof(Status));
+                OnPropertyChanged(nameof(CardPresentation));
+            }
+        }
+    }
+
+    // Local, non-operation feedback for an item-specific action admission response.
+    // This is intentionally separate from authoritative operation and observation state.
+    public string? TransientFeedback
+    {
+        get => _transientFeedback;
+        set
+        {
+            if (SetField(ref _transientFeedback, value))
+            {
                 OnPropertyChanged(nameof(CardPresentation));
             }
         }

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -29,13 +29,25 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     public string DisplayName
     {
         get => _displayName;
-        set => SetField(ref _displayName, value);
+        set
+        {
+            if (SetField(ref _displayName, value))
+            {
+                OnPropertyChanged(nameof(CardPresentation));
+            }
+        }
     }
 
     public string? Description
     {
         get => _description;
-        set => SetField(ref _description, value);
+        set
+        {
+            if (SetField(ref _description, value))
+            {
+                OnPropertyChanged(nameof(CardPresentation));
+            }
+        }
     }
 
     public string? TargetVersion
@@ -46,6 +58,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
             if (SetField(ref _targetVersion, value))
             {
                 OnPropertyChanged(nameof(Version));
+                OnPropertyChanged(nameof(CardPresentation));
             }
         }
     }
@@ -70,6 +83,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
                 OnPropertyChanged(nameof(InstalledVersion));
                 OnPropertyChanged(nameof(IsInstalled));
                 OnPropertyChanged(nameof(Status));
+                OnPropertyChanged(nameof(CardPresentation));
             }
         }
     }
@@ -81,7 +95,13 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     public Policy? Policy
     {
         get => _policy;
-        set => SetField(ref _policy, value);
+        set
+        {
+            if (SetField(ref _policy, value))
+            {
+                OnPropertyChanged(nameof(CardPresentation));
+            }
+        }
     }
 
     public ActionDecision InstallDecision
@@ -94,6 +114,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
                 OnPropertyChanged(nameof(InstallAllowed));
                 OnPropertyChanged(nameof(InstallUnavailableReason));
                 OnPropertyChanged(nameof(CanInstall));
+                OnPropertyChanged(nameof(CardPresentation));
             }
         }
     }
@@ -108,6 +129,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
                 OnPropertyChanged(nameof(RemoveAllowed));
                 OnPropertyChanged(nameof(RemoveUnavailableReason));
                 OnPropertyChanged(nameof(CanRemove));
+                OnPropertyChanged(nameof(CardPresentation));
             }
         }
     }
@@ -144,6 +166,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
             if (SetField(ref _activeOperation, value))
             {
                 OnPropertyChanged(nameof(Status));
+                OnPropertyChanged(nameof(CardPresentation));
             }
         }
     }
@@ -176,6 +199,8 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
     public bool CanInstall => InstallDecision.Allowed && !IsBusy;
 
     public bool CanRemove => RemoveDecision.Allowed && !IsBusy;
+
+    public CatalogCardPresentation CardPresentation => CatalogCardPresentationMapper.Map(this);
 
     // Transitional compatibility state for the existing Stage 4 ListView. New UI
     // should bind the typed Observation/ActiveOperation/LatestOperation properties.
@@ -226,6 +251,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
             {
                 OnPropertyChanged(nameof(CanInstall));
                 OnPropertyChanged(nameof(CanRemove));
+                OnPropertyChanged(nameof(CardPresentation));
             }
         }
     }

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/UiOptionalInstallItem.cs
@@ -181,6 +181,7 @@ public sealed class UiOptionalInstallItem : INotifyPropertyChanged
             if (SetField(ref _latestOperation, value))
             {
                 OnPropertyChanged(nameof(Status));
+                OnPropertyChanged(nameof(CardPresentation));
             }
         }
     }

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -125,13 +125,14 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     public async Task InstallAsync(UiOptionalInstallItem item, CancellationToken cancellationToken)
     {
+        item.TransientFeedback = null;
         item.IsBusy = true;
         try
         {
             var accepted = await _client.InstallItemAsync(item.ItemName, cancellationToken);
             if (!accepted.Accepted)
             {
-                WarningBanner = $"Install was not accepted for {item.DisplayName}.";
+                item.TransientFeedback = $"Install was not accepted for {item.DisplayName}.";
                 return;
             }
 
@@ -158,13 +159,14 @@ public sealed class HomeViewModel : INotifyPropertyChanged
 
     public async Task RemoveAsync(UiOptionalInstallItem item, CancellationToken cancellationToken)
     {
+        item.TransientFeedback = null;
         item.IsBusy = true;
         try
         {
             var accepted = await _client.RemoveItemAsync(item.ItemName, cancellationToken);
             if (!accepted.Accepted)
             {
-                WarningBanner = $"Remove was not accepted for {item.DisplayName}.";
+                item.TransientFeedback = $"Remove was not accepted for {item.DisplayName}.";
                 return;
             }
 

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -412,29 +412,10 @@ public sealed class HomeViewModel : INotifyPropertyChanged
             item.PreferOperationStatus();
         }
 
+        // OperationTracker owns the structured per-item terminal result. The card
+        // presentation consumes LatestOperation directly; page warnings are reserved
+        // for service/catalog/status infrastructure problems.
         ReprojectOperation(item);
-        if (update.State == OperationState.Completed)
-        {
-            ApplyAuthoritativeResult(item, update.Result!);
-        }
-    }
-
-    private void ApplyAuthoritativeResult(UiOptionalInstallItem item, Result result)
-    {
-        var details = OperationDisplay.Details(result);
-
-        switch (result.Outcome)
-        {
-            case Outcome.Succeeded:
-            case Outcome.AlreadySatisfied:
-                WarningBanner = string.Empty;
-                break;
-            case Outcome.Failed:
-            case Outcome.Unverified:
-            case Outcome.Interrupted:
-                WarningBanner = $"Operation for {item.DisplayName} ended with {result.Outcome}: {details}";
-                break;
-        }
     }
 
     private static void ValidateOperationIdentity(

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AppLaunchSmokeTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AppLaunchSmokeTests.cs
@@ -14,7 +14,7 @@ public sealed class AppLaunchSmokeTests
             var home = new HomePageDriver(session);
             Assert.Equal("App Catalog", session.MainWindow.Title);
             Assert.Equal("Available Software", home.Heading.Name);
-            Assert.Equal("Available software", home.ItemsList.Name);
+            Assert.Equal("Available software", home.CatalogItems.Name);
             Assert.False(home.HasOperationFailureText());
         });
     }

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -25,7 +25,6 @@ public sealed class CatalogSurfaceTests
             _ = home.WaitForCard(FixtureItemName);
             _ = home.WaitForCard(FailureFixtureItemName);
             _ = home.WaitForCard(InstalledFixtureItemName);
-            Assert.Equal("Not installed", home.ItemStatus(FixtureItemName));
             Assert.Null(home.Description(FailureFixtureItemName));
             Assert.Contains("Celestial amber telescope", home.Description(InstalledFixtureItemName), StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -16,15 +16,19 @@ public sealed class CatalogSurfaceTests
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
-    public void CatalogRendersCardsAndMissingDescriptionWithoutPlaceholder()
+    public void CatalogRendersDenseCardsAndMissingDescriptionWithoutPlaceholder()
     {
-        RunWithDiagnostics(nameof(CatalogRendersCardsAndMissingDescriptionWithoutPlaceholder), session =>
+        RunWithDiagnostics(nameof(CatalogRendersDenseCardsAndMissingDescriptionWithoutPlaceholder), session =>
         {
             var home = new HomePageDriver(session);
 
             _ = home.WaitForCard(FixtureItemName);
             _ = home.WaitForCard(FailureFixtureItemName);
             _ = home.WaitForCard(InstalledFixtureItemName);
+            Assert.True(
+                home.CardWidth(FixtureItemName) <= 280.5,
+                $"Expected dense catalog card width at or below 280px, got {home.CardWidth(FixtureItemName):0.0}px."
+            );
             Assert.Null(home.Description(FailureFixtureItemName));
             Assert.Contains("Celestial amber telescope", home.Description(InstalledFixtureItemName), StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -182,10 +182,22 @@ public sealed class CatalogSurfaceTests
         RunWithDiagnostics(nameof(ActiveOperationShowsBusyStateWithoutReplacingObservation), session =>
         {
             var slowMarkerPath = RequiredPath("GORILLA_UI_E2E_SLOW_MARKER_PATH");
-            File.Delete(slowMarkerPath);
-
             var home = new HomePageDriver(session);
-            home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
+            _ = home.WaitForItem(SlowFixtureItemName);
+
+            // Another healthy E2E deliberately leaves this selected and installed
+            // to prove the one-action Remove presentation. Reset through Gorilla
+            // itself so physical state and service-owned selection stay coherent.
+            if (string.Equals(home.ItemStatus(SlowFixtureItemName), "Installed", StringComparison.OrdinalIgnoreCase))
+            {
+                home.RemoveButton(SlowFixtureItemName).Invoke();
+                session.WaitUntil(() => !File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
+                home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
+            }
+            else
+            {
+                home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
+            }
 
             home.PrimaryActionButton(SlowFixtureItemName).Invoke();
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -1,4 +1,5 @@
 using FlaUI.Core.Definitions;
+using Microsoft.Win32;
 using Xunit;
 
 namespace Gorilla.UI.App.WindowsUiTests;
@@ -10,6 +11,8 @@ public sealed class CatalogSurfaceTests
     private const string UpdateFixtureItemName = "RegistryUpdateFixture";
     private const string InstalledFixtureItemName = "RegistryInstalledFixture";
     private const string SlowFixtureItemName = "SlowInstallFixture";
+    private const string UpdateRegistrySubKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiUpdateFixture";
+    private const string InstalledRegistrySubKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiInstalledFixture";
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
@@ -27,7 +30,11 @@ public sealed class CatalogSurfaceTests
             Assert.Contains("Celestial amber telescope", home.Description(InstalledFixtureItemName), StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(
                 session.MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Text)),
-                element => string.Equals(element.Name, "No description available", StringComparison.OrdinalIgnoreCase)
+                element => string.Equals(
+                    HomePageDriver.AutomationName(element),
+                    "No description available",
+                    StringComparison.OrdinalIgnoreCase
+                )
             );
             session.CaptureCheckpoint("catalog-cards", includeAutomationTree: true);
         });
@@ -100,17 +107,27 @@ public sealed class CatalogSurfaceTests
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
-    public void AbsentFixtureShowsOnePrimaryInstallAction()
+    public void InstalledSelectedFixtureShowsOnePrimaryRemoveAction()
     {
-        RunWithDiagnostics(nameof(AbsentFixtureShowsOnePrimaryInstallAction), session =>
+        RunWithDiagnostics(nameof(InstalledSelectedFixtureShowsOnePrimaryRemoveAction), session =>
         {
+            var slowMarkerPath = RequiredPath("GORILLA_UI_E2E_SLOW_MARKER_PATH");
             var home = new HomePageDriver(session);
-            var card = home.WaitForCard(FailureFixtureItemName);
+            _ = home.WaitForItem(SlowFixtureItemName);
+
+            if (!string.Equals(home.ItemStatus(SlowFixtureItemName), "Installed", StringComparison.OrdinalIgnoreCase))
+            {
+                home.InstallButton(SlowFixtureItemName).Invoke();
+                session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
+                home.WaitForItemStatus(SlowFixtureItemName, "Installed", TimeSpan.FromSeconds(30));
+            }
+
+            var card = home.WaitForCard(SlowFixtureItemName);
             var primary = card.FindFirstDescendant(cf => cf.ByAutomationId("PrimaryActionButton"));
             var secondary = card.FindFirstDescendant(cf => cf.ByAutomationId("SecondaryActionButton"));
 
             Assert.NotNull(primary);
-            Assert.Equal("Install", primary!.Name);
+            Assert.Equal("Remove", HomePageDriver.AutomationName(primary!));
             Assert.Null(secondary);
         });
     }
@@ -119,6 +136,8 @@ public sealed class CatalogSurfaceTests
     [Trait("E2EPhase", "Healthy")]
     public void UpdateAvailableFixtureShowsUpdatePrimaryAndRemoveSecondary()
     {
+        SeedRegistryFixture(UpdateRegistrySubKey, "Gorilla UI Update Fixture", "1.0.0");
+
         RunWithDiagnostics(nameof(UpdateAvailableFixtureShowsUpdatePrimaryAndRemoveSecondary), session =>
         {
             var home = new HomePageDriver(session);
@@ -139,6 +158,8 @@ public sealed class CatalogSurfaceTests
     [Trait("E2EPhase", "Healthy")]
     public void InstalledUnselectedFixtureShowsKeepInstalledPrimaryAndRemoveSecondary()
     {
+        SeedRegistryFixture(InstalledRegistrySubKey, "Gorilla UI Installed Fixture", "1.0.0");
+
         RunWithDiagnostics(nameof(InstalledUnselectedFixtureShowsKeepInstalledPrimaryAndRemoveSecondary), session =>
         {
             var home = new HomePageDriver(session);
@@ -178,6 +199,16 @@ public sealed class CatalogSurfaceTests
             home.WaitForItemStatus(SlowFixtureItemName, "Installed", TimeSpan.FromSeconds(30));
             Assert.True(home.HasSecondaryAction(SlowFixtureItemName) || home.PrimaryActionButton(SlowFixtureItemName).Name == "Remove");
         });
+    }
+
+    private static void SeedRegistryFixture(string subKey, string displayName, string displayVersion)
+    {
+        using var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+        using var key = baseKey.CreateSubKey(subKey, writable: true)
+            ?? throw new InvalidOperationException($"Unable to create registry fixture HKLM\\{subKey}.");
+        key.SetValue("DisplayName", displayName, RegistryValueKind.String);
+        key.SetValue("DisplayVersion", displayVersion, RegistryValueKind.String);
+        key.SetValue("UninstallString", "cmd.exe /c exit 0", RegistryValueKind.String);
     }
 
     private static string RequiredPath(string variableName)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -16,21 +16,23 @@ public sealed class CatalogSurfaceTests
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
-    public void CatalogRendersDenseCardsAndMissingDescriptionWithoutPlaceholder()
+    public void CatalogRendersCompactCardsWithoutDescriptions()
     {
-        RunWithDiagnostics(nameof(CatalogRendersDenseCardsAndMissingDescriptionWithoutPlaceholder), session =>
+        RunWithDiagnostics(nameof(CatalogRendersCompactCardsWithoutDescriptions), session =>
         {
             var home = new HomePageDriver(session);
 
             _ = home.WaitForCard(FixtureItemName);
             _ = home.WaitForCard(FailureFixtureItemName);
             _ = home.WaitForCard(InstalledFixtureItemName);
-            Assert.True(
-                home.CardWidth(FixtureItemName) <= 280.5,
-                $"Expected dense catalog card width at or below 280px, got {home.CardWidth(FixtureItemName):0.0}px."
-            );
-            Assert.Null(home.Description(FailureFixtureItemName));
-            Assert.Contains("Celestial amber telescope", home.Description(InstalledFixtureItemName), StringComparison.OrdinalIgnoreCase);
+
+            var width = home.CardWidth(FixtureItemName);
+            var height = home.CardHeight(FixtureItemName);
+            Assert.InRange(width, 299.5, 340.5);
+            Assert.InRange(height, 203.5, 204.5);
+            Assert.False(home.HasDescriptionElement(FixtureItemName));
+            Assert.False(home.HasDescriptionElement(FailureFixtureItemName));
+            Assert.False(home.HasDescriptionElement(InstalledFixtureItemName));
             Assert.DoesNotContain(
                 session.MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Text)),
                 element => string.Equals(
@@ -64,9 +66,9 @@ public sealed class CatalogSurfaceTests
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
-    public void SearchByDescriptionFlowsFromCatalogThroughServiceAndCore()
+    public void SearchByDescriptionFlowsFromCatalogThroughServiceAndCoreWithoutRenderingDescription()
     {
-        RunWithDiagnostics(nameof(SearchByDescriptionFlowsFromCatalogThroughServiceAndCore), session =>
+        RunWithDiagnostics(nameof(SearchByDescriptionFlowsFromCatalogThroughServiceAndCoreWithoutRenderingDescription), session =>
         {
             var home = new HomePageDriver(session);
             _ = home.WaitForItem(InstalledFixtureItemName);
@@ -76,11 +78,7 @@ public sealed class CatalogSurfaceTests
             home.Search(descriptionOnlyQuery);
 
             session.WaitUntil(() => home.HasItem(InstalledFixtureItemName) && !home.HasItem(UpdateFixtureItemName));
-            Assert.Contains(
-                descriptionOnlyQuery,
-                home.Description(InstalledFixtureItemName),
-                StringComparison.OrdinalIgnoreCase
-            );
+            Assert.False(home.HasDescriptionElement(InstalledFixtureItemName));
             session.CaptureCheckpoint("catalog-search-description", includeAutomationTree: true);
 
             home.ClearSearch();
@@ -208,6 +206,7 @@ public sealed class CatalogSurfaceTests
             home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
             Assert.Equal("Not installed", home.ItemStatus(SlowFixtureItemName));
             Assert.False(home.PrimaryActionButton(SlowFixtureItemName).IsEnabled);
+            Assert.InRange(home.CardHeight(SlowFixtureItemName), 203.5, 204.5);
             session.CaptureCheckpoint("catalog-active-operation", includeAutomationTree: true);
 
             session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -7,6 +7,9 @@ public sealed class CatalogSurfaceTests
 {
     private const string FixtureItemName = "Ps1V1";
     private const string FailureFixtureItemName = "Ps1Failure";
+    private const string UpdateFixtureItemName = "RegistryUpdateFixture";
+    private const string InstalledFixtureItemName = "RegistryInstalledFixture";
+    private const string SlowFixtureItemName = "SlowInstallFixture";
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
@@ -18,8 +21,10 @@ public sealed class CatalogSurfaceTests
 
             _ = home.WaitForCard(FixtureItemName);
             _ = home.WaitForCard(FailureFixtureItemName);
+            _ = home.WaitForCard(InstalledFixtureItemName);
             Assert.Equal("Not installed", home.ItemStatus(FixtureItemName));
             Assert.Null(home.Description(FailureFixtureItemName));
+            Assert.Contains("Celestial amber telescope", home.Description(InstalledFixtureItemName), StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(
                 session.MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Text)),
                 element => string.Equals(element.Name, "No description available", StringComparison.OrdinalIgnoreCase)
@@ -44,6 +49,32 @@ public sealed class CatalogSurfaceTests
 
             home.ClearSearch();
             session.WaitUntil(() => home.HasItem(FixtureItemName) && home.HasItem(FailureFixtureItemName));
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void SearchByDescriptionFlowsFromCatalogThroughServiceAndCore()
+    {
+        RunWithDiagnostics(nameof(SearchByDescriptionFlowsFromCatalogThroughServiceAndCore), session =>
+        {
+            var home = new HomePageDriver(session);
+            _ = home.WaitForItem(InstalledFixtureItemName);
+            _ = home.WaitForItem(UpdateFixtureItemName);
+
+            const string descriptionOnlyQuery = "celestial amber telescope";
+            home.Search(descriptionOnlyQuery);
+
+            session.WaitUntil(() => home.HasItem(InstalledFixtureItemName) && !home.HasItem(UpdateFixtureItemName));
+            Assert.Contains(
+                descriptionOnlyQuery,
+                home.Description(InstalledFixtureItemName),
+                StringComparison.OrdinalIgnoreCase
+            );
+            session.CaptureCheckpoint("catalog-search-description", includeAutomationTree: true);
+
+            home.ClearSearch();
+            _ = home.WaitForItem(UpdateFixtureItemName);
         });
     }
 
@@ -82,6 +113,81 @@ public sealed class CatalogSurfaceTests
             Assert.Equal("Install", primary!.Name);
             Assert.Null(secondary);
         });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void UpdateAvailableFixtureShowsUpdatePrimaryAndRemoveSecondary()
+    {
+        RunWithDiagnostics(nameof(UpdateAvailableFixtureShowsUpdatePrimaryAndRemoveSecondary), session =>
+        {
+            var home = new HomePageDriver(session);
+            home.WaitForItemStatus(UpdateFixtureItemName, "Update available", TimeSpan.FromSeconds(30));
+
+            var primary = home.PrimaryActionButton(UpdateFixtureItemName);
+            var secondary = home.SecondaryActionButton(UpdateFixtureItemName);
+
+            Assert.Equal("Update", primary.Name);
+            Assert.True(primary.IsEnabled);
+            Assert.Equal("Remove", secondary.Name);
+            Assert.True(secondary.IsEnabled);
+            session.CaptureCheckpoint("catalog-update-dual-action", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void InstalledUnselectedFixtureShowsKeepInstalledPrimaryAndRemoveSecondary()
+    {
+        RunWithDiagnostics(nameof(InstalledUnselectedFixtureShowsKeepInstalledPrimaryAndRemoveSecondary), session =>
+        {
+            var home = new HomePageDriver(session);
+            home.WaitForItemStatus(InstalledFixtureItemName, "Installed", TimeSpan.FromSeconds(30));
+
+            var primary = home.PrimaryActionButton(InstalledFixtureItemName);
+            var secondary = home.SecondaryActionButton(InstalledFixtureItemName);
+
+            Assert.Equal("Keep Installed", primary.Name);
+            Assert.True(primary.IsEnabled);
+            Assert.Equal("Remove", secondary.Name);
+            Assert.True(secondary.IsEnabled);
+            session.CaptureCheckpoint("catalog-installed-unselected-dual-action", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void ActiveOperationShowsBusyStateWithoutReplacingObservation()
+    {
+        RunWithDiagnostics(nameof(ActiveOperationShowsBusyStateWithoutReplacingObservation), session =>
+        {
+            var slowMarkerPath = RequiredPath("GORILLA_UI_E2E_SLOW_MARKER_PATH");
+            File.Delete(slowMarkerPath);
+
+            var home = new HomePageDriver(session);
+            home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
+
+            home.PrimaryActionButton(SlowFixtureItemName).Invoke();
+
+            home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
+            Assert.Equal("Not installed", home.ItemStatus(SlowFixtureItemName));
+            Assert.False(home.PrimaryActionButton(SlowFixtureItemName).IsEnabled);
+            session.CaptureCheckpoint("catalog-active-operation", includeAutomationTree: true);
+
+            session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
+            home.WaitForItemStatus(SlowFixtureItemName, "Installed", TimeSpan.FromSeconds(30));
+            Assert.True(home.HasSecondaryAction(SlowFixtureItemName) || home.PrimaryActionButton(SlowFixtureItemName).Name == "Remove");
+        });
+    }
+
+    private static string RequiredPath(string variableName)
+    {
+        var value = Environment.GetEnvironmentVariable(variableName);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{variableName} must be set by the E2E harness.");
+        }
+        return value;
     }
 
     private static void RunWithDiagnostics(string testName, Action<GorillaAppSession> test)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -39,6 +39,7 @@ public sealed class CatalogSurfaceTests
                     StringComparison.OrdinalIgnoreCase
                 )
             );
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("catalog-cards", includeAutomationTree: true);
         });
     }
@@ -55,6 +56,7 @@ public sealed class CatalogSurfaceTests
 
             home.Search(FailureFixtureItemName);
             session.WaitUntil(() => home.HasItem(FailureFixtureItemName) && !home.HasItem(FixtureItemName));
+            home.EnsureItemVisible(FailureFixtureItemName);
             session.CaptureCheckpoint("catalog-search-name", includeAutomationTree: true);
 
             home.ClearSearch();
@@ -77,6 +79,7 @@ public sealed class CatalogSurfaceTests
 
             session.WaitUntil(() => home.HasItem(InstalledFixtureItemName) && !home.HasItem(UpdateFixtureItemName));
             Assert.False(home.HasDescriptionElement(InstalledFixtureItemName));
+            home.EnsureItemVisible(InstalledFixtureItemName);
             session.CaptureCheckpoint("catalog-search-description", includeAutomationTree: true);
 
             home.ClearSearch();
@@ -149,6 +152,7 @@ public sealed class CatalogSurfaceTests
             Assert.True(primary.IsEnabled);
             Assert.Equal("Remove", secondary.Name);
             Assert.True(secondary.IsEnabled);
+            home.EnsureItemVisible(UpdateFixtureItemName);
             session.CaptureCheckpoint("catalog-update-dual-action", includeAutomationTree: true);
         });
     }
@@ -171,6 +175,7 @@ public sealed class CatalogSurfaceTests
             Assert.True(primary.IsEnabled);
             Assert.Equal("Remove", secondary.Name);
             Assert.True(secondary.IsEnabled);
+            home.EnsureItemVisible(InstalledFixtureItemName);
             session.CaptureCheckpoint("catalog-installed-unselected-dual-action", includeAutomationTree: true);
         });
     }
@@ -206,6 +211,7 @@ public sealed class CatalogSurfaceTests
             Assert.Equal("Not installed", home.ItemStatus(SlowFixtureItemName));
             Assert.False(home.PrimaryActionButton(SlowFixtureItemName).IsEnabled);
             Assert.InRange(home.PrimaryActionTop(SlowFixtureItemName), actionTopBefore - 1.0, actionTopBefore + 1.0);
+            home.EnsureItemVisible(SlowFixtureItemName);
             session.CaptureCheckpoint("catalog-active-operation", includeAutomationTree: true);
 
             session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -1,0 +1,100 @@
+using FlaUI.Core.Definitions;
+using Xunit;
+
+namespace Gorilla.UI.App.WindowsUiTests;
+
+public sealed class CatalogSurfaceTests
+{
+    private const string FixtureItemName = "Ps1V1";
+    private const string FailureFixtureItemName = "Ps1Failure";
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void CatalogRendersCardsAndMissingDescriptionWithoutPlaceholder()
+    {
+        RunWithDiagnostics(nameof(CatalogRendersCardsAndMissingDescriptionWithoutPlaceholder), session =>
+        {
+            var home = new HomePageDriver(session);
+
+            _ = home.WaitForCard(FixtureItemName);
+            _ = home.WaitForCard(FailureFixtureItemName);
+            Assert.Equal("Not installed", home.ItemStatus(FixtureItemName));
+            Assert.Null(home.Description(FailureFixtureItemName));
+            Assert.DoesNotContain(
+                session.MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Text)),
+                element => string.Equals(element.Name, "No description available", StringComparison.OrdinalIgnoreCase)
+            );
+            session.CaptureCheckpoint("catalog-cards", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void SearchByNameFiltersAndClearingRestoresCatalog()
+    {
+        RunWithDiagnostics(nameof(SearchByNameFiltersAndClearingRestoresCatalog), session =>
+        {
+            var home = new HomePageDriver(session);
+            _ = home.WaitForItem(FixtureItemName);
+            _ = home.WaitForItem(FailureFixtureItemName);
+
+            home.Search(FailureFixtureItemName);
+            session.WaitUntil(() => home.HasItem(FailureFixtureItemName) && !home.HasItem(FixtureItemName));
+            session.CaptureCheckpoint("catalog-search-name", includeAutomationTree: true);
+
+            home.ClearSearch();
+            session.WaitUntil(() => home.HasItem(FixtureItemName) && home.HasItem(FailureFixtureItemName));
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void SearchNoResultsUsesQuerySpecificStateAndClearingRestoresCatalog()
+    {
+        RunWithDiagnostics(nameof(SearchNoResultsUsesQuerySpecificStateAndClearingRestoresCatalog), session =>
+        {
+            var home = new HomePageDriver(session);
+            _ = home.WaitForItem(FixtureItemName);
+
+            const string query = "definitely-no-such-gorilla-app";
+            home.Search(query);
+            var noResults = home.WaitForSearchNoResults();
+            Assert.Contains(query, noResults.Name, StringComparison.OrdinalIgnoreCase);
+            session.CaptureCheckpoint("catalog-search-no-results", includeAutomationTree: true);
+
+            home.ClearSearch();
+            _ = home.WaitForItem(FixtureItemName);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void AbsentFixtureShowsOnePrimaryInstallAction()
+    {
+        RunWithDiagnostics(nameof(AbsentFixtureShowsOnePrimaryInstallAction), session =>
+        {
+            var home = new HomePageDriver(session);
+            var card = home.WaitForCard(FailureFixtureItemName);
+            var primary = card.FindFirstDescendant(cf => cf.ByAutomationId("PrimaryActionButton"));
+            var secondary = card.FindFirstDescendant(cf => cf.ByAutomationId("SecondaryActionButton"));
+
+            Assert.NotNull(primary);
+            Assert.Equal("Install", primary!.Name);
+            Assert.Null(secondary);
+        });
+    }
+
+    private static void RunWithDiagnostics(string testName, Action<GorillaAppSession> test)
+    {
+        using var session = GorillaAppSession.Launch();
+        try
+        {
+            test(session);
+        }
+        catch (Exception ex)
+        {
+            session.CaptureFailure(ex, testName);
+            throw;
+        }
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogSurfaceTests.cs
@@ -27,9 +27,7 @@ public sealed class CatalogSurfaceTests
             _ = home.WaitForCard(InstalledFixtureItemName);
 
             var width = home.CardWidth(FixtureItemName);
-            var height = home.CardHeight(FixtureItemName);
             Assert.InRange(width, 299.5, 340.5);
-            Assert.InRange(height, 203.5, 204.5);
             Assert.False(home.HasDescriptionElement(FixtureItemName));
             Assert.False(home.HasDescriptionElement(FailureFixtureItemName));
             Assert.False(home.HasDescriptionElement(InstalledFixtureItemName));
@@ -201,12 +199,13 @@ public sealed class CatalogSurfaceTests
                 home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
             }
 
+            var actionTopBefore = home.PrimaryActionTop(SlowFixtureItemName);
             home.PrimaryActionButton(SlowFixtureItemName).Invoke();
 
             home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
             Assert.Equal("Not installed", home.ItemStatus(SlowFixtureItemName));
             Assert.False(home.PrimaryActionButton(SlowFixtureItemName).IsEnabled);
-            Assert.InRange(home.CardHeight(SlowFixtureItemName), 203.5, 204.5);
+            Assert.InRange(home.PrimaryActionTop(SlowFixtureItemName), actionTopBefore - 1.0, actionTopBefore + 1.0);
             session.CaptureCheckpoint("catalog-active-operation", includeAutomationTree: true);
 
             session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
@@ -22,6 +22,7 @@ public sealed class CriticalPathTests
             home.WaitForItemStatus(FixtureItemName, "NotInstalled");
             Assert.True(File.Exists(cachePath), $"Expected startup cache at {cachePath}.");
             Assert.False(File.Exists(markerPath), $"Fixture marker should be absent before install: {markerPath}");
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("healthy-startup", includeAutomationTree: true);
 
             var startupCacheWrite = File.GetLastWriteTimeUtc(cachePath);
@@ -32,6 +33,7 @@ public sealed class CriticalPathTests
             home.WaitForItemStatus(FixtureItemName, "Installed", TimeSpan.FromSeconds(30));
             Assert.False(home.HasOperationFailureText());
             Assert.DoesNotContain("failed", home.WarningText, StringComparison.OrdinalIgnoreCase);
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("after-install");
 
             var installRefreshWrite = File.GetLastWriteTimeUtc(cachePath);
@@ -42,6 +44,7 @@ public sealed class CriticalPathTests
             home.WaitForItemStatus(FixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
             Assert.False(home.HasOperationFailureText());
             Assert.DoesNotContain("failed", home.WarningText, StringComparison.OrdinalIgnoreCase);
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("after-remove");
         });
     }
@@ -66,6 +69,7 @@ public sealed class CriticalPathTests
             session.WaitUntil(() => File.Exists(markerPath), TimeSpan.FromSeconds(60));
             home.WaitForItemStatus(FixtureItemName, "Installed", TimeSpan.FromSeconds(30));
             Assert.False(home.HasOperationFailureText());
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("reopen-after-install-before-close", includeAutomationTree: true);
         });
 
@@ -78,6 +82,7 @@ public sealed class CriticalPathTests
             home.WaitForItemStatus(FixtureItemName, "Installed", TimeSpan.FromSeconds(30));
             Assert.True(File.Exists(markerPath), $"Fixture marker should remain present after UI relaunch: {markerPath}");
             Assert.False(home.HasOperationFailureText());
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("reopen-installed", includeAutomationTree: true);
 
             home.RemoveButton(FixtureItemName).Invoke();
@@ -85,6 +90,7 @@ public sealed class CriticalPathTests
             session.WaitUntil(() => !File.Exists(markerPath), TimeSpan.FromSeconds(60));
             home.WaitForItemStatus(FixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
             Assert.False(home.HasOperationFailureText());
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("reopen-after-remove-before-close", includeAutomationTree: true);
         });
 
@@ -97,6 +103,7 @@ public sealed class CriticalPathTests
             home.WaitForItemStatus(FixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
             Assert.False(File.Exists(markerPath), $"Fixture marker should remain absent after UI relaunch: {markerPath}");
             Assert.False(home.HasOperationFailureText());
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("reopen-not-installed", includeAutomationTree: true);
         });
     }
@@ -113,6 +120,7 @@ public sealed class CriticalPathTests
             _ = home.WaitForItem(FailureFixtureItemName);
             home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled");
             var actionTopBefore = home.PrimaryActionTop(FailureFixtureItemName);
+            home.EnsureItemVisible(FailureFixtureItemName);
             session.CaptureCheckpoint("failure-before-install", includeAutomationTree: true);
 
             home.InstallButton(FailureFixtureItemName).Invoke();
@@ -129,6 +137,7 @@ public sealed class CriticalPathTests
             );
             Assert.InRange(home.PrimaryActionTop(FailureFixtureItemName), actionTopBefore - 1.0, actionTopBefore + 1.0);
             home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
+            home.EnsureItemVisible(FailureFixtureItemName);
             session.CaptureCheckpoint("failure-after-install", includeAutomationTree: true);
         });
     }
@@ -143,6 +152,7 @@ public sealed class CriticalPathTests
             Assert.Equal("Available Software", home.Heading.Name);
             _ = home.WaitForItem(FixtureItemName);
             home.WaitForWarningContaining("Showing cached data. Refresh failed", TimeSpan.FromSeconds(15));
+            home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("cached-service-unavailable", includeAutomationTree: true);
         });
     }

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
@@ -104,9 +104,9 @@ public sealed class CriticalPathTests
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
-    public void DeliberateInstallerFailureIsDisplayedAsFailure()
+    public void DeliberateInstallerFailureIsDisplayedOnItsCard()
     {
-        RunWithDiagnostics(nameof(DeliberateInstallerFailureIsDisplayedAsFailure), session =>
+        RunWithDiagnostics(nameof(DeliberateInstallerFailureIsDisplayedOnItsCard), session =>
         {
             var home = new HomePageDriver(session);
 
@@ -117,9 +117,16 @@ public sealed class CriticalPathTests
 
             home.InstallButton(FailureFixtureItemName).Invoke();
 
-            home.WaitForWarningContaining("ended with Failed", TimeSpan.FromSeconds(60));
-            Assert.Contains("Installation error: exit status 7", home.WarningText, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("Succeeded", home.WarningText, StringComparison.OrdinalIgnoreCase);
+            home.WaitForTerminalFeedbackContaining(FailureFixtureItemName, "Failed:", TimeSpan.FromSeconds(60));
+            Assert.Contains(
+                "Installation error: exit status 7",
+                home.TerminalFeedbackText(FailureFixtureItemName),
+                StringComparison.OrdinalIgnoreCase
+            );
+            Assert.True(
+                string.IsNullOrWhiteSpace(home.WarningText),
+                $"Item-specific failure should not populate the page warning: {home.WarningText}"
+            );
             home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
             session.CaptureCheckpoint("failure-after-install", includeAutomationTree: true);
         });

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
@@ -28,7 +28,6 @@ public sealed class CriticalPathTests
             home.InstallButton(FixtureItemName).Invoke();
 
             session.WaitUntil(() => File.Exists(markerPath), TimeSpan.FromSeconds(60));
-            // Core refreshes the authoritative list/cache only after the operation stream reaches a terminal state.
             session.WaitUntil(() => File.GetLastWriteTimeUtc(cachePath) > startupCacheWrite, TimeSpan.FromSeconds(30));
             home.WaitForItemStatus(FixtureItemName, "Installed", TimeSpan.FromSeconds(30));
             Assert.False(home.HasOperationFailureText());
@@ -113,6 +112,7 @@ public sealed class CriticalPathTests
             Assert.Equal("Available Software", home.Heading.Name);
             _ = home.WaitForItem(FailureFixtureItemName);
             home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled");
+            var actionTopBefore = home.PrimaryActionTop(FailureFixtureItemName);
             session.CaptureCheckpoint("failure-before-install", includeAutomationTree: true);
 
             home.InstallButton(FailureFixtureItemName).Invoke();
@@ -127,6 +127,7 @@ public sealed class CriticalPathTests
                 string.IsNullOrWhiteSpace(home.WarningText),
                 $"Item-specific failure should not populate the page warning: {home.WarningText}"
             );
+            Assert.InRange(home.PrimaryActionTop(FailureFixtureItemName), actionTopBefore - 1.0, actionTopBefore + 1.0);
             home.WaitForItemStatus(FailureFixtureItemName, "NotInstalled", TimeSpan.FromSeconds(30));
             session.CaptureCheckpoint("failure-after-install", includeAutomationTree: true);
         });

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/GorillaAppSession.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/GorillaAppSession.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
@@ -9,6 +10,13 @@ namespace Gorilla.UI.App.WindowsUiTests;
 
 internal sealed class GorillaAppSession : IDisposable
 {
+    private const int SwRestore = 9;
+    private const uint SwpNoSize = 0x0001;
+    private const uint SwpNoMove = 0x0002;
+    private const uint SwpShowWindow = 0x0040;
+    private static readonly nint HwndTopmost = new(-1);
+    private static readonly nint HwndNotTopmost = new(-2);
+
     private readonly string _artifactsDirectory;
     private readonly Application _application;
     private readonly Process _process;
@@ -174,8 +182,19 @@ internal sealed class GorillaAppSession : IDisposable
             {
                 MainWindow = current;
             }
+
+            _process.Refresh();
+            var hwnd = _process.MainWindowHandle;
+            if (hwnd != nint.Zero)
+            {
+                _ = ShowWindow(hwnd, SwRestore);
+                _ = SetWindowPos(hwnd, HwndTopmost, 0, 0, 0, 0, SwpNoMove | SwpNoSize | SwpShowWindow);
+                _ = SetForegroundWindow(hwnd);
+                _ = SetWindowPos(hwnd, HwndNotTopmost, 0, 0, 0, 0, SwpNoMove | SwpNoSize | SwpShowWindow);
+            }
+
             MainWindow.Focus();
-            Thread.Sleep(100);
+            Thread.Sleep(250);
         });
     }
 
@@ -322,4 +341,24 @@ internal sealed class GorillaAppSession : IDisposable
         _process.Dispose();
         _automation.Dispose();
     }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ShowWindow(nint hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetForegroundWindow(nint hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetWindowPos(
+        nint hWnd,
+        nint hWndInsertAfter,
+        int x,
+        int y,
+        int cx,
+        int cy,
+        uint flags
+    );
 }

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/GorillaAppSession.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/GorillaAppSession.cs
@@ -106,16 +106,13 @@ internal sealed class GorillaAppSession : IDisposable
 
     public void CaptureCheckpoint(string name, bool includeAutomationTree = false)
     {
-        BestEffort(() =>
-        {
-            var screenshotsDirectory = Path.Combine(_artifactsDirectory, "screenshots");
-            Directory.CreateDirectory(screenshotsDirectory);
-            using var image = MainWindow.Capture();
-            image.Save(Path.Combine(screenshotsDirectory, SafeFileName(name) + ".png"));
-        });
+        CaptureWindowScreenshot(name);
 
         if (includeAutomationTree)
         {
+            var checkpointTree = $"automation-tree-{SafeFileName(name)}.txt";
+            CaptureAutomationTree(checkpointTree);
+            // Preserve the conventional rolling filename used by workflow guidance.
             CaptureAutomationTree("automation-tree.txt");
         }
         CaptureProcessInfo();
@@ -123,6 +120,8 @@ internal sealed class GorillaAppSession : IDisposable
 
     public void CaptureAutomationTree(string fileName = "automation-tree.txt")
     {
+        RefreshAndFocusMainWindow();
+
         var builder = new StringBuilder();
         builder.AppendLine("UI Automation tree");
         try
@@ -149,15 +148,35 @@ internal sealed class GorillaAppSession : IDisposable
                 Path.Combine(_artifactsDirectory, $"failure-{SafeFileName(testName)}.txt"),
                 exception + Environment.NewLine + BuildProcessInfo());
         });
+        CaptureWindowScreenshot($"failure-{SafeFileName(testName)}");
+        CaptureAutomationTree("automation-tree-failure.txt");
+        CaptureProcessInfo();
+    }
+
+    private void CaptureWindowScreenshot(string name)
+    {
+        RefreshAndFocusMainWindow();
         BestEffort(() =>
         {
             var screenshotsDirectory = Path.Combine(_artifactsDirectory, "screenshots");
             Directory.CreateDirectory(screenshotsDirectory);
             using var image = MainWindow.Capture();
-            image.Save(Path.Combine(screenshotsDirectory, $"failure-{SafeFileName(testName)}.png"));
+            image.Save(Path.Combine(screenshotsDirectory, SafeFileName(name) + ".png"));
         });
-        CaptureAutomationTree("automation-tree-failure.txt");
-        CaptureProcessInfo();
+    }
+
+    private void RefreshAndFocusMainWindow()
+    {
+        BestEffort(() =>
+        {
+            var current = _application.GetMainWindow(_automation, TimeSpan.FromMilliseconds(500));
+            if (current is not null)
+            {
+                MainWindow = current;
+            }
+            MainWindow.Focus();
+            Thread.Sleep(100);
+        });
     }
 
     private string BuildProcessInfo()

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -75,10 +75,8 @@ internal sealed class HomePageDriver
 
     public double CardWidth(string itemName) => WaitForCard(itemName).BoundingRectangle.Width;
 
-    // The inner Border's UI Automation peer reports only its semantic/content
-    // extent on WinUI, not the full fixed-height GridView layout slot. Measure
-    // the item container for height so this assertion tracks rendered layout.
-    public double CardHeight(string itemName) => WaitForItem(itemName).BoundingRectangle.Height;
+    public double PrimaryActionTop(string itemName)
+        => PrimaryActionButton(itemName).BoundingRectangle.Top;
 
     public bool HasItem(string itemName)
         => CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName)) is not null;

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -14,24 +14,54 @@ internal sealed class HomePageDriver
     }
 
     public AutomationElement Heading => _session.WaitFor(() => ById("HomeHeading"));
-    public AutomationElement ItemsList => _session.WaitFor(() => ById("ItemsList"));
+    public AutomationElement CatalogItems => _session.WaitFor(() => ById("CatalogItems"));
     public AutomationElement ServiceWarning => _session.WaitFor(() => ById("ServiceWarning"));
+    public TextBox SearchBox => _session.WaitFor(() => ById("CatalogSearchBox")?.AsTextBox());
     public string WarningText => SafeName(ServiceWarning);
 
     public AutomationElement WaitForItem(string itemName)
     {
-        return _session.WaitFor(() => ItemsList.FindFirstDescendant(cf => cf.ByAutomationId(itemName)));
+        return _session.WaitFor(() => CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName)));
     }
 
-    public Button InstallButton(string itemName) => ButtonFor(itemName, "InstallButton");
-    public Button RemoveButton(string itemName) => ButtonFor(itemName, "RemoveButton");
+    public AutomationElement WaitForCard(string itemName)
+    {
+        var item = WaitForItem(itemName);
+        return _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogCard")));
+    }
+
+    public Button InstallButton(string itemName) => ActionButton(itemName, "Install", "Update", "Keep Installed");
+    public Button RemoveButton(string itemName) => ActionButton(itemName, "Remove");
 
     public string ItemStatus(string itemName)
     {
         var item = WaitForItem(itemName);
-        var status = _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("ItemStatus")));
+        var status = _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogObservation")));
         return SafeName(status);
     }
+
+    public string? Description(string itemName)
+    {
+        var item = WaitForItem(itemName);
+        var description = item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogDescription"));
+        return description is null ? null : SafeName(description);
+    }
+
+    public bool HasItem(string itemName)
+        => CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName)) is not null;
+
+    public void Search(string query)
+    {
+        SearchBox.Text = query;
+    }
+
+    public void ClearSearch()
+    {
+        SearchBox.Text = string.Empty;
+    }
+
+    public AutomationElement WaitForSearchNoResults()
+        => _session.WaitFor(() => ById("SearchNoResults"));
 
     public void WaitForItemStatus(string itemName, string expectedPrefix, TimeSpan? timeout = null)
     {
@@ -61,10 +91,21 @@ internal sealed class HomePageDriver
         return _session.MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
     }
 
-    private Button ButtonFor(string itemName, string automationId)
+    private Button ActionButton(string itemName, params string[] labels)
     {
         var item = WaitForItem(itemName);
-        return _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId(automationId))?.AsButton());
+        return _session.WaitFor(() =>
+        {
+            foreach (var button in item.FindAllDescendants(cf => cf.ByControlType(ControlType.Button)))
+            {
+                var name = SafeName(button);
+                if (labels.Any(label => string.Equals(name, label, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return button.AsButton();
+                }
+            }
+            return null;
+        });
     }
 
     private static string SafeName(AutomationElement element)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -66,6 +66,16 @@ internal sealed class HomePageDriver
         return operation is null ? string.Empty : SafeName(operation);
     }
 
+    public string TerminalFeedbackText(string itemName)
+    {
+        var catalog = ById("CatalogItems");
+        var item = catalog?.FindFirstDescendant(cf => cf.ByAutomationId(itemName));
+        var feedback = item?.FindFirstDescendant(cf => cf.ByAutomationId("CatalogTerminalFeedback"));
+        return feedback is null ? string.Empty : SafeName(feedback);
+    }
+
+    public double CardWidth(string itemName) => WaitForCard(itemName).BoundingRectangle.Width;
+
     public bool HasItem(string itemName)
         => CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName)) is not null;
 
@@ -99,6 +109,14 @@ internal sealed class HomePageDriver
     {
         _session.WaitUntil(
             () => OperationText(itemName).Contains(expected, StringComparison.OrdinalIgnoreCase),
+            timeout
+        );
+    }
+
+    public void WaitForTerminalFeedbackContaining(string itemName, string expected, TimeSpan? timeout = null)
+    {
+        _session.WaitUntil(
+            () => TerminalFeedbackText(itemName).Contains(expected, StringComparison.OrdinalIgnoreCase),
             timeout
         );
     }

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -30,6 +30,13 @@ internal sealed class HomePageDriver
         return _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogCard")));
     }
 
+    public void EnsureItemVisible(string itemName)
+    {
+        var item = WaitForItem(itemName);
+        item.Focus();
+        Thread.Sleep(150);
+    }
+
     public Button InstallButton(string itemName) => ActionButton(itemName, "Install", "Update", "Keep Installed");
     public Button RemoveButton(string itemName) => ActionButton(itemName, "Remove");
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -61,8 +61,13 @@ internal sealed class HomePageDriver
 
     public string OperationText(string itemName)
     {
-        var item = WaitForItem(itemName);
-        var operation = _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogOperation")));
+        var item = CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName));
+        var operation = item?.FindFirstDescendant(cf => cf.ByAutomationId("CatalogOperation"));
+        if (operation is null)
+        {
+            return string.Empty;
+        }
+
         return string.Join(
             " ",
             operation
@@ -118,6 +123,8 @@ internal sealed class HomePageDriver
             .FindAllDescendants(cf => cf.ByControlType(ControlType.Text))
             .Any(text => SafeName(text).StartsWith("Operation failed", StringComparison.OrdinalIgnoreCase));
     }
+
+    public static string AutomationName(AutomationElement element) => SafeName(element);
 
     private AutomationElement? ById(string automationId)
     {

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -47,9 +47,8 @@ internal sealed class HomePageDriver
 
     public string ItemStatus(string itemName)
     {
-        var item = WaitForItem(itemName);
-        var status = _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogObservation")));
-        return SafeName(status);
+        var status = TryItemStatus(itemName);
+        return status ?? string.Empty;
     }
 
     public string? Description(string itemName)
@@ -96,7 +95,12 @@ internal sealed class HomePageDriver
     public void WaitForItemStatus(string itemName, string expectedPrefix, TimeSpan? timeout = null)
     {
         _session.WaitUntil(
-            () => Normalize(ItemStatus(itemName)).StartsWith(Normalize(expectedPrefix), StringComparison.OrdinalIgnoreCase),
+            () =>
+            {
+                var status = TryItemStatus(itemName);
+                return status is not null
+                    && Normalize(status).StartsWith(Normalize(expectedPrefix), StringComparison.OrdinalIgnoreCase);
+            },
             timeout
         );
     }
@@ -125,6 +129,14 @@ internal sealed class HomePageDriver
     }
 
     public static string AutomationName(AutomationElement element) => SafeName(element);
+
+    private string? TryItemStatus(string itemName)
+    {
+        var catalog = ById("CatalogItems");
+        var item = catalog?.FindFirstDescendant(cf => cf.ByAutomationId(itemName));
+        var status = item?.FindFirstDescendant(cf => cf.ByAutomationId("CatalogObservation"));
+        return status is null ? null : SafeName(status);
+    }
 
     private AutomationElement? ById(string automationId)
     {

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -33,8 +33,9 @@ internal sealed class HomePageDriver
     public void EnsureItemVisible(string itemName)
     {
         var item = WaitForItem(itemName);
+        item.Patterns.ScrollItem.PatternOrDefault?.ScrollIntoView();
         item.Focus();
-        Thread.Sleep(150);
+        Thread.Sleep(250);
     }
 
     public Button InstallButton(string itemName) => ActionButton(itemName, "Install", "Update", "Keep Installed");

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -60,20 +60,10 @@ internal sealed class HomePageDriver
 
     public string OperationText(string itemName)
     {
-        var item = CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName));
+        var catalog = ById("CatalogItems");
+        var item = catalog?.FindFirstDescendant(cf => cf.ByAutomationId(itemName));
         var operation = item?.FindFirstDescendant(cf => cf.ByAutomationId("CatalogOperation"));
-        if (operation is null)
-        {
-            return string.Empty;
-        }
-
-        return string.Join(
-            " ",
-            operation
-                .FindAllDescendants(cf => cf.ByControlType(ControlType.Text))
-                .Select(SafeName)
-                .Where(name => !string.IsNullOrWhiteSpace(name))
-        );
+        return operation is null ? string.Empty : SafeName(operation);
     }
 
     public bool HasItem(string itemName)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -33,6 +33,18 @@ internal sealed class HomePageDriver
     public Button InstallButton(string itemName) => ActionButton(itemName, "Install", "Update", "Keep Installed");
     public Button RemoveButton(string itemName) => ActionButton(itemName, "Remove");
 
+    public Button PrimaryActionButton(string itemName)
+        => ButtonByAutomationId(itemName, "PrimaryActionButton");
+
+    public Button SecondaryActionButton(string itemName)
+        => ButtonByAutomationId(itemName, "SecondaryActionButton");
+
+    public bool HasSecondaryAction(string itemName)
+    {
+        var item = WaitForItem(itemName);
+        return item.FindFirstDescendant(cf => cf.ByAutomationId("SecondaryActionButton")) is not null;
+    }
+
     public string ItemStatus(string itemName)
     {
         var item = WaitForItem(itemName);
@@ -45,6 +57,13 @@ internal sealed class HomePageDriver
         var item = WaitForItem(itemName);
         var description = item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogDescription"));
         return description is null ? null : SafeName(description);
+    }
+
+    public string OperationText(string itemName)
+    {
+        var item = WaitForItem(itemName);
+        var operation = _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogOperation")));
+        return SafeName(operation);
     }
 
     public bool HasItem(string itemName)
@@ -67,6 +86,14 @@ internal sealed class HomePageDriver
     {
         _session.WaitUntil(
             () => Normalize(ItemStatus(itemName)).StartsWith(Normalize(expectedPrefix), StringComparison.OrdinalIgnoreCase),
+            timeout
+        );
+    }
+
+    public void WaitForOperationContaining(string itemName, string expected, TimeSpan? timeout = null)
+    {
+        _session.WaitUntil(
+            () => OperationText(itemName).Contains(expected, StringComparison.OrdinalIgnoreCase),
             timeout
         );
     }
@@ -106,6 +133,12 @@ internal sealed class HomePageDriver
             }
             return null;
         });
+    }
+
+    private Button ButtonByAutomationId(string itemName, string automationId)
+    {
+        var item = WaitForItem(itemName);
+        return _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId(automationId))?.AsButton());
     }
 
     private static string Normalize(string value)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -74,7 +74,11 @@ internal sealed class HomePageDriver
     }
 
     public double CardWidth(string itemName) => WaitForCard(itemName).BoundingRectangle.Width;
-    public double CardHeight(string itemName) => WaitForCard(itemName).BoundingRectangle.Height;
+
+    // The inner Border's UI Automation peer reports only its semantic/content
+    // extent on WinUI, not the full fixed-height GridView layout slot. Measure
+    // the item container for height so this assertion tracks rendered layout.
+    public double CardHeight(string itemName) => WaitForItem(itemName).BoundingRectangle.Height;
 
     public bool HasItem(string itemName)
         => CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName)) is not null;

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -63,7 +63,13 @@ internal sealed class HomePageDriver
     {
         var item = WaitForItem(itemName);
         var operation = _session.WaitFor(() => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogOperation")));
-        return SafeName(operation);
+        return string.Join(
+            " ",
+            operation
+                .FindAllDescendants(cf => cf.ByControlType(ControlType.Text))
+                .Select(SafeName)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+        );
     }
 
     public bool HasItem(string itemName)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -66,7 +66,7 @@ internal sealed class HomePageDriver
     public void WaitForItemStatus(string itemName, string expectedPrefix, TimeSpan? timeout = null)
     {
         _session.WaitUntil(
-            () => ItemStatus(itemName).StartsWith(expectedPrefix, StringComparison.OrdinalIgnoreCase),
+            () => Normalize(ItemStatus(itemName)).StartsWith(Normalize(expectedPrefix), StringComparison.OrdinalIgnoreCase),
             timeout
         );
     }
@@ -107,6 +107,9 @@ internal sealed class HomePageDriver
             return null;
         });
     }
+
+    private static string Normalize(string value)
+        => value.Replace(" ", string.Empty, StringComparison.Ordinal);
 
     private static string SafeName(AutomationElement element)
     {

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -51,13 +51,6 @@ internal sealed class HomePageDriver
         return status ?? string.Empty;
     }
 
-    public string? Description(string itemName)
-    {
-        var item = WaitForItem(itemName);
-        var description = item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogDescription"));
-        return description is null ? null : SafeName(description);
-    }
-
     public string OperationText(string itemName)
     {
         var catalog = ById("CatalogItems");
@@ -74,7 +67,14 @@ internal sealed class HomePageDriver
         return feedback is null ? string.Empty : SafeName(feedback);
     }
 
+    public bool HasDescriptionElement(string itemName)
+    {
+        var item = WaitForItem(itemName);
+        return item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogDescription")) is not null;
+    }
+
     public double CardWidth(string itemName) => WaitForCard(itemName).BoundingRectangle.Width;
+    public double CardHeight(string itemName) => WaitForCard(itemName).BoundingRectangle.Height;
 
     public bool HasItem(string itemName)
         => CatalogItems.FindFirstDescendant(cf => cf.ByAutomationId(itemName)) is not null;

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
@@ -1,0 +1,132 @@
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using Gorilla.UI.Core.Models;
+using Xunit;
+using CatalogAction = Gorilla.UI.Client.AppCatalog.Action;
+
+namespace Gorilla.UI.Core.Tests;
+
+public sealed class CatalogCardPresentationMapperTests
+{
+    [Fact]
+    public void Absent_WithInstallOnly_PresentsOnePrimaryInstallAction()
+    {
+        var item = Item(ObservedState.Absent, installAllowed: true, removeAllowed: false);
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal("Install", presentation.PrimaryAction?.Label);
+        Assert.Equal(CatalogCardActionKind.Install, presentation.PrimaryAction?.Kind);
+        Assert.Null(presentation.SecondaryAction);
+    }
+
+    [Fact]
+    public void Installed_WithRemoveOnly_PresentsOnePrimaryRemoveAction()
+    {
+        var item = Item(ObservedState.Installed, installAllowed: false, removeAllowed: true);
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal("Remove", presentation.PrimaryAction?.Label);
+        Assert.Equal(CatalogCardActionKind.Remove, presentation.PrimaryAction?.Kind);
+        Assert.Null(presentation.SecondaryAction);
+    }
+
+    [Fact]
+    public void UpdateAvailable_WithBothAllowed_PresentsUpdateThenRemove()
+    {
+        var item = Item(ObservedState.UpdateAvailable, installAllowed: true, removeAllowed: true);
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal("Update", presentation.PrimaryAction?.Label);
+        Assert.Equal(CatalogCardActionKind.Install, presentation.PrimaryAction?.Kind);
+        Assert.Equal("Remove", presentation.SecondaryAction?.Label);
+        Assert.Equal(CatalogCardActionKind.Remove, presentation.SecondaryAction?.Kind);
+    }
+
+    [Fact]
+    public void InstalledUnselected_WithBothAllowed_PresentsKeepInstalledThenRemove()
+    {
+        var item = Item(ObservedState.Installed, installAllowed: true, removeAllowed: true);
+        item.Policy = new Policy(
+            Optional: true,
+            RequiredInstall: false,
+            RequiredUninstall: false,
+            RequiredDependency: false,
+            Selection: Selection.None
+        );
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal("Keep Installed", presentation.PrimaryAction?.Label);
+        Assert.Equal(CatalogCardActionKind.Install, presentation.PrimaryAction?.Kind);
+        Assert.Equal("Remove", presentation.SecondaryAction?.Label);
+    }
+
+    [Fact]
+    public void NeitherAllowed_PresentsNoAction()
+    {
+        var presentation = CatalogCardPresentationMapper.Map(
+            Item(ObservedState.Installed, installAllowed: false, removeAllowed: false)
+        );
+
+        Assert.Null(presentation.PrimaryAction);
+        Assert.Null(presentation.SecondaryAction);
+    }
+
+    [Fact]
+    public void BusyItem_PreservesActionsDisabledAndShowsOperationSeparately()
+    {
+        var item = Item(ObservedState.Installed, installAllowed: true, removeAllowed: true);
+        item.IsBusy = true;
+        item.ActiveOperation = new UiOperationPresentation(
+            OperationId: "op-1",
+            Action: CatalogAction.Remove,
+            State: OperationState.Removing,
+            ProgressPercent: null,
+            Result: null,
+            Message: "Removing files",
+            TimestampUtc: DateTimeOffset.Parse("2026-09-11T15:00:00Z")
+        );
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal("Installed", presentation.ObservationText);
+        Assert.Equal("Removing…", presentation.OperationText);
+        Assert.True(presentation.IsProgressIndeterminate);
+        Assert.False(presentation.PrimaryAction?.Enabled);
+        Assert.False(presentation.SecondaryAction?.Enabled);
+    }
+
+    [Fact]
+    public void UpdateVersion_UsesProvidedVersionsWithoutComparingThem()
+    {
+        var item = Item(ObservedState.UpdateAvailable, installAllowed: true, removeAllowed: true);
+        item.Observation = item.Observation with { InstalledVersion = "1.7" };
+        item.TargetVersion = "2.0";
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal("1.7 → 2.0", presentation.VersionText);
+    }
+
+    private static UiOptionalInstallItem Item(
+        ObservedState observedState,
+        bool installAllowed,
+        bool removeAllowed
+    ) => new()
+    {
+        ItemName = "Fixture",
+        DisplayName = "Fixture App",
+        Observation = new Observation(
+            observedState,
+            InstalledVersion: null,
+            CheckedAtUtc: null,
+            DetailCode: string.Empty,
+            InstallRequirement: RequirementState.Unknown
+        ),
+        InstallDecision = new ActionDecision(installAllowed, string.Empty),
+        RemoveDecision = new ActionDecision(removeAllowed, string.Empty),
+    };
+}

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
@@ -170,7 +170,7 @@ public sealed class CatalogCardPresentationMapperTests
         Action: CatalogAction.Install,
         State: OperationState.Completed,
         ProgressPercent: null,
-        Result: new Result(outcome, "terminal", message),
+        Result: new Result(outcome, "terminal", Message: message),
         Message: message,
         TimestampUtc: DateTimeOffset.Parse("2026-09-11T15:00:00Z")
     );

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
@@ -99,6 +99,60 @@ public sealed class CatalogCardPresentationMapperTests
         Assert.False(presentation.SecondaryAction!.Enabled);
     }
 
+    [Theory]
+    [InlineData(Outcome.Failed, "Installer exited with code 1", "Failed: Installer exited with code 1")]
+    [InlineData(Outcome.Unverified, "Unable to confirm installed state", "Unable to verify: Unable to confirm installed state")]
+    [InlineData(Outcome.Interrupted, "Service operation was interrupted", "Interrupted: Service operation was interrupted")]
+    public void TerminalProblem_IsPresentedOnCard(
+        Outcome outcome,
+        string message,
+        string expected
+    )
+    {
+        var item = Item(ObservedState.Absent, installAllowed: true, removeAllowed: false);
+        item.LatestOperation = TerminalOperation(outcome, message);
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal(expected, presentation.TerminalFeedbackText);
+        Assert.True(presentation.HasTerminalFeedback);
+    }
+
+    [Theory]
+    [InlineData(Outcome.Succeeded)]
+    [InlineData(Outcome.AlreadySatisfied)]
+    public void SuccessfulTerminalOutcome_DoesNotAddCardFeedback(Outcome outcome)
+    {
+        var item = Item(ObservedState.Installed, installAllowed: false, removeAllowed: true);
+        item.LatestOperation = TerminalOperation(outcome, "Done");
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Null(presentation.TerminalFeedbackText);
+        Assert.False(presentation.HasTerminalFeedback);
+    }
+
+    [Fact]
+    public void NewActiveOperation_SuppressesStaleTerminalFeedback()
+    {
+        var item = Item(ObservedState.Absent, installAllowed: true, removeAllowed: false);
+        item.LatestOperation = TerminalOperation(Outcome.Failed, "Previous failure");
+        item.ActiveOperation = new UiOperationPresentation(
+            OperationId: "op-new",
+            Action: CatalogAction.Install,
+            State: OperationState.Installing,
+            ProgressPercent: null,
+            Result: null,
+            Message: "Installing",
+            TimestampUtc: DateTimeOffset.Parse("2026-09-11T15:01:00Z")
+        );
+
+        var presentation = CatalogCardPresentationMapper.Map(item);
+
+        Assert.Equal("Installing…", presentation.OperationText);
+        Assert.Null(presentation.TerminalFeedbackText);
+    }
+
     [Fact]
     public void UpdateVersion_UsesProvidedVersionsWithoutComparingThem()
     {
@@ -110,6 +164,16 @@ public sealed class CatalogCardPresentationMapperTests
 
         Assert.Equal("1.7 → 2.0", presentation.VersionText);
     }
+
+    private static UiOperationPresentation TerminalOperation(Outcome outcome, string message) => new(
+        OperationId: "op-terminal",
+        Action: CatalogAction.Install,
+        State: OperationState.Completed,
+        ProgressPercent: null,
+        Result: new Result(outcome, "terminal", message),
+        Message: message,
+        TimestampUtc: DateTimeOffset.Parse("2026-09-11T15:00:00Z")
+    );
 
     private static UiOptionalInstallItem Item(
         ObservedState observedState,

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardPresentationMapperTests.cs
@@ -95,8 +95,8 @@ public sealed class CatalogCardPresentationMapperTests
         Assert.Equal("Installed", presentation.ObservationText);
         Assert.Equal("Removing…", presentation.OperationText);
         Assert.True(presentation.IsProgressIndeterminate);
-        Assert.False(presentation.PrimaryAction?.Enabled);
-        Assert.False(presentation.SecondaryAction?.Enabled);
+        Assert.False(presentation.PrimaryAction!.Enabled);
+        Assert.False(presentation.SecondaryAction!.Enabled);
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardTransientFeedbackTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogCardTransientFeedbackTests.cs
@@ -1,0 +1,83 @@
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using Gorilla.UI.Core.Models;
+using Xunit;
+using CatalogAction = Gorilla.UI.Client.AppCatalog.Action;
+
+namespace Gorilla.UI.Core.Tests;
+
+public class CatalogCardTransientFeedbackTests
+{
+    [Fact]
+    public void TransientActionFeedback_UsesCardResultSlotAndIsSuppressedByActiveWork()
+    {
+        var item = new UiOptionalInstallItem
+        {
+            ItemName = "Example",
+            DisplayName = "Example",
+            Observation = new Observation(
+                ObservedState.Absent,
+                InstalledVersion: null,
+                CheckedAtUtc: DateTimeOffset.Parse("2026-09-11T20:00:00Z"),
+                DetailCode: string.Empty,
+                InstallRequirement: RequirementState.Unknown
+            ),
+            InstallDecision = new ActionDecision(true, string.Empty),
+            RemoveDecision = new ActionDecision(false, "already_absent"),
+        };
+
+        item.TransientFeedback = "Install was not accepted for Example.";
+
+        Assert.Equal(
+            "Install was not accepted for Example.",
+            item.CardPresentation.TerminalFeedbackText
+        );
+        Assert.True(item.CardPresentation.HasTerminalFeedback);
+
+        item.ActiveOperation = new UiOperationPresentation(
+            "op-1",
+            CatalogAction.Install,
+            OperationState.Installing,
+            ProgressPercent: null,
+            Result: null,
+            Message: "Installing",
+            TimestampUtc: DateTimeOffset.Parse("2026-09-11T20:00:01Z")
+        );
+
+        Assert.Null(item.CardPresentation.TerminalFeedbackText);
+        Assert.False(item.CardPresentation.HasTerminalFeedback);
+        Assert.Equal("Installing…", item.CardPresentation.OperationText);
+    }
+
+    [Fact]
+    public void TransientActionFeedback_SupersedesRetainedTerminalFeedbackUntilCleared()
+    {
+        var item = new UiOptionalInstallItem
+        {
+            ItemName = "Example",
+            DisplayName = "Example",
+            Observation = new Observation(
+                ObservedState.Absent,
+                InstalledVersion: null,
+                CheckedAtUtc: DateTimeOffset.Parse("2026-09-11T20:00:00Z"),
+                DetailCode: string.Empty,
+                InstallRequirement: RequirementState.Unknown
+            ),
+        };
+        item.LatestOperation = new UiOperationPresentation(
+            "op-old",
+            CatalogAction.Install,
+            OperationState.Completed,
+            ProgressPercent: null,
+            Result: new Result(Outcome.Failed, "execution_failed", Message: "old failure"),
+            Message: "old failure",
+            TimestampUtc: DateTimeOffset.Parse("2026-09-11T19:59:00Z")
+        );
+
+        item.TransientFeedback = "Install was not accepted for Example.";
+        Assert.Equal("Install was not accepted for Example.", item.CardPresentation.TerminalFeedbackText);
+
+        item.TransientFeedback = null;
+        Assert.Equal("Failed: old failure", item.CardPresentation.TerminalFeedbackText);
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
@@ -32,29 +32,56 @@ public class HomeViewModelMutationTests
     }
 
     [Fact]
-    public async Task InstallAsync_RejectedOperation_DoesNotTrackOrRefresh()
+    public async Task InstallAsync_RejectedOperation_StaysItemLocalAndDoesNotTrackOrRefresh()
     {
         var client = new FakeClient { InstallAsync = (_, _) => Task.FromResult(new OperationAccepted("op-1", false, Now)) };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
         await viewModel.InstallAsync(item, CancellationToken.None);
         Assert.False(item.IsBusy);
-        Assert.Equal("Install was not accepted for VLC.", viewModel.WarningBanner);
+        Assert.Equal("Install was not accepted for VLC.", item.TransientFeedback);
+        Assert.Equal("Install was not accepted for VLC.", item.CardPresentation.TerminalFeedbackText);
+        Assert.Empty(viewModel.WarningBanner);
         Assert.Equal(0, client.StreamCalls);
         Assert.Equal(0, client.ListCalls);
     }
 
     [Fact]
-    public async Task RemoveAsync_RejectedOperation_DoesNotTrackOrRefresh()
+    public async Task RemoveAsync_RejectedOperation_StaysItemLocalAndDoesNotTrackOrRefresh()
     {
         var client = new FakeClient { RemoveAsync = (_, _) => Task.FromResult(new OperationAccepted("op-2", false, Now)) };
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC", installed: true);
         await viewModel.RemoveAsync(item, CancellationToken.None);
         Assert.False(item.IsBusy);
-        Assert.Equal("Remove was not accepted for VLC.", viewModel.WarningBanner);
+        Assert.Equal("Remove was not accepted for VLC.", item.TransientFeedback);
+        Assert.Equal("Remove was not accepted for VLC.", item.CardPresentation.TerminalFeedbackText);
+        Assert.Empty(viewModel.WarningBanner);
         Assert.Equal(0, client.StreamCalls);
         Assert.Equal(0, client.ListCalls);
+    }
+
+    [Fact]
+    public async Task InstallAsync_NewActionClearsPriorTransientFeedbackBeforeAdmission()
+    {
+        var admissionObserved = NewSignal();
+        var client = new FakeClient
+        {
+            InstallAsync = (_, _) =>
+            {
+                admissionObserved.TrySetResult(true);
+                return Task.FromResult(new OperationAccepted("op-1", false, Now));
+            },
+        };
+        var viewModel = CreateViewModel(client);
+        var item = MakeUiItem("VLC");
+        item.TransientFeedback = "old feedback";
+
+        var installTask = viewModel.InstallAsync(item, CancellationToken.None);
+        await admissionObserved.Task;
+        Assert.NotEqual("old feedback", item.TransientFeedback);
+        await installTask;
+        Assert.Equal("Install was not accepted for VLC.", item.TransientFeedback);
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
@@ -149,7 +149,7 @@ public class HomeViewModelMutationTests
     }
 
     [Fact]
-    public async Task InstallAsync_RefreshFailureAfterOperationFailure_PreservesOperationWarning()
+    public async Task InstallAsync_RefreshFailureAfterOperationFailure_ShowsRefreshWarningAndKeepsItemFailureLocal()
     {
         var client = new FakeClient
         {
@@ -160,18 +160,20 @@ public class HomeViewModelMutationTests
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
         await viewModel.InstallAsync(item, CancellationToken.None);
-        Assert.Equal("Operation for VLC ended with Failed: exit code 1", viewModel.WarningBanner);
+        Assert.Equal("Failed: exit code 1", item.CardPresentation.TerminalFeedbackText);
+        Assert.Contains("Operation completed, but optional installs refresh failed", viewModel.WarningBanner);
+        Assert.Contains("refresh unavailable", viewModel.WarningBanner);
         Assert.Equal(1, client.ListCalls);
     }
 
     [Theory]
-    [InlineData(Outcome.Failed, "execution_failed", "exit code 1", "Operation for VLC ended with Failed: exit code 1")]
-    [InlineData(Outcome.Interrupted, "execution_interrupted", "Canceled by service", "Operation for VLC ended with Interrupted: Canceled by service")]
-    public async Task InstallAsync_UnsuccessfulOutcome_UsesStructuredResult(
+    [InlineData(Outcome.Failed, "execution_failed", "exit code 1", "Failed: exit code 1")]
+    [InlineData(Outcome.Interrupted, "execution_interrupted", "Canceled by service", "Interrupted: Canceled by service")]
+    public async Task InstallAsync_UnsuccessfulOutcome_UsesStructuredItemResult(
         Outcome outcome,
         string code,
         string message,
-        string expectedWarning)
+        string expectedFeedback)
     {
         var client = new FakeClient
         {
@@ -182,7 +184,8 @@ public class HomeViewModelMutationTests
         var viewModel = CreateViewModel(client);
         var item = MakeUiItem("VLC");
         await viewModel.InstallAsync(item, CancellationToken.None);
-        Assert.Equal(expectedWarning, viewModel.WarningBanner);
+        Assert.Equal(expectedFeedback, item.CardPresentation.TerminalFeedbackText);
+        Assert.Empty(viewModel.WarningBanner);
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelOperationResultTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelOperationResultTests.cs
@@ -15,15 +15,15 @@ public class HomeViewModelOperationResultTests
     private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-09-09T19:45:00Z");
 
     [Theory]
-    [InlineData(Outcome.Succeeded, "Succeeded: Installed", "")]
-    [InlineData(Outcome.AlreadySatisfied, "AlreadySatisfied: Already installed", "")]
-    [InlineData(Outcome.Failed, "Failed: Installer exited with code 1", "Operation for VLC ended with Failed: Installer exited with code 1")]
-    [InlineData(Outcome.Unverified, "Unverified: Unable to confirm installed state", "Operation for VLC ended with Unverified: Unable to confirm installed state")]
-    [InlineData(Outcome.Interrupted, "Interrupted: Service operation was interrupted", "Operation for VLC ended with Interrupted: Service operation was interrupted")]
-    public async Task InstallAsync_UsesAuthoritativeOutcome(
+    [InlineData(Outcome.Succeeded, "Succeeded: Installed", null)]
+    [InlineData(Outcome.AlreadySatisfied, "AlreadySatisfied: Already installed", null)]
+    [InlineData(Outcome.Failed, "Failed: Installer exited with code 1", "Failed: Installer exited with code 1")]
+    [InlineData(Outcome.Unverified, "Unverified: Unable to confirm installed state", "Unable to verify: Unable to confirm installed state")]
+    [InlineData(Outcome.Interrupted, "Interrupted: Service operation was interrupted", "Interrupted: Service operation was interrupted")]
+    public async Task InstallAsync_UsesAuthoritativeOutcomeWithoutGlobalItemWarning(
         Outcome outcome,
         string expectedStatus,
-        string expectedWarning)
+        string? expectedTerminalFeedback)
     {
         var resultMessage = outcome switch
         {
@@ -54,7 +54,8 @@ public class HomeViewModelOperationResultTests
         await viewModel.InstallAsync(item, CancellationToken.None);
 
         Assert.Equal(expectedStatus, item.Status);
-        Assert.Equal(expectedWarning, viewModel.WarningBanner);
+        Assert.Equal(expectedTerminalFeedback, item.CardPresentation.TerminalFeedbackText);
+        Assert.Empty(viewModel.WarningBanner);
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
@@ -48,7 +48,7 @@ public class HomeViewModelTests
     }
 
     [Fact]
-    public async Task InstallAsync_SuccessfulStream_RefreshesAuthoritativeItems()
+    public async Task InstallAsync_SuccessfulStream_RefreshesAuthoritativeItemsWithoutClearingPageWarning()
     {
         var client = new FakeClient
         {
@@ -68,13 +68,14 @@ public class HomeViewModelTests
         await viewModel.InstallAsync(item, CancellationToken.None);
 
         Assert.False(item.IsBusy);
-        Assert.Equal(string.Empty, viewModel.WarningBanner);
+        Assert.Equal("old warning", viewModel.WarningBanner);
         Assert.Equal(1, client.ListCalls);
         var refreshedItem = Assert.Single(viewModel.Items);
         Assert.Equal("VLC", refreshedItem.ItemName);
         Assert.True(refreshedItem.IsInstalled);
         Assert.Equal("Installed", refreshedItem.Status);
         Assert.Equal(Outcome.Succeeded, refreshedItem.LatestOperation?.Result?.Outcome);
+        Assert.Null(refreshedItem.CardPresentation.TerminalFeedbackText);
     }
 
     [Fact]
@@ -103,10 +104,11 @@ public class HomeViewModelTests
         Assert.False(refreshedItem.IsInstalled);
         Assert.Equal("NotInstalled", refreshedItem.Status);
         Assert.Equal(Outcome.Succeeded, refreshedItem.LatestOperation?.Result?.Outcome);
+        Assert.Null(refreshedItem.CardPresentation.TerminalFeedbackText);
     }
 
     [Fact]
-    public async Task InstallAsync_TerminalFailure_RefreshesItemsAndPreservesOperationWarning()
+    public async Task InstallAsync_TerminalFailure_RefreshesItemsAndKeepsFailureOnItem()
     {
         var client = new FakeClient
         {
@@ -124,8 +126,10 @@ public class HomeViewModelTests
         await viewModel.InstallAsync(item, CancellationToken.None);
 
         Assert.Equal(1, client.ListCalls);
-        Assert.Equal("Operation for VLC ended with Failed: exit code 1", viewModel.WarningBanner);
-        Assert.False(Assert.Single(viewModel.Items).IsInstalled);
+        Assert.Empty(viewModel.WarningBanner);
+        var refreshedItem = Assert.Single(viewModel.Items);
+        Assert.False(refreshedItem.IsInstalled);
+        Assert.Equal("Failed: exit code 1", refreshedItem.CardPresentation.TerminalFeedbackText);
         Assert.False(item.IsBusy);
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
@@ -14,7 +14,7 @@ public class HomeViewModelTests
     private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-02-19T18:10:00Z");
 
     [Fact]
-    public async Task InstallAsync_RejectedOperation_SetsWarningAndClearsBusy()
+    public async Task InstallAsync_RejectedOperation_SetsItemFeedbackAndClearsBusy()
     {
         var client = new FakeClient
         {
@@ -26,12 +26,13 @@ public class HomeViewModelTests
         await viewModel.InstallAsync(item, CancellationToken.None);
 
         Assert.False(item.IsBusy);
-        Assert.Equal("Install was not accepted for VLC.", viewModel.WarningBanner);
+        Assert.Equal("Install was not accepted for VLC.", item.TransientFeedback);
+        Assert.Empty(viewModel.WarningBanner);
         Assert.Equal(0, client.ListCalls);
     }
 
     [Fact]
-    public async Task RemoveAsync_RejectedOperation_SetsWarningAndClearsBusy()
+    public async Task RemoveAsync_RejectedOperation_SetsItemFeedbackAndClearsBusy()
     {
         var client = new FakeClient
         {
@@ -43,7 +44,8 @@ public class HomeViewModelTests
         await viewModel.RemoveAsync(item, CancellationToken.None);
 
         Assert.False(item.IsBusy);
-        Assert.Equal("Remove was not accepted for VLC.", viewModel.WarningBanner);
+        Assert.Equal("Remove was not accepted for VLC.", item.TransientFeedback);
+        Assert.Empty(viewModel.WarningBanner);
         Assert.Equal(0, client.ListCalls);
     }
 

--- a/integration/windows/run-ui-e2e.ps1
+++ b/integration/windows/run-ui-e2e.ps1
@@ -28,6 +28,9 @@ $serviceName = "gorilla-ui-e2e"
 $servicePipeName = "gorilla-ui-e2e"
 $markerPath = "C:\ProgramData\gorilla-it\ps1.txt"
 $failureMarkerPath = "C:\ProgramData\gorilla-it\ps1-failure.txt"
+$slowMarkerPath = "C:\ProgramData\gorilla-it\ui-slow.txt"
+$updateRegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiUpdateFixture"
+$installedRegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiInstalledFixture"
 $appDataPath = "C:\ProgramData\gorilla-ui-e2e"
 $serviceLogPath = Join-Path $appDataPath "gorilla.log"
 $serviceManifestPath = Join-Path $appDataPath "service-manifest.yaml"
@@ -46,12 +49,60 @@ if (-not (Test-Path -LiteralPath $serverExe) -or -not (Test-Path -LiteralPath $c
     }
 }
 
-$failureScriptPath = Join-Path $repoFixtureRoot "packages\scripts\intentional-failure.ps1"
+$scriptsRoot = Join-Path $repoFixtureRoot "packages\scripts"
+$failureScriptPath = Join-Path $scriptsRoot "intentional-failure.ps1"
 @'
 Write-Error "Intentional App Catalog E2E installer failure"
 exit 7
 '@ | Set-Content -LiteralPath $failureScriptPath -NoNewline
 $failureScriptHash = (Get-FileHash -LiteralPath $failureScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$updateInstallScriptPath = Join-Path $scriptsRoot "ui-update-install.ps1"
+@'
+$path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiUpdateFixture"
+New-Item -Path $path -Force | Out-Null
+Set-ItemProperty -Path $path -Name DisplayName -Value "Gorilla UI Update Fixture"
+Set-ItemProperty -Path $path -Name DisplayVersion -Value "2.0.0"
+'@ | Set-Content -LiteralPath $updateInstallScriptPath -NoNewline
+$updateInstallScriptHash = (Get-FileHash -LiteralPath $updateInstallScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$updateUninstallScriptPath = Join-Path $scriptsRoot "ui-update-uninstall.ps1"
+@'
+$path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiUpdateFixture"
+Remove-Item -Path $path -Recurse -Force -ErrorAction SilentlyContinue
+'@ | Set-Content -LiteralPath $updateUninstallScriptPath -NoNewline
+$updateUninstallScriptHash = (Get-FileHash -LiteralPath $updateUninstallScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$installedInstallScriptPath = Join-Path $scriptsRoot "ui-installed-install.ps1"
+@'
+$path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiInstalledFixture"
+New-Item -Path $path -Force | Out-Null
+Set-ItemProperty -Path $path -Name DisplayName -Value "Gorilla UI Installed Fixture"
+Set-ItemProperty -Path $path -Name DisplayVersion -Value "1.0.0"
+'@ | Set-Content -LiteralPath $installedInstallScriptPath -NoNewline
+$installedInstallScriptHash = (Get-FileHash -LiteralPath $installedInstallScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$installedUninstallScriptPath = Join-Path $scriptsRoot "ui-installed-uninstall.ps1"
+@'
+$path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GorillaUiInstalledFixture"
+Remove-Item -Path $path -Recurse -Force -ErrorAction SilentlyContinue
+'@ | Set-Content -LiteralPath $installedUninstallScriptPath -NoNewline
+$installedUninstallScriptHash = (Get-FileHash -LiteralPath $installedUninstallScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$slowInstallScriptPath = Join-Path $scriptsRoot "ui-slow-install.ps1"
+@"
+Start-Sleep -Seconds 6
+`$marker = '$slowMarkerPath'
+New-Item -Path (Split-Path -Path `$marker -Parent) -ItemType Directory -Force | Out-Null
+Set-Content -LiteralPath `$marker -Value 'installed' -NoNewline
+"@ | Set-Content -LiteralPath $slowInstallScriptPath -NoNewline
+$slowInstallScriptHash = (Get-FileHash -LiteralPath $slowInstallScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$slowUninstallScriptPath = Join-Path $scriptsRoot "ui-slow-uninstall.ps1"
+@"
+Remove-Item -LiteralPath '$slowMarkerPath' -Force -ErrorAction SilentlyContinue
+"@ | Set-Content -LiteralPath $slowUninstallScriptPath -NoNewline
+$slowUninstallScriptHash = (Get-FileHash -LiteralPath $slowUninstallScriptPath -Algorithm SHA256).Hash.ToLowerInvariant()
 
 $catalogRaw = Get-Content -LiteralPath $catalogPath -Raw
 if ($catalogRaw -notmatch '(?m)^Ps1Failure:') {
@@ -70,12 +121,80 @@ Ps1Failure:
 "@ | Add-Content -LiteralPath $catalogPath -NoNewline
 }
 
+@"
+
+RegistryUpdateFixture:
+  display_name: Update Fixture
+  description: Exercises the real update-available App Catalog presentation path.
+  check:
+    registry:
+      name: Gorilla UI Update Fixture
+      version: 2.0.0
+  installer:
+    type: ps1
+    location: packages/scripts/ui-update-install.ps1
+    hash: $updateInstallScriptHash
+  uninstaller:
+    type: ps1
+    location: packages/scripts/ui-update-uninstall.ps1
+    hash: $updateUninstallScriptHash
+  version: 2.0.0
+
+RegistryInstalledFixture:
+  display_name: Installed Fixture
+  description: Celestial amber telescope utility for description-only search coverage.
+  check:
+    registry:
+      name: Gorilla UI Installed Fixture
+      version: 1.0.0
+  installer:
+    type: ps1
+    location: packages/scripts/ui-installed-install.ps1
+    hash: $installedInstallScriptHash
+  uninstaller:
+    type: ps1
+    location: packages/scripts/ui-installed-uninstall.ps1
+    hash: $installedUninstallScriptHash
+  version: 1.0.0
+
+SlowInstallFixture:
+  display_name: Slow Install Fixture
+  description: Deliberately slow fixture used to observe an active operation.
+  check:
+    file:
+      - path: '$slowMarkerPath'
+  installer:
+    type: ps1
+    location: packages/scripts/ui-slow-install.ps1
+    hash: $slowInstallScriptHash
+  uninstaller:
+    type: ps1
+    location: packages/scripts/ui-slow-uninstall.ps1
+    hash: $slowUninstallScriptHash
+  version: 1.0.0
+"@ | Add-Content -LiteralPath $catalogPath -NoNewline
+
 @'
 name: ui-e2e
 optional_installs:
   - Ps1V1
   - Ps1Failure
+  - RegistryUpdateFixture
+  - RegistryInstalledFixture
+  - SlowInstallFixture
 '@ | Set-Content -LiteralPath $manifestPath -NoNewline
+
+function Set-FixtureUninstallEntry {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [Parameter(Mandatory)][string]$DisplayVersion
+    )
+
+    New-Item -Path $Path -Force | Out-Null
+    Set-ItemProperty -Path $Path -Name DisplayName -Value $DisplayName
+    Set-ItemProperty -Path $Path -Name DisplayVersion -Value $DisplayVersion
+}
 
 function Wait-ServiceState {
     param(
@@ -315,6 +434,11 @@ try {
     Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $failureMarkerPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $slowMarkerPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $updateRegistryPath -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $installedRegistryPath -Recurse -Force -ErrorAction SilentlyContinue
+    Set-FixtureUninstallEntry -Path $updateRegistryPath -DisplayName "Gorilla UI Update Fixture" -DisplayVersion "1.0.0"
+    Set-FixtureUninstallEntry -Path $installedRegistryPath -DisplayName "Gorilla UI Installed Fixture" -DisplayVersion "1.0.0"
     Remove-Item -LiteralPath (Split-Path -Parent $uiCachePath) -Recurse -Force -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Path (Split-Path -Parent $configPath), $evidenceRoot -Force | Out-Null
 
@@ -342,6 +466,7 @@ debug: true
     $env:GORILLA_UI_CACHE_PATH = $uiCachePath
     $env:GORILLA_UI_E2E_MARKER_PATH = $markerPath
     $env:GORILLA_UI_E2E_CACHE_PATH = $uiCachePath
+    $env:GORILLA_UI_E2E_SLOW_MARKER_PATH = $slowMarkerPath
 
     & $GorillaExePath -config $configPath -integration-test-service-identity $serviceName -serviceinstall | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Failed to install source-built Gorilla service" }
@@ -369,6 +494,9 @@ debug: true
     throw $originalError
 } finally {
     Remove-TestService
+    Remove-Item -Path $updateRegistryPath -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $installedRegistryPath -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $slowMarkerPath -Force -ErrorAction SilentlyContinue
     if ($serverProc -and -not $serverProc.HasExited) {
         Stop-Process -Id $serverProc.Id -Force -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
Replaces the optional-software row list with the Stage 5 store-style App Catalog surface.

- Adds a responsive compact card grid targeting roughly 300–340 px card widths and a fixed ~204 px card height.
- Uses a horizontal app identity row with a 38 px icon and 17 px semibold display name, wrapping to at most two lines.
- Keeps descriptions in the catalog/Core model for search and future details, but does not render descriptions on catalog cards.
- Binds search directly to Core `SearchQuery`, including name, item-name, and description filtering plus a dedicated query-specific no-results state.
- Presents typed observation and version information with readable 13–14 px supporting typography.
- Reserves a fixed two-line operation/result region on every card so active or terminal feedback cannot change card height or push actions downward.
- Presents active operations and item-specific terminal `Failed`, `Unverified`, and `Interrupted` results locally on the affected card from typed operation state; rejected install/remove admission responses are also surfaced transiently in that same card-local result region instead of the page warning banner.
- Keeps page-level warnings for service/catalog/status infrastructure problems.
- Pins primary/secondary actions to the bottom of each fixed-height card, preserving alignment across long names, missing versions, operations, failures, and transient admission feedback.
- Adds deterministic presentation mapping for one- and two-action cards, including Update/Remove and Keep Installed/Remove hierarchy without changing service allowedness.
- Preserves the service warning live region and adds card-local live automation feedback for active, terminal, and transient item-specific feedback.
- Uses stable `ItemName`-based automation identity and extends the FlaUI driver/critical-path selectors to the card surface.
- Adds portable presentation tests for action hierarchy, terminal card feedback, successful terminal suppression, stale terminal feedback suppression during retries, and transient admission-feedback precedence.
- Extends the real Windows E2E fixture with registry-backed update and installed/unselected apps plus deliberately slow and failing install fixtures.
- Adds end-to-end Windows coverage for compact card dimensions, description-only search without description rendering, UpdateAvailable → Update + Remove, installed/unselected → Keep Installed + Remove, active-operation presentation while preserving observed state, and a real installer failure remaining card-local rather than populating the global warning.
- Hardens Windows UI evidence capture by restoring/foregrounding the Gorilla window at the Win32 level, scrolling target cards into view through UI Automation before targeted screenshots, and saving checkpoint-specific automation trees.
- Fixes stream lifecycle diagnostics so terminal state/outcome is recorded before yielding `Completed`, keeping lifecycle logs truthful even when consumers stop enumeration immediately after the terminal event.

The new E2E states are produced through Gorilla’s existing detection/action pipeline rather than mocked in WinUI: registry fixtures establish real installed/version evidence and the slow/failing PS1 fixtures produce real service operations.

This PR does not change service policy/action decisions, operation recovery semantics, protocol behavior, or details/navigation architecture. Details navigation remains deferred to PR D.

Repository Windows/CI gates remain the authoritative validation for XAML compilation and FlaUI behavior.