### PR TITLE
Stabilize catalog details navigation E2E

### DIFF
--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -41,7 +41,12 @@ internal sealed class HomePageDriver
     public void OpenDetails(string itemName)
     {
         EnsureItemVisible(itemName);
-        WaitForItem(itemName).Click();
+        var item = WaitForItem(itemName);
+        var nonActionTarget = _session.WaitFor(
+            () => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogDisplayName"))
+        );
+        nonActionTarget.Click();
+        _ = _session.WaitFor(() => ById("AppDetailsRoot"));
     }
 
     public Button InstallButton(string itemName) => ActionButton(itemName, "Install", "Update", "Keep Installed");

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/TestAssembly.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/TestAssembly.cs
@@ -1,6 +1,0 @@
-using Xunit;
-
-// These end-to-end tests share one machine-wide Gorilla service plus registry,
-// marker-file, package, and catalog fixture state. Running test classes in
-// parallel allows one scenario to mutate another scenario's authoritative state.
-[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/TestAssembly.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/TestAssembly.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// These end-to-end tests share one machine-wide Gorilla service plus registry,
+// marker-file, package, and catalog fixture state. Running test classes in
+// parallel allows one scenario to mutate another scenario's authoritative state.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary

Fixes the post-merge Windows UI E2E failure after #222.

The original Build Release failure was not caused by test parallelism; this test assembly was already serialized. The failure evidence showed `SlowInstallFixture` had been successfully reset to **Not installed**, the card was present and enabled, but `HomePageDriver.OpenDetails()` remained on the catalog page.

The driver previously called `Click()` on the `GridViewItem` / UIA `ListItem` container. In the installed-MSIX run, that activation did not reliably produce WinUI's `GridView.ItemClick`, so the app never executed `Frame.Navigate(...)`.

This PR now makes the automation exercise the intended UX more deterministically:

- scroll/focus the target card as before;
- click the explicit non-action `CatalogDisplayName` element inside the card, rather than the `ListItem` container;
- wait for `AppDetailsRoot` before returning from `OpenDetails()`.

This still tests that clicking a non-action part of a catalog card navigates to details, while avoiding ambiguous automation semantics of a `GridViewItem` with `SelectionMode=None`.

The earlier redundant `CollectionBehavior` change has been removed.

## Evidence

Post-merge Build Release run `34665862193` failed 1/18 installed-product UI tests in `DetailsOperationContinuesAfterNavigatingBackToCatalog`. Failure diagnostics showed:

- `SlowInstallFixture` present and enabled;
- observation `Not installed`;
- primary action `Install` enabled;
- no `AppDetailsRoot` in the automation tree;
- screenshot remained on the catalog page with the slow fixture focused.

That isolates the failure to the automation click/navigation boundary rather than service state, operation tracking, or details rendering.