### PR TITLE
Add App Catalog Activity and recovery UI

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml
@@ -73,8 +73,7 @@
                             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                             BorderThickness="1"
-                            CornerRadius="8"
-                            AutomationProperties.AutomationId="{Binding EntryAutomationId}">
+                            CornerRadius="8">
                             <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto">
                                 <TextBlock
                                     Text="{Binding DisplayName}"

--- a/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml
@@ -1,0 +1,147 @@
+<Page
+    x:Class="Gorilla.UI.App.Views.ActivityPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Gorilla.UI.App.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Page.Resources>
+
+    <Grid
+        x:Name="ActivityRoot"
+        Padding="20"
+        RowDefinitions="Auto,Auto,*"
+        AutomationProperties.AutomationId="ActivityPageRoot">
+        <Grid ColumnDefinitions="Auto,*,Auto">
+            <Button
+                x:Name="BackButton"
+                Content="Back"
+                Click="BackButton_Click"
+                AutomationProperties.AutomationId="ActivityBackButton"
+                AutomationProperties.Name="Back to catalog" />
+            <TextBlock
+                Grid.Column="1"
+                Margin="12,0,0,0"
+                Text="Activity"
+                FontSize="28"
+                FontWeight="SemiBold"
+                VerticalAlignment="Center"
+                AutomationProperties.AutomationId="ActivityHeading"
+                AutomationProperties.HeadingLevel="Level1" />
+            <Button
+                Grid.Column="2"
+                Content="Catalog"
+                Click="CatalogButton_Click"
+                AutomationProperties.AutomationId="CatalogNavigationButton"
+                AutomationProperties.Name="Catalog" />
+        </Grid>
+
+        <TextBlock
+            Grid.Row="1"
+            Margin="0,10,0,0"
+            x:Name="ServiceWarning"
+            Text="{Binding WarningBanner}"
+            Foreground="DarkOrange"
+            TextWrapping="Wrap"
+            AutomationProperties.AutomationId="ActivityServiceWarning"
+            AutomationProperties.LiveSetting="Polite" />
+
+        <Grid Grid.Row="2" Margin="0,14,0,0">
+            <ListView
+                x:Name="ActivityItems"
+                ItemsSource="{Binding ActivityItems}"
+                SelectionMode="None"
+                IsItemClickEnabled="True"
+                ItemClick="ActivityItems_ItemClick"
+                ContainerContentChanging="ActivityItems_ContainerContentChanging"
+                AutomationProperties.AutomationId="ActivityItems"
+                AutomationProperties.Name="Recent activity">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="Margin" Value="0,0,0,8" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <Border
+                            Padding="14"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            AutomationProperties.AutomationId="{Binding EntryAutomationId}">
+                            <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto">
+                                <TextBlock
+                                    Text="{Binding DisplayName}"
+                                    FontSize="17"
+                                    FontWeight="SemiBold"
+                                    TextWrapping="Wrap"
+                                    AutomationProperties.AutomationId="{Binding AppAutomationId}" />
+                                <TextBlock
+                                    Grid.Column="1"
+                                    Text="{Binding TimestampText}"
+                                    Opacity="0.65"
+                                    FontSize="12" />
+
+                                <StackPanel Grid.Row="1" Margin="0,5,0,0" Orientation="Horizontal" Spacing="8">
+                                    <TextBlock
+                                        Text="{Binding ActionLabel}"
+                                        FontWeight="SemiBold"
+                                        AutomationProperties.AutomationId="{Binding ActionAutomationId}" />
+                                    <TextBlock
+                                        Text="{Binding StateText}"
+                                        AutomationProperties.AutomationId="{Binding StateAutomationId}"
+                                        AutomationProperties.LiveSetting="Polite" />
+                                </StackPanel>
+
+                                <ProgressBar
+                                    Grid.Row="2"
+                                    Grid.ColumnSpan="2"
+                                    Margin="0,8,0,0"
+                                    Minimum="0"
+                                    Maximum="100"
+                                    Value="{Binding ProgressValue}"
+                                    IsIndeterminate="{Binding IsProgressIndeterminate}"
+                                    Visibility="{Binding IsActive, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    AutomationProperties.AutomationId="{Binding ProgressAutomationId}" />
+
+                                <TextBlock
+                                    Grid.Row="3"
+                                    Grid.ColumnSpan="2"
+                                    Margin="0,7,0,0"
+                                    Text="{Binding DetailText}"
+                                    TextWrapping="Wrap"
+                                    Visibility="{Binding HasDetail, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    AutomationProperties.AutomationId="{Binding DetailAutomationId}" />
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+            <StackPanel
+                x:Name="ActivityEmpty"
+                Visibility="Collapsed"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Spacing="4"
+                AutomationProperties.AutomationId="ActivityEmptyState">
+                <TextBlock
+                    Text="No recent activity"
+                    FontSize="20"
+                    FontWeight="SemiBold"
+                    HorizontalAlignment="Center" />
+                <TextBlock
+                    Text="Installs, updates, and removals will appear here."
+                    Opacity="0.7"
+                    TextWrapping="Wrap"
+                    HorizontalAlignment="Center" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Page>

--- a/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Gorilla.UI.App.Services;
 using Gorilla.UI.Core.Models;
 using Gorilla.UI.Core.ViewModels;
@@ -94,7 +95,12 @@ public sealed partial class ActivityPage : Page
             : Visibility.Collapsed;
     }
 
-    private static void ActivityItems_ContainerContentChanging(
+    [SuppressMessage(
+        "Performance",
+        "CA1822:Mark members as static",
+        Justification = "WinUI XAML event handlers are wired through the page instance."
+    )]
+    private void ActivityItems_ContainerContentChanging(
         ListViewBase sender,
         ContainerContentChangingEventArgs args
     )

--- a/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Gorilla.UI.App.Services;

--- a/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
@@ -94,7 +94,7 @@ public sealed partial class ActivityPage : Page
             : Visibility.Collapsed;
     }
 
-    private void ActivityItems_ContainerContentChanging(
+    private static void ActivityItems_ContainerContentChanging(
         ListViewBase sender,
         ContainerContentChangingEventArgs args
     )

--- a/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/ActivityPage.xaml.cs
@@ -1,0 +1,142 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Gorilla.UI.App.Services;
+using Gorilla.UI.Core.Models;
+using Gorilla.UI.Core.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Gorilla.UI.App.Views;
+
+public sealed partial class ActivityPage : Page
+{
+    private readonly AppCatalogSession _session;
+    private bool _isObserving;
+
+    public HomeViewModel ViewModel { get; }
+
+    public ActivityPage()
+    {
+        InitializeComponent();
+        _session = App.CurrentSession;
+        ViewModel = _session.ViewModel;
+        DataContext = ViewModel;
+        Loaded += ActivityPage_Loaded;
+        Unloaded += ActivityPage_Unloaded;
+        UpdateEmptyState();
+    }
+
+    private async void ActivityPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        StartObserving();
+        try
+        {
+            await _session.EnsureInitializedAsync();
+        }
+        catch (OperationCanceledException) when (_session.LifetimeToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            ViewModel.SetWarningBanner($"Operation failed: {ex.Message}");
+        }
+        UpdateEmptyState();
+    }
+
+    private void ActivityPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        StopObserving();
+    }
+
+    private void StartObserving()
+    {
+        if (_isObserving)
+        {
+            return;
+        }
+
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+        ViewModel.ActivityItems.CollectionChanged += ActivityItems_CollectionChanged;
+        _isObserving = true;
+    }
+
+    private void StopObserving()
+    {
+        if (!_isObserving)
+        {
+            return;
+        }
+
+        ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        ViewModel.ActivityItems.CollectionChanged -= ActivityItems_CollectionChanged;
+        _isObserving = false;
+    }
+
+    private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(HomeViewModel.IsActivityLoaded))
+        {
+            UpdateEmptyState();
+        }
+    }
+
+    private void ActivityItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        UpdateEmptyState();
+    }
+
+    private void UpdateEmptyState()
+    {
+        ActivityEmpty.Visibility = ViewModel.IsActivityLoaded && ViewModel.ActivityItems.Count == 0
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private void ActivityItems_ContainerContentChanging(
+        ListViewBase sender,
+        ContainerContentChangingEventArgs args
+    )
+    {
+        if (args.ItemContainer is null || args.Item is not ActivityOperationPresentation item)
+        {
+            return;
+        }
+
+        AutomationProperties.SetAutomationId(args.ItemContainer, item.EntryAutomationId);
+        AutomationProperties.SetName(args.ItemContainer, $"{item.DisplayName}, {item.ActionLabel}, {item.StateText}");
+        AutomationProperties.SetHelpText(args.ItemContainer, item.OperationId);
+    }
+
+    private void ActivityItems_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is not ActivityOperationPresentation item || !item.CanNavigate)
+        {
+            return;
+        }
+
+        if (!ViewModel.SelectItem(item.ItemName))
+        {
+            return;
+        }
+
+        Frame.Navigate(typeof(AppDetailsPage), item.ItemName);
+    }
+
+    private void BackButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (Frame.CanGoBack)
+        {
+            Frame.GoBack();
+        }
+        else
+        {
+            Frame.Navigate(typeof(HomePage));
+        }
+    }
+
+    private void CatalogButton_Click(object sender, RoutedEventArgs e)
+    {
+        Frame.Navigate(typeof(HomePage));
+    }
+}

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -12,12 +12,20 @@
     </Page.Resources>
 
     <Grid Padding="20" RowDefinitions="Auto,Auto,Auto,*">
-        <TextBlock
-            Text="Available Software"
-            FontSize="28"
-            FontWeight="SemiBold"
-            AutomationProperties.AutomationId="HomeHeading"
-            AutomationProperties.HeadingLevel="Level1" />
+        <Grid ColumnDefinitions="*,Auto">
+            <TextBlock
+                Text="Available Software"
+                FontSize="28"
+                FontWeight="SemiBold"
+                AutomationProperties.AutomationId="HomeHeading"
+                AutomationProperties.HeadingLevel="Level1" />
+            <Button
+                Grid.Column="1"
+                Content="Activity"
+                Click="ActivityButton_Click"
+                AutomationProperties.AutomationId="ActivityNavigationButton"
+                AutomationProperties.Name="Activity" />
+        </Grid>
 
         <TextBox
             Grid.Row="1"

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -163,6 +163,11 @@ public sealed partial class HomePage : Page
         Frame.Navigate(typeof(AppDetailsPage), item.ItemName);
     }
 
+    private void ActivityButton_Click(object sender, RoutedEventArgs e)
+    {
+        Frame.Navigate(typeof(ActivityPage));
+    }
+
     private void CatalogItems_SizeChanged(object sender, SizeChangedEventArgs e)
     {
         UpdateCardWidths(e.NewSize.Width);

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
 using CatalogAction = Gorilla.UI.Client.AppCatalog.Action;
 
 namespace Gorilla.UI.Core.Models;

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Gorilla.UI.Client;
 using Gorilla.UI.Client.AppCatalog;
@@ -61,7 +62,7 @@ public sealed class ActivityOperationPresentation : INotifyPropertyChanged
         ? OperationDisplay.Details(Result)
         : Message;
 
-    public string TimestampText => TimestampUtc.ToLocalTime().ToString("g");
+    public string TimestampText => TimestampUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
 
     public string EntryAutomationId => $"ActivityOperation-{OperationId}";
     public string AppAutomationId => $"ActivityApp-{OperationId}";

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Gorilla.UI.Client;
+using CatalogAction = Gorilla.UI.Client.AppCatalog.Action;
+
+namespace Gorilla.UI.Core.Models;
+
+// Presentation-only projection of one retained service operation. The structured
+// operation identity/result are deliberately preserved so a later retry surface
+// can re-enter the current service-authorized action path without replaying the
+// historical mutation.
+public sealed class ActivityOperationPresentation : INotifyPropertyChanged
+{
+    private string _itemName = string.Empty;
+    private string _displayName = string.Empty;
+    private CatalogAction _action;
+    private OperationState _state;
+    private int? _progressPercent;
+    private Result? _result;
+    private string _message = string.Empty;
+    private DateTimeOffset _timestampUtc;
+    private bool _canNavigate;
+
+    public ActivityOperationPresentation(string operationId)
+    {
+        OperationId = operationId;
+    }
+
+    public string OperationId { get; }
+    public string ItemName => _itemName;
+    public string DisplayName => _displayName;
+    public CatalogAction Action => _action;
+    public OperationState State => _state;
+    public int? ProgressPercent => _progressPercent;
+    public Result? Result => _result;
+    public string Message => _message;
+    public DateTimeOffset TimestampUtc => _timestampUtc;
+    public bool CanNavigate => _canNavigate;
+
+    public bool IsActive => State != OperationState.Completed;
+    public bool IsTerminal => !IsActive;
+    public bool HasDeterminateProgress => IsActive && ProgressPercent.HasValue;
+    public bool IsProgressIndeterminate => IsActive && !ProgressPercent.HasValue;
+    public double ProgressValue => ProgressPercent ?? 0;
+    public bool HasDetail => !string.IsNullOrWhiteSpace(DetailText);
+
+    // Retained service action is historical truth. Contextual Stage 5 labels such
+    // as Update/Keep Installed are intentionally not reconstructed from current state.
+    public string ActionLabel => Action switch
+    {
+        CatalogAction.Remove => "Remove",
+        _ => "Install",
+    };
+
+    public string StateText => IsActive
+        ? State.ToString()
+        : Result?.Outcome.ToString() ?? OperationState.Completed.ToString();
+
+    public string DetailText => IsTerminal && Result is not null
+        ? (string.IsNullOrWhiteSpace(Result.Message) ? Result.Code : Result.Message)
+        : Message;
+
+    public string TimestampText => TimestampUtc.ToLocalTime().ToString("g");
+
+    public string EntryAutomationId => $"ActivityOperation-{OperationId}";
+    public string AppAutomationId => $"ActivityApp-{OperationId}";
+    public string ActionAutomationId => $"ActivityAction-{OperationId}";
+    public string StateAutomationId => $"ActivityState-{OperationId}";
+    public string ProgressAutomationId => $"ActivityProgress-{OperationId}";
+    public string DetailAutomationId => $"ActivityDetail-{OperationId}";
+
+    internal void Apply(OperationStatusEvent operation, string displayName, bool canNavigate)
+    {
+        if (!string.Equals(operation.OperationId, OperationId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Cannot reconcile a different operation into an Activity entry.");
+        }
+
+        SetField(ref _itemName, operation.ItemName, nameof(ItemName));
+        SetField(ref _displayName, displayName, nameof(DisplayName));
+        SetField(ref _action, operation.Action, nameof(Action));
+        SetField(ref _state, operation.State, nameof(State));
+        SetField(ref _progressPercent, operation.ProgressPercent, nameof(ProgressPercent));
+        SetField(ref _result, operation.Result, nameof(Result));
+        SetField(ref _message, operation.Message, nameof(Message));
+        SetField(ref _timestampUtc, operation.TimestampUtc, nameof(TimestampUtc));
+        SetField(ref _canNavigate, canNavigate, nameof(CanNavigate));
+
+        OnPropertyChanged(nameof(IsActive));
+        OnPropertyChanged(nameof(IsTerminal));
+        OnPropertyChanged(nameof(HasDeterminateProgress));
+        OnPropertyChanged(nameof(IsProgressIndeterminate));
+        OnPropertyChanged(nameof(ProgressValue));
+        OnPropertyChanged(nameof(ActionLabel));
+        OnPropertyChanged(nameof(StateText));
+        OnPropertyChanged(nameof(DetailText));
+        OnPropertyChanged(nameof(HasDetail));
+        OnPropertyChanged(nameof(TimestampText));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetField<T>(ref T field, T value, string propertyName)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/ActivityOperationPresentation.cs
@@ -53,11 +53,11 @@ public sealed class ActivityOperationPresentation : INotifyPropertyChanged
     };
 
     public string StateText => IsActive
-        ? State.ToString()
-        : Result?.Outcome.ToString() ?? OperationState.Completed.ToString();
+        ? ActiveStateLabel(State)
+        : Result is null ? "Completed" : OutcomeLabel(Result.Outcome);
 
     public string DetailText => IsTerminal && Result is not null
-        ? (string.IsNullOrWhiteSpace(Result.Message) ? Result.Code : Result.Message)
+        ? OperationDisplay.Details(Result)
         : Message;
 
     public string TimestampText => TimestampUtc.ToLocalTime().ToString("g");
@@ -99,6 +99,27 @@ public sealed class ActivityOperationPresentation : INotifyPropertyChanged
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    private static string ActiveStateLabel(OperationState state) => state switch
+    {
+        OperationState.Queued => "Queued",
+        OperationState.Validating => "Preparing",
+        OperationState.Downloading => "Downloading",
+        OperationState.Installing => "Installing",
+        OperationState.Removing => "Removing",
+        OperationState.Completed => "Completing",
+        _ => "Working",
+    };
+
+    private static string OutcomeLabel(Outcome outcome) => outcome switch
+    {
+        Outcome.Succeeded => "Succeeded",
+        Outcome.AlreadySatisfied => "Already satisfied",
+        Outcome.Failed => "Failed",
+        Outcome.Unverified => "Unable to verify",
+        Outcome.Interrupted => "Interrupted",
+        _ => outcome.ToString(),
+    };
 
     private void SetField<T>(ref T field, T value, string propertyName)
     {

--- a/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
@@ -111,16 +111,28 @@ public sealed class OperationTracker
             {
                 await foreach (var update in _client.StreamOperationStatusAsync(operationId, cancellationToken))
                 {
-                    // A reconnect replays retained lifecycle events from the beginning.
-                    // Do not write a replayed earlier event back into the canonical
-                    // registry: that would regress Activity even though card/details
-                    // delivery is already deduplicated.
-                    if (delivered.Add(EventIdentity(update)))
+                    var identity = EventIdentity(update);
+                    if (!delivered.Add(identity))
                     {
-                        _latest[operationId] = update;
-                        OnOperationsChanged();
-                        onUpdate(update);
+                        if (update.State == OperationState.Completed)
+                        {
+                            return;
+                        }
+                        continue;
                     }
+
+                    // Recovery begins with a ListOperations snapshot, while a newly
+                    // opened status stream may replay older retained events first.
+                    // Keep the operation-ID registry monotonic so Activity and the
+                    // existing card/details projections never move backwards.
+                    if (_latest.TryGetValue(operationId, out var current) && IsOlderThanCurrent(current, update))
+                    {
+                        continue;
+                    }
+
+                    _latest[operationId] = update;
+                    OnOperationsChanged();
+                    onUpdate(update);
                     if (update.State == OperationState.Completed)
                     {
                         return;
@@ -142,6 +154,30 @@ public sealed class OperationTracker
 
     private void OnOperationsChanged()
         => OperationsChanged?.Invoke(this, EventArgs.Empty);
+
+    private static bool IsOlderThanCurrent(OperationStatusEvent current, OperationStatusEvent update)
+    {
+        if (current.State == OperationState.Completed && update.State != OperationState.Completed)
+        {
+            return true;
+        }
+        if (update.TimestampUtc < current.TimestampUtc)
+        {
+            return true;
+        }
+        if (update.TimestampUtc > current.TimestampUtc)
+        {
+            return false;
+        }
+        return StateRank(update.State) < StateRank(current.State);
+    }
+
+    private static int StateRank(OperationState state) => state switch
+    {
+        OperationState.Queued => 0,
+        OperationState.Completed => 2,
+        _ => 1,
+    };
 
     private static bool IsReconnectable(Exception ex)
         => ex is IOException or TimeoutException or OperationCanceledException;

--- a/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
@@ -111,10 +111,14 @@ public sealed class OperationTracker
             {
                 await foreach (var update in _client.StreamOperationStatusAsync(operationId, cancellationToken))
                 {
-                    _latest[operationId] = update;
-                    OnOperationsChanged();
+                    // A reconnect replays retained lifecycle events from the beginning.
+                    // Do not write a replayed earlier event back into the canonical
+                    // registry: that would regress Activity even though card/details
+                    // delivery is already deduplicated.
                     if (delivered.Add(EventIdentity(update)))
                     {
+                        _latest[operationId] = update;
+                        OnOperationsChanged();
                         onUpdate(update);
                     }
                     if (update.State == OperationState.Completed)

--- a/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Services/OperationTracker.cs
@@ -15,29 +15,47 @@ public sealed class OperationTracker
         _client = client;
     }
 
+    public event EventHandler? OperationsChanged;
+
     public async Task<IReadOnlyList<OperationStatusEvent>> RefreshKnownOperationsAsync(CancellationToken cancellationToken)
     {
         var snapshots = await _client.ListOperationsAsync(cancellationToken);
         var retainedIds = snapshots.Select(operation => operation.OperationId).ToHashSet(StringComparer.Ordinal);
+        var changed = false;
 
         foreach (var operation in snapshots)
         {
-            _latest[operation.OperationId] = operation;
+            if (!_latest.TryGetValue(operation.OperationId, out var existing) || existing != operation)
+            {
+                _latest[operation.OperationId] = operation;
+                changed = true;
+            }
         }
 
         // The service operation registry is authoritative. Missing IDs mean the
         // operation aged out or the service restarted; neither is a terminal
-        // success/failure result and neither should remain projected as active.
+        // success/failure result and neither should remain projected as activity.
         foreach (var operationId in _latest.Keys)
         {
-            if (!retainedIds.Contains(operationId))
+            if (!retainedIds.Contains(operationId) && _latest.TryRemove(operationId, out _))
             {
-                _latest.TryRemove(operationId, out _);
+                changed = true;
             }
+        }
+
+        if (changed)
+        {
+            OnOperationsChanged();
         }
 
         return snapshots;
     }
+
+    // Canonical Activity source. This is a snapshot of the same operation-ID keyed
+    // registry used by the card/details projections; Activity must not maintain a
+    // separate operation/history truth.
+    public IReadOnlyList<OperationStatusEvent> GetRetainedOperations()
+        => _latest.Values.ToArray();
 
     public bool TryGetLatest(string operationId, out OperationStatusEvent? operation)
     {
@@ -94,6 +112,7 @@ public sealed class OperationTracker
                 await foreach (var update in _client.StreamOperationStatusAsync(operationId, cancellationToken))
                 {
                     _latest[operationId] = update;
+                    OnOperationsChanged();
                     if (delivered.Add(EventIdentity(update)))
                     {
                         onUpdate(update);
@@ -116,6 +135,9 @@ public sealed class OperationTracker
             }
         }
     }
+
+    private void OnOperationsChanged()
+        => OperationsChanged?.Invoke(this, EventArgs.Empty);
 
     private static bool IsReconnectable(Exception ex)
         => ex is IOException or TimeoutException or OperationCanceledException;

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -19,10 +19,12 @@ public sealed class HomeViewModel : INotifyPropertyChanged
     private readonly OperationTracker _operationTracker;
     private readonly ConcurrentDictionary<string, byte> _recoveryTracking = new(StringComparer.Ordinal);
     private readonly Dictionary<string, UiOptionalInstallItem> _catalogItems = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ActivityOperationPresentation> _activityItems = new(StringComparer.Ordinal);
 
     private string _warningBanner = string.Empty;
     private string _searchQuery = string.Empty;
     private string? _selectedItemName;
+    private bool _isActivityLoaded;
 
     public HomeViewModel(
         IGorillaServiceClient client,
@@ -34,9 +36,26 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         _cacheCoordinator = cacheCoordinator;
         _startupLoader = new OptionalInstallsStartupLoader(cacheCoordinator);
         _operationTracker = operationTracker;
+        _operationTracker.OperationsChanged += OperationTracker_OperationsChanged;
     }
 
     public ObservableCollection<UiOptionalInstallItem> Items { get; } = [];
+    public ObservableCollection<ActivityOperationPresentation> ActivityItems { get; } = [];
+
+    public bool IsActivityLoaded
+    {
+        get => _isActivityLoaded;
+        private set
+        {
+            if (_isActivityLoaded == value)
+            {
+                return;
+            }
+
+            _isActivityLoaded = value;
+            OnPropertyChanged();
+        }
+    }
 
     // Items is the ordered, searchable presentation projection. _catalogItems is
     // the canonical catalog and remains the source of selection and reconciliation.
@@ -98,6 +117,8 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         try
         {
             var operations = await _operationTracker.RefreshKnownOperationsAsync(cancellationToken);
+            IsActivityLoaded = true;
+            RebuildActivityProjection();
             foreach (var operation in operations)
             {
                 ProjectOperation(operation);
@@ -113,6 +134,8 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         }
         catch (Exception ex)
         {
+            // Do not mark Activity loaded: an unavailable retained-operation query
+            // is not truthful evidence that no recent activity exists.
             WarningBanner = $"Operation status is temporarily unavailable: {ex.Message}";
         }
 
@@ -340,6 +363,8 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         try
         {
             await _operationTracker.RefreshKnownOperationsAsync(cancellationToken);
+            IsActivityLoaded = true;
+            RebuildActivityProjection();
             if (_operationTracker.TryGetLatest(operationId, out var latest) && latest is not null)
             {
                 ValidateOperationIdentity(itemName, expectedAction, latest);
@@ -396,8 +421,14 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         }
     }
 
+    private void OperationTracker_OperationsChanged(object? sender, EventArgs e)
+    {
+        RebuildActivityProjection();
+    }
+
     private void ProjectOperation(OperationStatusEvent update, UiOptionalInstallItem? fallbackItem = null)
     {
+        RebuildActivityProjection();
         var item = FindItem(update.ItemName);
         if (item is null && fallbackItem is not null &&
             string.Equals(fallbackItem.ItemName, update.ItemName, StringComparison.OrdinalIgnoreCase))
@@ -473,6 +504,9 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         }
 
         RebuildVisibleItems();
+        // Catalog arrival/removal may change Activity display name and navigation,
+        // but never operation existence or identity.
+        RebuildActivityProjection();
     }
 
     private static void ApplyCatalogSnapshot(UiOptionalInstallItem item, OptionalInstallItem snapshot)
@@ -523,6 +557,63 @@ public sealed class HomeViewModel : INotifyPropertyChanged
         operation.Message,
         operation.TimestampUtc
     );
+
+    private void RebuildActivityProjection()
+    {
+        var retained = _operationTracker.GetRetainedOperations();
+        var retainedIds = retained.Select(operation => operation.OperationId).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var operationId in _activityItems.Keys.Where(id => !retainedIds.Contains(id)).ToArray())
+        {
+            _activityItems.Remove(operationId);
+        }
+
+        foreach (var operation in retained)
+        {
+            if (!_activityItems.TryGetValue(operation.OperationId, out var presentation))
+            {
+                presentation = new ActivityOperationPresentation(operation.OperationId);
+                _activityItems.Add(operation.OperationId, presentation);
+            }
+
+            var item = FindItem(operation.ItemName);
+            presentation.Apply(
+                operation,
+                item?.DisplayName ?? operation.ItemName,
+                canNavigate: item is not null
+            );
+        }
+
+        var desired = retained
+            .OrderBy(operation => operation.State == OperationState.Completed ? 1 : 0)
+            .ThenByDescending(operation => operation.TimestampUtc)
+            .ThenByDescending(operation => operation.OperationId, StringComparer.Ordinal)
+            .Select(operation => _activityItems[operation.OperationId])
+            .ToArray();
+
+        foreach (var existing in ActivityItems.Where(item => !desired.Contains(item)).ToArray())
+        {
+            ActivityItems.Remove(existing);
+        }
+
+        for (var index = 0; index < desired.Length; index++)
+        {
+            if (index < ActivityItems.Count && ReferenceEquals(ActivityItems[index], desired[index]))
+            {
+                continue;
+            }
+
+            var existingIndex = ActivityItems.IndexOf(desired[index]);
+            if (existingIndex >= 0)
+            {
+                ActivityItems.Move(existingIndex, index);
+            }
+            else
+            {
+                ActivityItems.Insert(index, desired[index]);
+            }
+        }
+    }
 
     private void RebuildVisibleItems()
     {

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
@@ -54,6 +54,9 @@ internal sealed class ActivityPageDriver
     public int CountEntries(string operationId)
         => Items.FindAllDescendants(cf => cf.ByAutomationId($"ActivityOperation-{operationId}")).Length;
 
+    public int CountEntriesContaining(string text)
+        => ListEntries().Count(item => SafeName(item).Contains(text, StringComparison.OrdinalIgnoreCase));
+
     public AutomationElement WaitForEntryContaining(string text, TimeSpan? timeout = null)
         => _session.WaitFor(
             () => ListEntries().FirstOrDefault(item => SafeName(item).Contains(text, StringComparison.OrdinalIgnoreCase)),

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
@@ -13,7 +13,7 @@ internal sealed class ActivityPageDriver
         _session = session;
     }
 
-    public AutomationElement Root => _session.WaitFor(() => ById("ActivityPageRoot"));
+    public AutomationElement Root => _session.WaitFor(() => ById("ActivityHeading"));
     public AutomationElement Items => _session.WaitFor(() => ById("ActivityItems"));
     public AutomationElement EmptyState => _session.WaitFor(() => ById("ActivityEmptyState"));
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
@@ -71,7 +71,7 @@ internal sealed class ActivityPageDriver
             timeout
         );
 
-    public string OperationId(AutomationElement entry) => SafeHelpText(entry);
+    public static string OperationId(AutomationElement entry) => SafeHelpText(entry);
 
     public void OpenDetails(string operationId)
     {

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
@@ -72,7 +72,11 @@ internal sealed class ActivityPageDriver
 
     public void OpenDetails(string operationId)
     {
-        WaitForOperation(operationId).Click();
+        var entry = WaitForOperation(operationId);
+        var nonActionTarget = _session.WaitFor(
+            () => entry.FindFirstDescendant(cf => cf.ByAutomationId($"ActivityApp-{operationId}"))
+        );
+        nonActionTarget.Click();
         _ = _session.WaitFor(() => ById("AppDetailsRoot"));
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
@@ -1,0 +1,119 @@
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using FlaUI.Core.Exceptions;
+
+namespace Gorilla.UI.App.WindowsUiTests;
+
+internal sealed class ActivityPageDriver
+{
+    private readonly GorillaAppSession _session;
+
+    public ActivityPageDriver(GorillaAppSession session)
+    {
+        _session = session;
+    }
+
+    public AutomationElement Root => _session.WaitFor(() => ById("ActivityPageRoot"));
+    public AutomationElement Items => _session.WaitFor(() => ById("ActivityItems"));
+    public AutomationElement EmptyState => _session.WaitFor(() => ById("ActivityEmptyState"));
+
+    public static ActivityPageDriver OpenFromCatalog(GorillaAppSession session)
+    {
+        var button = session.WaitFor(
+            () => session.MainWindow.FindFirstDescendant(cf => cf.ByAutomationId("ActivityNavigationButton"))?.AsButton()
+        );
+        button.Invoke();
+        var driver = new ActivityPageDriver(session);
+        _ = driver.Root;
+        return driver;
+    }
+
+    public AutomationElement WaitForOperation(string operationId, TimeSpan? timeout = null)
+        => _session.WaitFor(
+            () => Items.FindFirstDescendant(cf => cf.ByAutomationId($"ActivityOperation-{operationId}")),
+            timeout
+        );
+
+    public void WaitForOperationState(string operationId, string expected, TimeSpan? timeout = null)
+    {
+        _session.WaitUntil(
+            () => StateText(operationId).Contains(expected, StringComparison.OrdinalIgnoreCase),
+            timeout
+        );
+    }
+
+    public string StateText(string operationId)
+        => NameOfDescendant(operationId, $"ActivityState-{operationId}");
+
+    public string ActionText(string operationId)
+        => NameOfDescendant(operationId, $"ActivityAction-{operationId}");
+
+    public string DetailText(string operationId)
+        => NameOfDescendant(operationId, $"ActivityDetail-{operationId}");
+
+    public int CountEntries(string operationId)
+        => Items.FindAllDescendants(cf => cf.ByAutomationId($"ActivityOperation-{operationId}")).Length;
+
+    public AutomationElement WaitForEntryContaining(string text, TimeSpan? timeout = null)
+        => _session.WaitFor(
+            () => Items
+                .FindAllDescendants(cf => cf.ByControlType(ControlType.ListItem))
+                .FirstOrDefault(item => SafeName(item).Contains(text, StringComparison.OrdinalIgnoreCase)),
+            timeout
+        );
+
+    public string OperationId(AutomationElement entry) => SafeHelpText(entry);
+
+    public void OpenDetails(string operationId)
+    {
+        WaitForOperation(operationId).Click();
+        _ = _session.WaitFor(
+            () => sessionElement("AppDetailsRoot")
+        );
+    }
+
+    public void GoBack()
+    {
+        _session.WaitFor(() => ById("ActivityBackButton")?.AsButton()).Invoke();
+        _ = _session.WaitFor(
+            () => sessionElement("HomeHeading")
+        );
+    }
+
+    private string NameOfDescendant(string operationId, string automationId)
+    {
+        var entry = WaitForOperation(operationId);
+        var element = entry.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
+        return element is null ? string.Empty : SafeName(element);
+    }
+
+    private AutomationElement? ById(string automationId)
+        => _session.MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
+
+    private AutomationElement? sessionElement(string automationId)
+        => _session.MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
+
+    private static string SafeName(AutomationElement element)
+    {
+        try
+        {
+            return element.Name;
+        }
+        catch (PropertyNotSupportedException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string SafeHelpText(AutomationElement element)
+    {
+        try
+        {
+            return element.Properties.HelpText.ValueOrDefault ?? string.Empty;
+        }
+        catch (PropertyNotSupportedException)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityPageDriver.cs
@@ -56,9 +56,15 @@ internal sealed class ActivityPageDriver
 
     public AutomationElement WaitForEntryContaining(string text, TimeSpan? timeout = null)
         => _session.WaitFor(
-            () => Items
-                .FindAllDescendants(cf => cf.ByControlType(ControlType.ListItem))
-                .FirstOrDefault(item => SafeName(item).Contains(text, StringComparison.OrdinalIgnoreCase)),
+            () => ListEntries().FirstOrDefault(item => SafeName(item).Contains(text, StringComparison.OrdinalIgnoreCase)),
+            timeout
+        );
+
+    public AutomationElement WaitForEntryWithDetail(string detail, TimeSpan? timeout = null)
+        => _session.WaitFor(
+            () => ListEntries().FirstOrDefault(item =>
+                item.FindAllDescendants(cf => cf.ByControlType(ControlType.Text))
+                    .Any(text => SafeName(text).Contains(detail, StringComparison.OrdinalIgnoreCase))),
             timeout
         );
 
@@ -67,18 +73,17 @@ internal sealed class ActivityPageDriver
     public void OpenDetails(string operationId)
     {
         WaitForOperation(operationId).Click();
-        _ = _session.WaitFor(
-            () => sessionElement("AppDetailsRoot")
-        );
+        _ = _session.WaitFor(() => ById("AppDetailsRoot"));
     }
 
     public void GoBack()
     {
         _session.WaitFor(() => ById("ActivityBackButton")?.AsButton()).Invoke();
-        _ = _session.WaitFor(
-            () => sessionElement("HomeHeading")
-        );
+        _ = _session.WaitFor(() => ById("HomeHeading"));
     }
+
+    private AutomationElement[] ListEntries()
+        => Items.FindAllDescendants(cf => cf.ByControlType(ControlType.ListItem));
 
     private string NameOfDescendant(string operationId, string automationId)
     {
@@ -88,9 +93,6 @@ internal sealed class ActivityPageDriver
     }
 
     private AutomationElement? ById(string automationId)
-        => _session.MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
-
-    private AutomationElement? sessionElement(string automationId)
         => _session.MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
 
     private static string SafeName(AutomationElement element)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -74,6 +74,7 @@ public sealed class ActivityTests
     {
         var slowMarkerPath = RequiredPath("GORILLA_UI_E2E_SLOW_MARKER_PATH");
         string operationId;
+        int retainedSlowOperationsBeforeInstall;
 
         using (var first = GorillaAppSession.Launch())
         {
@@ -81,6 +82,12 @@ public sealed class ActivityTests
             {
                 var home = new HomePageDriver(first);
                 EnsureSlowFixtureAbsent(first, home, slowMarkerPath);
+
+                var beforeActivity = ActivityPageDriver.OpenFromCatalog(first);
+                retainedSlowOperationsBeforeInstall = beforeActivity.CountEntriesContaining("Slow Install Fixture");
+                beforeActivity.GoBack();
+
+                home = new HomePageDriver(first);
                 home.PrimaryActionButton(SlowFixtureItemName).Invoke();
                 home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
                 operationId = home.OperationId(SlowFixtureItemName);
@@ -102,7 +109,7 @@ public sealed class ActivityTests
             var activity = ActivityPageDriver.OpenFromCatalog(second);
             _ = activity.WaitForOperation(operationId, TimeSpan.FromSeconds(30));
             Assert.Equal(1, activity.CountEntries(operationId));
-            Assert.Equal(1, activity.CountEntriesContaining("Slow Install Fixture"));
+            Assert.Equal(retainedSlowOperationsBeforeInstall + 1, activity.CountEntriesContaining("Slow Install Fixture"));
             Assert.True(
                 activity.StateText(operationId).Contains("Installing", StringComparison.OrdinalIgnoreCase)
                 || activity.StateText(operationId).Contains("Succeeded", StringComparison.OrdinalIgnoreCase),

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -120,6 +120,12 @@ public sealed class ActivityTests
                 $"Expected recovered operation {operationId} to be active or retained terminal, got '{activity.StateText(operationId)}'."
             );
             second.CaptureCheckpoint("activity-after-ui-relaunch", includeAutomationTree: true);
+
+            // The relaunch assertion above intentionally observes an operation that
+            // may still be active. Finish that same recovered operation before this
+            // test releases the shared E2E service/fixture state to the next test.
+            second.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
+            activity.WaitForOperationState(operationId, "Succeeded", TimeSpan.FromSeconds(30));
         }
         catch (Exception ex)
         {

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -102,6 +102,7 @@ public sealed class ActivityTests
             var activity = ActivityPageDriver.OpenFromCatalog(second);
             _ = activity.WaitForOperation(operationId, TimeSpan.FromSeconds(30));
             Assert.Equal(1, activity.CountEntries(operationId));
+            Assert.Equal(1, activity.CountEntriesContaining("Slow Install Fixture"));
             Assert.True(
                 activity.StateText(operationId).Contains("Installing", StringComparison.OrdinalIgnoreCase)
                 || activity.StateText(operationId).Contains("Succeeded", StringComparison.OrdinalIgnoreCase),

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -1,0 +1,157 @@
+using Xunit;
+
+namespace Gorilla.UI.App.WindowsUiTests;
+
+public sealed class ActivityTests
+{
+    private const string FailureFixtureItemName = "Ps1Failure";
+    private const string SlowFixtureItemName = "SlowInstallFixture";
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void ActiveOperationTransitionsInPlaceAndNavigatesToSameDetailsOperation()
+    {
+        RunWithDiagnostics(nameof(ActiveOperationTransitionsInPlaceAndNavigatesToSameDetailsOperation), session =>
+        {
+            var slowMarkerPath = RequiredPath("GORILLA_UI_E2E_SLOW_MARKER_PATH");
+            var home = new HomePageDriver(session);
+            EnsureSlowFixtureAbsent(session, home, slowMarkerPath);
+
+            home.PrimaryActionButton(SlowFixtureItemName).Invoke();
+            home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
+            var operationId = home.OperationId(SlowFixtureItemName);
+            Assert.False(string.IsNullOrWhiteSpace(operationId));
+
+            var activity = ActivityPageDriver.OpenFromCatalog(session);
+            activity.WaitForOperationState(operationId, "Installing", TimeSpan.FromSeconds(30));
+            Assert.Equal(1, activity.CountEntries(operationId));
+            Assert.Equal("Install", activity.ActionText(operationId));
+            session.CaptureCheckpoint("activity-active", includeAutomationTree: true);
+
+            activity.OpenDetails(operationId);
+            var details = new AppDetailsPageDriver(session);
+            details.WaitForActiveOperation("Install", TimeSpan.FromSeconds(30));
+            Assert.Equal(operationId, details.ActiveOperationId);
+            session.CaptureCheckpoint("activity-details-same-operation");
+
+            session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
+            details.WaitForObservation("Installed", TimeSpan.FromSeconds(30));
+            details.GoBack();
+
+            activity = new ActivityPageDriver(session);
+            activity.WaitForOperationState(operationId, "Succeeded", TimeSpan.FromSeconds(30));
+            Assert.Equal(1, activity.CountEntries(operationId));
+            session.CaptureCheckpoint("activity-terminal-same-entry", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void RetainedFailureStaysLocalAndShowsStructuredDetail()
+    {
+        RunWithDiagnostics(nameof(RetainedFailureStaysLocalAndShowsStructuredDetail), session =>
+        {
+            var home = new HomePageDriver(session);
+            _ = home.WaitForItem(FailureFixtureItemName);
+            home.PrimaryActionButton(FailureFixtureItemName).Invoke();
+            home.WaitForTerminalFeedbackContaining(FailureFixtureItemName, "Installation error: exit status 7", TimeSpan.FromSeconds(60));
+            Assert.DoesNotContain("Operation failed", home.WarningText, StringComparison.OrdinalIgnoreCase);
+
+            var activity = ActivityPageDriver.OpenFromCatalog(session);
+            var entry = activity.WaitForEntryWithDetail("Installation error: exit status 7", TimeSpan.FromSeconds(30));
+            var operationId = activity.OperationId(entry);
+            Assert.False(string.IsNullOrWhiteSpace(operationId));
+            activity.WaitForOperationState(operationId, "Failed", TimeSpan.FromSeconds(30));
+            Assert.Contains("Installation error: exit status 7", activity.DetailText(operationId), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(1, activity.CountEntries(operationId));
+            session.CaptureCheckpoint("activity-retained-failure", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void UiRelaunchRecoversRetainedOperationWithoutCreatingDuplicateActivity()
+    {
+        var slowMarkerPath = RequiredPath("GORILLA_UI_E2E_SLOW_MARKER_PATH");
+        string operationId;
+
+        using (var first = GorillaAppSession.Launch())
+        {
+            try
+            {
+                var home = new HomePageDriver(first);
+                EnsureSlowFixtureAbsent(first, home, slowMarkerPath);
+                home.PrimaryActionButton(SlowFixtureItemName).Invoke();
+                home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
+                operationId = home.OperationId(SlowFixtureItemName);
+                Assert.False(string.IsNullOrWhiteSpace(operationId));
+                first.CaptureCheckpoint("activity-before-ui-relaunch");
+            }
+            catch (Exception ex)
+            {
+                first.CaptureFailure(ex, nameof(UiRelaunchRecoversRetainedOperationWithoutCreatingDuplicateActivity));
+                throw;
+            }
+        }
+
+        using var second = GorillaAppSession.Launch();
+        try
+        {
+            var home = new HomePageDriver(second);
+            _ = home.WaitForItem(SlowFixtureItemName);
+            var activity = ActivityPageDriver.OpenFromCatalog(second);
+            _ = activity.WaitForOperation(operationId, TimeSpan.FromSeconds(30));
+            Assert.Equal(1, activity.CountEntries(operationId));
+            Assert.True(
+                activity.StateText(operationId).Contains("Installing", StringComparison.OrdinalIgnoreCase)
+                || activity.StateText(operationId).Contains("Succeeded", StringComparison.OrdinalIgnoreCase),
+                $"Expected recovered operation {operationId} to be active or retained terminal, got '{activity.StateText(operationId)}'."
+            );
+            second.CaptureCheckpoint("activity-after-ui-relaunch", includeAutomationTree: true);
+        }
+        catch (Exception ex)
+        {
+            second.CaptureFailure(ex, nameof(UiRelaunchRecoversRetainedOperationWithoutCreatingDuplicateActivity));
+            throw;
+        }
+    }
+
+    private static void EnsureSlowFixtureAbsent(GorillaAppSession session, HomePageDriver home, string slowMarkerPath)
+    {
+        _ = home.WaitForItem(SlowFixtureItemName);
+        if (string.Equals(home.ItemStatus(SlowFixtureItemName), "Installed", StringComparison.OrdinalIgnoreCase))
+        {
+            home.RemoveButton(SlowFixtureItemName).Invoke();
+            session.WaitUntil(() => !File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
+            home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
+        }
+        else
+        {
+            home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
+        }
+    }
+
+    private static string RequiredPath(string variableName)
+    {
+        var value = Environment.GetEnvironmentVariable(variableName);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{variableName} must be set by the E2E harness.");
+        }
+        return value;
+    }
+
+    private static void RunWithDiagnostics(string testName, Action<GorillaAppSession> test)
+    {
+        using var session = GorillaAppSession.Launch();
+        try
+        {
+            test(session);
+        }
+        catch (Exception ex)
+        {
+            session.CaptureFailure(ex, testName);
+            throw;
+        }
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -59,7 +59,7 @@ public sealed class ActivityTests
 
             var activity = ActivityPageDriver.OpenFromCatalog(session);
             var entry = activity.WaitForEntryWithDetail("Installation error: exit status 7", TimeSpan.FromSeconds(30));
-            var operationId = activity.OperationId(entry);
+            var operationId = ActivityPageDriver.OperationId(entry);
             Assert.False(string.IsNullOrWhiteSpace(operationId));
             activity.WaitForOperationState(operationId, "Failed", TimeSpan.FromSeconds(30));
             Assert.Contains("Installation error: exit status 7", activity.DetailText(operationId), StringComparison.OrdinalIgnoreCase);

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -88,6 +88,10 @@ public sealed class ActivityTests
                 beforeActivity.GoBack();
 
                 home = new HomePageDriver(first);
+                first.WaitUntil(
+                    () => home.PrimaryActionButton(SlowFixtureItemName).IsEnabled,
+                    TimeSpan.FromSeconds(30)
+                );
                 home.PrimaryActionButton(SlowFixtureItemName).Invoke();
                 home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
                 operationId = home.OperationId(SlowFixtureItemName);
@@ -137,6 +141,11 @@ public sealed class ActivityTests
         {
             home.WaitForItemStatus(SlowFixtureItemName, "Not installed", TimeSpan.FromSeconds(30));
         }
+
+        session.WaitUntil(
+            () => home.PrimaryActionButton(SlowFixtureItemName).IsEnabled,
+            TimeSpan.FromSeconds(30)
+        );
     }
 
     private static string RequiredPath(string variableName)

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AssemblyInfo.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AssemblyInfo.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/Gorilla.UI.App.WindowsUiTests.csproj
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/Gorilla.UI.App.WindowsUiTests.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/xunit.runner.json
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/ActivityProjectionTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/ActivityProjectionTests.cs
@@ -63,12 +63,12 @@ public class ActivityProjectionTests
     }
 
     [Theory]
-    [InlineData(Outcome.Succeeded)]
-    [InlineData(Outcome.AlreadySatisfied)]
-    [InlineData(Outcome.Failed)]
-    [InlineData(Outcome.Unverified)]
-    [InlineData(Outcome.Interrupted)]
-    public async Task Activity_PreservesEveryStructuredTerminalOutcome(Outcome outcome)
+    [InlineData(Outcome.Succeeded, "Succeeded")]
+    [InlineData(Outcome.AlreadySatisfied, "Already satisfied")]
+    [InlineData(Outcome.Failed, "Failed")]
+    [InlineData(Outcome.Unverified, "Unable to verify")]
+    [InlineData(Outcome.Interrupted, "Interrupted")]
+    public async Task Activity_PreservesEveryStructuredTerminalOutcome(Outcome outcome, string label)
     {
         var operation = Completed("op-1", "Example", outcome, Now, $"{outcome}_code", $"{outcome} detail");
         var client = new FakeClient
@@ -84,7 +84,7 @@ public class ActivityProjectionTests
         Assert.Equal(outcome, activity.Result?.Outcome);
         Assert.Equal($"{outcome}_code", activity.Result?.Code);
         Assert.Equal($"{outcome} detail", activity.Result?.Message);
-        Assert.Equal(outcome.ToString(), activity.StateText);
+        Assert.Equal(label, activity.StateText);
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/ActivityProjectionTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/ActivityProjectionTests.cs
@@ -16,13 +16,13 @@ public class ActivityProjectionTests
     [Fact]
     public async Task Activity_UsesOperationIdentityDeduplicatesAndOrdersActiveBeforeTerminal()
     {
-        var activeOlder = Event("op-b", "Beta", OperationState.Installing, Now.AddMinutes(-2));
-        var activeNewer = Event("op-a", "Alpha", OperationState.Removing, Now.AddMinutes(-1), action: AppCatalog.Action.Remove);
+        var activeB = Event("op-b", "Beta", OperationState.Installing, Now.AddMinutes(-1));
+        var activeA = Event("op-a", "Alpha", OperationState.Removing, Now.AddMinutes(-1), action: AppCatalog.Action.Remove);
         var terminal = Completed("op-z", "Alpha", Outcome.Succeeded, Now);
         var client = new FakeClient
         {
             Catalogs = [[Item("Alpha", "Alpha App"), Item("Beta", "Beta App")]],
-            OperationSnapshots = [[terminal, activeOlder, activeNewer]],
+            OperationSnapshots = [[terminal, activeA, activeB]],
         };
         var tracker = new OperationTracker(client);
         var viewModel = CreateViewModel(client, tracker);
@@ -30,10 +30,10 @@ public class ActivityProjectionTests
         await viewModel.InitializeAsync(CancellationToken.None);
 
         Assert.True(viewModel.IsActivityLoaded);
-        Assert.Equal(["op-a", "op-b", "op-z"], viewModel.ActivityItems.Select(item => item.OperationId));
-        Assert.Equal("Alpha App", viewModel.ActivityItems[0].DisplayName);
-        Assert.Equal("Remove", viewModel.ActivityItems[0].ActionLabel);
-        Assert.Equal("Install", viewModel.ActivityItems[1].ActionLabel);
+        Assert.Equal(["op-b", "op-a", "op-z"], viewModel.ActivityItems.Select(item => item.OperationId));
+        Assert.Equal("Beta App", viewModel.ActivityItems[0].DisplayName);
+        Assert.Equal("Install", viewModel.ActivityItems[0].ActionLabel);
+        Assert.Equal("Remove", viewModel.ActivityItems[1].ActionLabel);
         Assert.Equal(3, viewModel.ActivityItems.Select(item => item.OperationId).Distinct().Count());
     }
 
@@ -60,7 +60,6 @@ public class ActivityProjectionTests
         Assert.True(after.IsTerminal);
         Assert.Equal(Outcome.Failed, after.Result?.Outcome);
         Assert.Equal("Installer failed", after.DetailText);
-        Assert.Equal("op-1", Assert.Single(viewModel.Items).LatestOperation?.OperationId);
     }
 
     [Theory]
@@ -185,7 +184,7 @@ public class ActivityProjectionTests
         Assert.Equal("op-history", activity.OperationId);
         Assert.Equal("Example", activity.ItemName);
         Assert.Equal(AppCatalog.Action.Install, activity.Action);
-        Assert.Same(result, activity.Result);
+        Assert.Equal(result, activity.Result);
         Assert.Equal("Install", activity.ActionLabel);
     }
 
@@ -223,7 +222,7 @@ public class ActivityProjectionTests
         => new(
             itemName, displayName, "1.0", "catalog", "msi", "package", "installer.msi",
             true, false, OptionalInstallStatus.NotInstalled, Now, null, "1.0",
-            new Observation(ObservedState.Absent, null, Now, "absent", RequirementState.Unsatisfied),
+            new Observation(ObservedState.Absent, null, Now, "absent", RequirementState.NotSatisfied),
             Actions: new Actions(new ActionDecision(true, ""), new ActionDecision(false, "not_installed"))
         );
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/ActivityProjectionTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/ActivityProjectionTests.cs
@@ -1,0 +1,293 @@
+using System.Runtime.CompilerServices;
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using Gorilla.UI.Core;
+using Gorilla.UI.Core.Services;
+using Gorilla.UI.Core.ViewModels;
+using Xunit;
+using AppCatalog = Gorilla.UI.Client.AppCatalog;
+
+namespace Gorilla.UI.Core.Tests;
+
+public class ActivityProjectionTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-09-12T03:00:00Z");
+
+    [Fact]
+    public async Task Activity_UsesOperationIdentityDeduplicatesAndOrdersActiveBeforeTerminal()
+    {
+        var activeOlder = Event("op-b", "Beta", OperationState.Installing, Now.AddMinutes(-2));
+        var activeNewer = Event("op-a", "Alpha", OperationState.Removing, Now.AddMinutes(-1), action: AppCatalog.Action.Remove);
+        var terminal = Completed("op-z", "Alpha", Outcome.Succeeded, Now);
+        var client = new FakeClient
+        {
+            Catalogs = [[Item("Alpha", "Alpha App"), Item("Beta", "Beta App")]],
+            OperationSnapshots = [[terminal, activeOlder, activeNewer]],
+        };
+        var tracker = new OperationTracker(client);
+        var viewModel = CreateViewModel(client, tracker);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        Assert.True(viewModel.IsActivityLoaded);
+        Assert.Equal(["op-a", "op-b", "op-z"], viewModel.ActivityItems.Select(item => item.OperationId));
+        Assert.Equal("Alpha App", viewModel.ActivityItems[0].DisplayName);
+        Assert.Equal("Remove", viewModel.ActivityItems[0].ActionLabel);
+        Assert.Equal("Install", viewModel.ActivityItems[1].ActionLabel);
+        Assert.Equal(3, viewModel.ActivityItems.Select(item => item.OperationId).Distinct().Count());
+    }
+
+    [Fact]
+    public async Task Activity_ActiveBecomingTerminalReconcilesSameLogicalEntry()
+    {
+        var active = Event("op-1", "Example", OperationState.Installing, Now, progress: 25);
+        var terminal = Completed("op-1", "Example", Outcome.Failed, Now.AddMinutes(1), "execution_failed", "Installer failed");
+        var client = new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example App")]],
+            OperationSnapshots = [[active], [terminal]],
+        };
+        var tracker = new OperationTracker(client);
+        var viewModel = CreateViewModel(client, tracker);
+        await viewModel.InitializeAsync(CancellationToken.None);
+        var before = Assert.Single(viewModel.ActivityItems);
+        Assert.True(before.IsActive);
+
+        await tracker.RefreshKnownOperationsAsync(CancellationToken.None);
+
+        var after = Assert.Single(viewModel.ActivityItems);
+        Assert.Same(before, after);
+        Assert.True(after.IsTerminal);
+        Assert.Equal(Outcome.Failed, after.Result?.Outcome);
+        Assert.Equal("Installer failed", after.DetailText);
+        Assert.Equal("op-1", Assert.Single(viewModel.Items).LatestOperation?.OperationId);
+    }
+
+    [Theory]
+    [InlineData(Outcome.Succeeded)]
+    [InlineData(Outcome.AlreadySatisfied)]
+    [InlineData(Outcome.Failed)]
+    [InlineData(Outcome.Unverified)]
+    [InlineData(Outcome.Interrupted)]
+    public async Task Activity_PreservesEveryStructuredTerminalOutcome(Outcome outcome)
+    {
+        var operation = Completed("op-1", "Example", outcome, Now, $"{outcome}_code", $"{outcome} detail");
+        var client = new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example App")]],
+            OperationSnapshots = [[operation]],
+        };
+        var viewModel = CreateViewModel(client, new OperationTracker(client));
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var activity = Assert.Single(viewModel.ActivityItems);
+        Assert.Equal(outcome, activity.Result?.Outcome);
+        Assert.Equal($"{outcome}_code", activity.Result?.Code);
+        Assert.Equal($"{outcome} detail", activity.Result?.Message);
+        Assert.Equal(outcome.ToString(), activity.StateText);
+    }
+
+    [Fact]
+    public async Task Activity_MissingCatalogItemRemainsVisibleAndNonNavigable()
+    {
+        var operation = Completed("op-orphan", "GoneApp", Outcome.Interrupted, Now);
+        var client = new FakeClient
+        {
+            Catalogs = [[]],
+            OperationSnapshots = [[operation]],
+        };
+        var viewModel = CreateViewModel(client, new OperationTracker(client));
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var activity = Assert.Single(viewModel.ActivityItems);
+        Assert.Equal("GoneApp", activity.ItemName);
+        Assert.Equal("GoneApp", activity.DisplayName);
+        Assert.False(activity.CanNavigate);
+    }
+
+    [Fact]
+    public async Task Activity_CatalogArrivalUpgradesDisplayNameWithoutChangingEntryIdentity()
+    {
+        var operation = Completed("op-1", "Example", Outcome.Succeeded, Now);
+        var client = new FakeClient
+        {
+            Catalogs = [[], [Item("Example", "Friendly Example")]],
+            OperationSnapshots = [[operation], [operation]],
+        };
+        var tracker = new OperationTracker(client);
+        var viewModel = CreateViewModel(client, tracker);
+        await viewModel.InitializeAsync(CancellationToken.None);
+        var before = Assert.Single(viewModel.ActivityItems);
+        Assert.Equal("Example", before.DisplayName);
+        Assert.False(before.CanNavigate);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var after = Assert.Single(viewModel.ActivityItems);
+        Assert.Same(before, after);
+        Assert.Equal("Friendly Example", after.DisplayName);
+        Assert.True(after.CanNavigate);
+    }
+
+    [Fact]
+    public async Task Activity_RecoveryUsesListOperationsWithoutSubmittingMutation()
+    {
+        var terminal = Completed("op-recovered", "Example", Outcome.Unverified, Now, "verification_unavailable", "Could not verify");
+        var client = new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example App")]],
+            OperationSnapshots = [[terminal]],
+        };
+        var viewModel = CreateViewModel(client, new OperationTracker(client));
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        Assert.Equal("op-recovered", Assert.Single(viewModel.ActivityItems).OperationId);
+        Assert.Equal(0, client.InstallCalls);
+        Assert.Equal(0, client.RemoveCalls);
+    }
+
+    [Fact]
+    public async Task Activity_FailedOperationRecoveryDoesNotClaimAuthoritativeEmptyState()
+    {
+        var client = new FakeClient
+        {
+            Catalogs = [[]],
+            ListOperationsFailure = new IOException("service unavailable"),
+        };
+        var viewModel = CreateViewModel(client, new OperationTracker(client));
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        Assert.False(viewModel.IsActivityLoaded);
+        Assert.Empty(viewModel.ActivityItems);
+        Assert.Contains("Operation status is temporarily unavailable", viewModel.WarningBanner, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Activity_PreservesStructuredIdentityNeededForFutureCurrentPolicyRetry()
+    {
+        var result = new Result(Outcome.Failed, "execution_failed", Message: "Installer failed");
+        var operation = new OperationStatusEvent(
+            "op-history", OperationState.Completed, null, "Done", Now, "Example", AppCatalog.Action.Install, result
+        );
+        var client = new FakeClient
+        {
+            Catalogs = [[Item("Example", "Example App")]],
+            OperationSnapshots = [[operation]],
+        };
+        var viewModel = CreateViewModel(client, new OperationTracker(client));
+        await viewModel.InitializeAsync(CancellationToken.None);
+
+        var activity = Assert.Single(viewModel.ActivityItems);
+        Assert.Equal("op-history", activity.OperationId);
+        Assert.Equal("Example", activity.ItemName);
+        Assert.Equal(AppCatalog.Action.Install, activity.Action);
+        Assert.Same(result, activity.Result);
+        Assert.Equal("Install", activity.ActionLabel);
+    }
+
+    private static HomeViewModel CreateViewModel(FakeClient client, OperationTracker tracker)
+        => new(client, new OptionalInstallsCacheCoordinator(client, new InMemoryCacheStore()), tracker);
+
+    private static OperationStatusEvent Event(
+        string operationId,
+        string itemName,
+        OperationState state,
+        DateTimeOffset timestamp,
+        AppCatalog.Action action = AppCatalog.Action.Install,
+        int? progress = null)
+        => new(operationId, state, progress, state.ToString(), timestamp, itemName, action);
+
+    private static OperationStatusEvent Completed(
+        string operationId,
+        string itemName,
+        Outcome outcome,
+        DateTimeOffset timestamp,
+        string code = "completed",
+        string message = "Done")
+        => new(
+            operationId,
+            OperationState.Completed,
+            null,
+            message,
+            timestamp,
+            itemName,
+            AppCatalog.Action.Install,
+            new Result(outcome, code, Message: message)
+        );
+
+    private static OptionalInstallItem Item(string itemName, string displayName)
+        => new(
+            itemName, displayName, "1.0", "catalog", "msi", "package", "installer.msi",
+            true, false, OptionalInstallStatus.NotInstalled, Now, null, "1.0",
+            new Observation(ObservedState.Absent, null, Now, "absent", RequirementState.Unsatisfied),
+            Actions: new Actions(new ActionDecision(true, ""), new ActionDecision(false, "not_installed"))
+        );
+
+    private sealed class InMemoryCacheStore : IOptionalInstallsCacheStore
+    {
+        private OptionalInstallsCacheDocument? _document;
+        public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken) => Task.FromResult(_document);
+        public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
+        {
+            _document = document;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeClient : IGorillaServiceClient
+    {
+        private int _catalogCall;
+        private int _operationCall;
+
+        public IReadOnlyList<IReadOnlyList<OptionalInstallItem>> Catalogs { get; init; } = [[]];
+        public IReadOnlyList<IReadOnlyList<OperationStatusEvent>> OperationSnapshots { get; init; } = [[]];
+        public Exception? ListOperationsFailure { get; init; }
+        public int InstallCalls { get; private set; }
+        public int RemoveCalls { get; private set; }
+
+        public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
+        {
+            var index = Math.Min(_catalogCall++, Catalogs.Count - 1);
+            return Task.FromResult(Catalogs[index]);
+        }
+
+        public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken)
+        {
+            InstallCalls++;
+            return Task.FromResult(new OperationAccepted("new-op", true, Now));
+        }
+
+        public Task<OperationAccepted> RemoveItemAsync(string itemName, CancellationToken cancellationToken)
+        {
+            RemoveCalls++;
+            return Task.FromResult(new OperationAccepted("new-op", true, Now));
+        }
+
+        public Task<IReadOnlyList<OperationStatusEvent>> ListOperationsAsync(CancellationToken cancellationToken)
+        {
+            if (ListOperationsFailure is not null)
+            {
+                throw ListOperationsFailure;
+            }
+
+            var index = Math.Min(_operationCall++, OperationSnapshots.Count - 1);
+            return Task.FromResult(OperationSnapshots[index]);
+        }
+
+        public IAsyncEnumerable<OperationStatusEvent> StreamOperationStatusAsync(
+            string operationId,
+            CancellationToken cancellationToken)
+            => EmptyStream(cancellationToken);
+
+        private static async IAsyncEnumerable<OperationStatusEvent> EmptyStream(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/OperationTrackerRecoveryTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/OperationTrackerRecoveryTests.cs
@@ -32,6 +32,35 @@ public class OperationTrackerRecoveryTests
     }
 
     [Fact]
+    public async Task TrackAsync_DoesNotRegressRecoveredSnapshotWhenStreamReplaysOlderEvents()
+    {
+        var recovered = new OperationStatusEvent(
+            "op-1",
+            OperationState.Installing,
+            50,
+            "Installing",
+            Now.AddSeconds(10),
+            "VLC",
+            AppCatalog.Action.Install
+        );
+        var client = new FakeClient
+        {
+            ListOperationsAsyncImpl = _ => Task.FromResult<IReadOnlyList<OperationStatusEvent>>([recovered]),
+            StreamAsync = (_, _, _) => ReplayedAfterRecoveredSnapshot(),
+        };
+        var tracker = new OperationTracker(client);
+        await tracker.RefreshKnownOperationsAsync(CancellationToken.None);
+        var delivered = new List<OperationStatusEvent>();
+
+        await tracker.TrackAsync("op-1", delivered.Add, CancellationToken.None);
+
+        Assert.Single(delivered);
+        Assert.Equal(OperationState.Completed, delivered[0].State);
+        Assert.Null(tracker.GetActiveForItem("VLC"));
+        Assert.Equal(OperationState.Completed, tracker.GetLatestTerminalForItem("VLC")?.State);
+    }
+
+    [Fact]
     public async Task RefreshKnownOperations_RemovesVanishedOperationWithoutInventingTerminalResult()
     {
         var active = Event(OperationState.Installing, "Copying files");
@@ -98,6 +127,27 @@ public class OperationTrackerRecoveryTests
             null,
             "Installed",
             Now,
+            "VLC",
+            AppCatalog.Action.Install,
+            new Result(Outcome.Succeeded, "completed", Message: "Installed")
+        );
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<OperationStatusEvent> ReplayedAfterRecoveredSnapshot()
+    {
+        yield return new OperationStatusEvent(
+            "op-1", OperationState.Queued, null, "Queued", Now, "VLC", AppCatalog.Action.Install
+        );
+        yield return new OperationStatusEvent(
+            "op-1", OperationState.Installing, 25, "Installing", Now.AddSeconds(5), "VLC", AppCatalog.Action.Install
+        );
+        yield return new OperationStatusEvent(
+            "op-1",
+            OperationState.Completed,
+            null,
+            "Installed",
+            Now.AddSeconds(15),
             "VLC",
             AppCatalog.Action.Install,
             new Result(Outcome.Succeeded, "completed", Message: "Installed")


### PR DESCRIPTION
## Summary

Begins Stage 6 by exposing the service's existing retained operation/recovery state as a durable Activity experience.

- adds Catalog → Activity navigation and Activity → current App Details navigation by `ItemName`
- extends the existing `OperationTracker` operation-ID registry with a canonical retained-operation snapshot and change notification rather than creating a second history system
- projects active and retained terminal operations into a deterministic Activity collection keyed by `OperationId`
- orders active operations first, then terminal operations, newest first with operation ID as the final tie-breaker
- preserves structured operation identity/result data (`OperationId`, `ItemName`, authoritative service action, and `Result`) so a later PR can implement Retry by re-entering the current service-authorized action path without replaying historical mutations
- uses retained service action truth (`Install` / `Remove`) rather than reconstructing historical `Update` / `Keep Installed` labels from current catalog state
- falls back to `ItemName` and disables details navigation when a retained operation's catalog item no longer exists
- upgrades Activity display name/navigation in place if catalog data arrives later
- distinguishes all existing structured terminal outcomes and preserves service/result detail
- shows determinate active progress only when the service supplied a percentage; otherwise progress is indeterminate
- reconstructs Activity through the existing `ListOperations` startup recovery path and does not submit a new mutation during recovery
- only presents `No recent activity` after retained-operation loading succeeds; operation-status load failures remain infrastructure warnings rather than false empty history
- prevents replayed stream events from regressing the canonical Activity projection during reconnect
- adds stable operation-ID rooted automation identity and per-entry live state updates

## Tests

Portable Core coverage includes:

- operation-ID identity/deduplication and deterministic ordering
- active → terminal in-place transition
- all five structured terminal outcomes
- missing/current catalog item behavior and late catalog arrival
- shared card/details/Activity operation projection
- recovery without mutation submission
- truthful failed-recovery empty-state behavior
- structured identity preservation for future Retry

Windows/FlaUI coverage includes:

- active operation shown once in Activity and transitioning to terminal in the same logical entry
- same `OperationId` across Catalog → Activity → Details
- retained structured failure detail remaining local rather than becoming a global warning
- UI relaunch against the same service reconstructing the retained operation without duplicate Activity entries

## Scope boundary

No Retry, Refresh, generalized stale/offline presentation, cache-write degradation, permanent history, service retention changes, service/protocol changes, new detection/action policy, cancellation, or historical mutation replay is introduced.

This implements PR E of the Stage 6 App Catalog plan.