### PR TITLE
Stabilize catalog details navigation E2E

### DIFF
--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Definitions;
 using FlaUI.Core.Exceptions;
@@ -40,13 +41,31 @@ internal sealed class HomePageDriver
 
     public void OpenDetails(string itemName)
     {
-        EnsureItemVisible(itemName);
-        var item = WaitForItem(itemName);
-        var nonActionTarget = _session.WaitFor(
-            () => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogDisplayName"))
-        );
-        nonActionTarget.Click();
-        _ = _session.WaitFor(() => ById("AppDetailsRoot"));
+        var timeout = TimeSpan.FromSeconds(30);
+        var stopwatch = Stopwatch.StartNew();
+
+        while (stopwatch.Elapsed < timeout)
+        {
+            EnsureItemVisible(itemName);
+            var item = WaitForItem(itemName);
+            var nonActionTarget = _session.WaitFor(
+                () => item.FindFirstDescendant(cf => cf.ByAutomationId("CatalogDisplayName"))
+            );
+            nonActionTarget.Click();
+
+            try
+            {
+                _ = _session.WaitFor(() => ById("AppDetailsRoot"), TimeSpan.FromSeconds(2));
+                return;
+            }
+            catch (TimeoutException) when (stopwatch.Elapsed < timeout)
+            {
+                // Pointer delivery can race GridView settling after ScrollIntoView/focus.
+                // Reacquire the current realized card and retry the same non-action target.
+            }
+        }
+
+        _ = _session.WaitFor(() => ById("AppDetailsRoot"), TimeSpan.FromMilliseconds(1));
     }
 
     public Button InstallButton(string itemName) => ActionButton(itemName, "Install", "Update", "Keep Installed");

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/HomePageDriver.cs
@@ -65,7 +65,9 @@ internal sealed class HomePageDriver
             }
         }
 
-        _ = _session.WaitFor(() => ById("AppDetailsRoot"), TimeSpan.FromMilliseconds(1));
+        throw new TimeoutException(
+            $"Timed out after {timeout.TotalSeconds:n0}s opening details for '{itemName}'."
+        );
     }
 
     public Button InstallButton(string itemName) => ActionButton(itemName, "Install", "Update", "Keep Installed");


### PR DESCRIPTION
## Summary

Fix the intermittent Windows UI E2E failure where `HomePageDriver.OpenDetails` issues a single pointer click on the catalog display name and then waits for navigation that may never have been delivered while the `GridView` is still settling after scroll/focus changes.

## Change

- keep the explicit `CatalogDisplayName` non-action click target introduced to avoid accidentally invoking card action buttons;
- retry that same user interaction when `AppDetailsRoot` does not appear within a short navigation window;
- reacquire the realized card/title before each retry so virtualization or layout changes cannot leave the driver holding stale automation elements;
- preserve the existing 30-second overall navigation bound and fail explicitly if Details never opens.

This changes only the Windows UI test driver; production navigation behavior is unchanged.