### PR TITLE
Fix App Catalog screenshot display setup

### DIFF
--- a/.github/workflows/app-catalog-screenshots.yml
+++ b/.github/workflows/app-catalog-screenshots.yml
@@ -26,14 +26,22 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up WinApp CLI
-        uses: microsoft/setup-WinAppCli@b93bbddc1f7abc061ca0d3a8119e3a0c7dd71495 # v0.2
-
-      - name: Inspect screenshot display
-        shell: pwsh
+      - name: Configure screenshot display
+        shell: powershell
         run: |
-          Add-Type -AssemblyName System.Windows.Forms
+          $setCommand = Get-Command Set-DisplayResolution -ErrorAction Stop
+          $getCommand = Get-Command Get-DisplayResolution -ErrorAction Stop
+          Write-Host "Using Set-DisplayResolution from $($setCommand.Source)"
+          Write-Host "Initial display resolution:"
+          Get-DisplayResolution | Out-Host
 
+          Set-DisplayResolution -Width 1920 -Height 1080 -Force
+          Start-Sleep -Seconds 2
+
+          Write-Host "Configured display resolution:"
+          Get-DisplayResolution | Out-Host
+
+          Add-Type -AssemblyName System.Windows.Forms
           $screen = [System.Windows.Forms.Screen]::PrimaryScreen
           if ($null -eq $screen) {
             throw "No primary display is available in the hosted runner session."
@@ -41,10 +49,12 @@ jobs:
 
           Write-Host "Primary display: $($screen.Bounds.Width)x$($screen.Bounds.Height)"
           Write-Host "Working area: $($screen.WorkingArea.Width)x$($screen.WorkingArea.Height)"
-          Write-Host "The canonical 1280x800 app window may extend beyond the runner desktop; capture uses the WinApp CLI window surface rather than the screen DC."
-          winapp --version
-          if ($LASTEXITCODE -ne 0) {
-            throw "WinApp CLI is not available after setup."
+
+          if ($screen.Bounds.Width -ne 1920 -or $screen.Bounds.Height -ne 1080) {
+            throw "Runner display is $($screen.Bounds.Width)x$($screen.Bounds.Height); expected 1920x1080 after Set-DisplayResolution."
+          }
+          if ($screen.WorkingArea.Width -lt 1280 -or $screen.WorkingArea.Height -lt 800) {
+            throw "Runner working area $($screen.WorkingArea.Width)x$($screen.WorkingArea.Height) cannot fit the canonical 1280x800 window."
           }
 
       - name: Configure Go cache paths
@@ -115,8 +125,8 @@ jobs:
             ''
             ('**Ref:** `{0}`  ' -f '${{ github.ref }}')
             ('**Commit:** `{0}`  ' -f '${{ github.sha }}')
+            '**Runner display:** 1920 × 1080'
             '**Canonical window:** 1280 × 800'
-            '**Capture:** WinApp CLI window-surface capture (WGC with PrintWindow fallback)'
             ''
             'Expected captures:'
             '- `catalog-default.png`'
@@ -138,5 +148,5 @@ jobs:
         with:
           name: app-catalog-screenshots-${{ github.sha }}
           path: build/app-catalog-screenshots/**
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/app-catalog-screenshots.yml
+++ b/.github/workflows/app-catalog-screenshots.yml
@@ -26,7 +26,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Validate screenshot display
+      - name: Set up WinApp CLI
+        uses: microsoft/setup-WinAppCli@b93bbddc1f7abc061ca0d3a8119e3a0c7dd71495 # v0.2
+
+      - name: Inspect screenshot display
         shell: pwsh
         run: |
           Add-Type -AssemblyName System.Windows.Forms
@@ -38,9 +41,10 @@ jobs:
 
           Write-Host "Primary display: $($screen.Bounds.Width)x$($screen.Bounds.Height)"
           Write-Host "Working area: $($screen.WorkingArea.Width)x$($screen.WorkingArea.Height)"
-
-          if ($screen.WorkingArea.Width -lt 1280 -or $screen.WorkingArea.Height -lt 800) {
-            throw "Runner working area $($screen.WorkingArea.Width)x$($screen.WorkingArea.Height) cannot fit the canonical 1280x800 window."
+          Write-Host "The canonical 1280x800 app window may extend beyond the runner desktop; capture uses the WinApp CLI window surface rather than the screen DC."
+          winapp --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "WinApp CLI is not available after setup."
           }
 
       - name: Configure Go cache paths
@@ -112,6 +116,7 @@ jobs:
             ('**Ref:** `{0}`  ' -f '${{ github.ref }}')
             ('**Commit:** `{0}`  ' -f '${{ github.sha }}')
             '**Canonical window:** 1280 × 800'
+            '**Capture:** WinApp CLI window-surface capture (WGC with PrintWindow fallback)'
             ''
             'Expected captures:'
             '- `catalog-default.png`'

--- a/.github/workflows/app-catalog-screenshots.yml
+++ b/.github/workflows/app-catalog-screenshots.yml
@@ -30,7 +30,7 @@ jobs:
         shell: powershell
         run: |
           $setCommand = Get-Command Set-DisplayResolution -ErrorAction Stop
-          $getCommand = Get-Command Get-DisplayResolution -ErrorAction Stop
+          Get-Command Get-DisplayResolution -ErrorAction Stop | Out-Null
           Write-Host "Using Set-DisplayResolution from $($setCommand.Source)"
           Write-Host "Initial display resolution:"
           Get-DisplayResolution | Out-Host

--- a/.github/workflows/app-catalog-screenshots.yml
+++ b/.github/workflows/app-catalog-screenshots.yml
@@ -26,89 +26,19 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Configure screenshot display
+      - name: Validate screenshot display
         shell: pwsh
         run: |
           Add-Type -AssemblyName System.Windows.Forms
-          Add-Type @'
-          using System;
-          using System.Runtime.InteropServices;
-
-          public static class DisplayModeNativeMethods
-          {
-              [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-              public struct DEVMODE
-              {
-                  [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string dmDeviceName;
-                  public short dmSpecVersion;
-                  public short dmDriverVersion;
-                  public short dmSize;
-                  public short dmDriverExtra;
-                  public int dmFields;
-                  public int dmPositionX;
-                  public int dmPositionY;
-                  public int dmDisplayOrientation;
-                  public int dmDisplayFixedOutput;
-                  public short dmColor;
-                  public short dmDuplex;
-                  public short dmYResolution;
-                  public short dmTTOption;
-                  public short dmCollate;
-                  [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string dmFormName;
-                  public short dmLogPixels;
-                  public int dmBitsPerPel;
-                  public int dmPelsWidth;
-                  public int dmPelsHeight;
-                  public int dmDisplayFlags;
-                  public int dmDisplayFrequency;
-                  public int dmICMMethod;
-                  public int dmICMIntent;
-                  public int dmMediaType;
-                  public int dmDitherType;
-                  public int dmReserved1;
-                  public int dmReserved2;
-                  public int dmPanningWidth;
-                  public int dmPanningHeight;
-              }
-
-              [DllImport("user32.dll", CharSet = CharSet.Ansi)]
-              public static extern bool EnumDisplaySettings(string deviceName, int modeNum, ref DEVMODE devMode);
-
-              [DllImport("user32.dll", CharSet = CharSet.Ansi)]
-              public static extern int ChangeDisplaySettings(ref DEVMODE devMode, int flags);
-
-              public const int ENUM_CURRENT_SETTINGS = -1;
-              public const int DM_PELSWIDTH = 0x00080000;
-              public const int DM_PELSHEIGHT = 0x00100000;
-              public const int DISP_CHANGE_SUCCESSFUL = 0;
-          }
-          '@
-
-          $targetWidth = 1920
-          $targetHeight = 1080
-          $mode = New-Object DisplayModeNativeMethods+DEVMODE
-          $mode.dmSize = [Runtime.InteropServices.Marshal]::SizeOf($mode)
-          if (-not [DisplayModeNativeMethods]::EnumDisplaySettings($null, [DisplayModeNativeMethods]::ENUM_CURRENT_SETTINGS, [ref]$mode)) {
-            throw "Unable to read current runner display mode."
-          }
-
-          if ($mode.dmPelsWidth -ne $targetWidth -or $mode.dmPelsHeight -ne $targetHeight) {
-            $mode.dmPelsWidth = $targetWidth
-            $mode.dmPelsHeight = $targetHeight
-            $mode.dmFields = [DisplayModeNativeMethods]::DM_PELSWIDTH -bor [DisplayModeNativeMethods]::DM_PELSHEIGHT
-            $result = [DisplayModeNativeMethods]::ChangeDisplaySettings([ref]$mode, 0)
-            if ($result -ne [DisplayModeNativeMethods]::DISP_CHANGE_SUCCESSFUL) {
-              throw "Unable to configure runner display to ${targetWidth}x${targetHeight}; ChangeDisplaySettings returned $result."
-            }
-            Start-Sleep -Seconds 1
-          }
 
           $screen = [System.Windows.Forms.Screen]::PrimaryScreen
+          if ($null -eq $screen) {
+            throw "No primary display is available in the hosted runner session."
+          }
+
           Write-Host "Primary display: $($screen.Bounds.Width)x$($screen.Bounds.Height)"
           Write-Host "Working area: $($screen.WorkingArea.Width)x$($screen.WorkingArea.Height)"
-          if ($screen.Bounds.Width -ne $targetWidth -or $screen.Bounds.Height -ne $targetHeight) {
-            throw "Runner display is $($screen.Bounds.Width)x$($screen.Bounds.Height); expected ${targetWidth}x${targetHeight}."
-          }
+
           if ($screen.WorkingArea.Width -lt 1280 -or $screen.WorkingArea.Height -lt 800) {
             throw "Runner working area $($screen.WorkingArea.Width)x$($screen.WorkingArea.Height) cannot fit the canonical 1280x800 window."
           }
@@ -181,7 +111,6 @@ jobs:
             ''
             ('**Ref:** `{0}`  ' -f '${{ github.ref }}')
             ('**Commit:** `{0}`  ' -f '${{ github.sha }}')
-            '**Runner display:** 1920 × 1080'
             '**Canonical window:** 1280 × 800'
             ''
             'Expected captures:'

--- a/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
+++ b/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
@@ -64,6 +64,9 @@ $appExe = Join-Path $repoRoot "gorilla-ui\src\Gorilla.UI.App\bin\x64\Release\net
 $fixtureSource = Join-Path $PSScriptRoot "fixture"
 $workRoot = Join-Path $env:RUNNER_TEMP "gorilla-app-catalog-screenshots"
 $fixtureRoot = Join-Path $workRoot "fixture"
+$toolsRoot = Join-Path $workRoot "tools"
+$serverSource = Join-Path $toolsRoot "fixture_server.go"
+$serverExe = Join-Path $toolsRoot "fixture-server.exe"
 $configPath = Join-Path $workRoot "config.yaml"
 $cachePath = Join-Path $workRoot "ui-state\optional-installs-cache.json"
 $appDataPath = "C:\ProgramData\gorilla-app-catalog-screenshots"
@@ -119,6 +122,33 @@ function Set-RegistryFixture {
     New-Item -Path $Path -Force | Out-Null
     Set-ItemProperty -Path $Path -Name DisplayName -Value $DisplayName
     Set-ItemProperty -Path $Path -Name DisplayVersion -Value $DisplayVersion
+}
+
+function Wait-FixtureServer {
+    param(
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+        [Parameter(Mandatory)][string]$ManifestUrl,
+        [int]$TimeoutSeconds = 15
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if ($Process.HasExited) {
+            throw "Fixture HTTP server exited before becoming ready. Exit code: $($Process.ExitCode)"
+        }
+        try {
+            $response = Invoke-WebRequest -Uri $ManifestUrl -UseBasicParsing -TimeoutSec 2
+            if ($response.StatusCode -eq 200 -and $response.Content -match 'name:\s*app-catalog-screenshots') {
+                Write-Host "Fixture HTTP server ready: $ManifestUrl"
+                return
+            }
+        } catch {
+            # Retry until the server is listening and the expected manifest is available.
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Timed out waiting for fixture HTTP server at $ManifestUrl"
 }
 
 function Wait-ForMainWindow {
@@ -238,14 +268,11 @@ function Open-DetailsWithRetry {
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {
-        # Reacquire the currently realized card and title on every attempt. GridView
-        # virtualization/settling can invalidate or race a pointer click after filtering.
         $item = Wait-ForElementById -Root $Root -AutomationId $ItemName -TimeoutSeconds 2
         try {
             $scrollPattern = $item.GetCurrentPattern([System.Windows.Automation.ScrollItemPattern]::Pattern)
             ([System.Windows.Automation.ScrollItemPattern]$scrollPattern).ScrollIntoView()
         } catch {
-            # The card may already be fully visible or not expose ScrollItemPattern.
         }
         $item.SetFocus()
         Start-Sleep -Milliseconds 250
@@ -320,11 +347,12 @@ function Write-AutomationTree {
 
 New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 Remove-Item -LiteralPath $workRoot -Recurse -Force -ErrorAction SilentlyContinue
-New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $fixtureRoot, $toolsRoot -Force | Out-Null
 Copy-Item -Path (Join-Path $fixtureSource "*") -Destination $fixtureRoot -Recurse -Force
 
 if (-not (Test-Path -LiteralPath $GorillaExePath)) { throw "gorilla.exe not found: $GorillaExePath" }
 if (-not (Test-Path -LiteralPath $appExe)) { throw "Gorilla UI executable not found: $appExe" }
+if (-not (Get-Command go -ErrorAction SilentlyContinue)) { throw "go is required to build the local fixture HTTP server" }
 
 $noopPath = Join-Path $fixtureRoot "packages\scripts\noop.ps1"
 $catalogPath = Join-Path $fixtureRoot "catalogs\screenshots.yaml"
@@ -332,7 +360,34 @@ $noopHash = (Get-FileHash -LiteralPath $noopPath -Algorithm SHA256).Hash.ToLower
 (Get-Content -LiteralPath $catalogPath -Raw).Replace("__NOOP_HASH__", $noopHash) |
     Set-Content -LiteralPath $catalogPath -NoNewline
 
+# Match the localhost fixture-serving pattern used by the Windows release/UI integration harnesses.
+@'
+package main
+
+import (
+    "flag"
+    "log"
+    "net/http"
+)
+
+func main() {
+    addr := flag.String("addr", "127.0.0.1:18080", "listen address")
+    root := flag.String("root", ".", "directory to serve")
+    flag.Parse()
+
+    fs := http.FileServer(http.Dir(*root))
+    if err := http.ListenAndServe(*addr, fs); err != nil {
+        log.Fatal(err)
+    }
+}
+'@ | Set-Content -LiteralPath $serverSource -NoNewline
+& go build -o $serverExe $serverSource
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $serverExe)) {
+    throw "Failed to build screenshot fixture HTTP server"
+}
+
 $uiProcess = $null
+$serverProcess = $null
 try {
     Remove-ScreenshotService
     Remove-Item -LiteralPath $appDataPath -Recurse -Force -ErrorAction SilentlyContinue
@@ -340,14 +395,21 @@ try {
         Remove-Item -Path $path -Recurse -Force -ErrorAction SilentlyContinue
     }
 
-    # Seed three truthful observation states through ordinary Windows uninstall-registry evidence:
-    # 7-Zip is behind the catalog version, Audacity is current, and Git is current.
     Set-RegistryFixture -Path $seededRegistryPaths[0] -DisplayName "Gorilla Screenshot 7-Zip" -DisplayVersion "23.01"
     Set-RegistryFixture -Path $seededRegistryPaths[1] -DisplayName "Gorilla Screenshot Audacity" -DisplayVersion "3.7.3"
     Set-RegistryFixture -Path $seededRegistryPaths[2] -DisplayName "Gorilla Screenshot Git" -DisplayVersion "2.50.1"
 
+    $serverPort = Get-Random -Minimum 20000 -Maximum 20999
+    $fixtureUri = "http://127.0.0.1:$serverPort/"
+    $serverProcess = Start-Process -FilePath $serverExe `
+        -ArgumentList @("-addr", "127.0.0.1:$serverPort", "-root", $fixtureRoot) `
+        -PassThru -WindowStyle Hidden `
+        -RedirectStandardOutput (Join-Path $OutputDirectory "fixture-server.stdout.log") `
+        -RedirectStandardError (Join-Path $OutputDirectory "fixture-server.stderr.log")
+    Wait-FixtureServer -Process $serverProcess -ManifestUrl "${fixtureUri}manifests/screenshots.yaml"
+    Write-Host "Serving screenshot fixture repository from $fixtureUri"
+
     New-Item -ItemType Directory -Path (Split-Path -Parent $configPath), (Split-Path -Parent $cachePath) -Force | Out-Null
-    $fixtureUri = ([Uri]((Resolve-Path $fixtureRoot).Path + [IO.Path]::DirectorySeparatorChar)).AbsoluteUri
     @"
 url: $fixtureUri
 manifest: screenshots
@@ -419,6 +481,7 @@ debug: true
         dpi = [ScreenshotNativeMethods]::GetDpiForWindow($windowHandle)
         theme = "runner-default-light"
         catalog = "realistic-open-source-fixture"
+        fixtureTransport = "localhost-http"
     } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $OutputDirectory "manifest.json")
 
     if (Test-Path -LiteralPath $serviceLogPath) {
@@ -436,6 +499,9 @@ debug: true
         Stop-Process -Id $uiProcess.Id -Force -ErrorAction SilentlyContinue
     }
     Remove-ScreenshotService
+    if ($serverProcess -and -not $serverProcess.HasExited) {
+        Stop-Process -Id $serverProcess.Id -Force -ErrorAction SilentlyContinue
+    }
     foreach ($path in $seededRegistryPaths) {
         Remove-Item -Path $path -Recurse -Force -ErrorAction SilentlyContinue
     }

--- a/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
+++ b/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
@@ -157,13 +157,12 @@ function Set-CanonicalWindow {
 
     [ScreenshotNativeMethods]::ShowWindow($Handle, [ScreenshotNativeMethods]::SW_RESTORE) | Out-Null
     $workingArea = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+    if ($WindowWidth -gt $workingArea.Width -or $WindowHeight -gt $workingArea.Height) {
+        throw "Requested $WindowWidth x $WindowHeight window does not fit in runner working area $($workingArea.Width) x $($workingArea.Height)"
+    }
 
-    # GitHub-hosted Windows sessions currently expose a smaller interactive desktop than
-    # our canonical documentation window. Keep the top-left of Gorilla visible for UIA
-    # interactions and allow the right/bottom edges to extend beyond the physical desktop.
-    # Screenshots are captured from the DWM window surface, not from the screen DC.
-    $x = $workingArea.Left
-    $y = $workingArea.Top
+    $x = $workingArea.Left + [Math]::Floor(($workingArea.Width - $WindowWidth) / 2)
+    $y = $workingArea.Top + [Math]::Floor(($workingArea.Height - $WindowHeight) / 2)
     $flags = [ScreenshotNativeMethods]::SWP_NOZORDER -bor [ScreenshotNativeMethods]::SWP_NOACTIVATE
     if (-not [ScreenshotNativeMethods]::SetWindowPos($Handle, [IntPtr]::Zero, $x, $y, $WindowWidth, $WindowHeight, $flags)) {
         throw "Unable to size Gorilla UI window"
@@ -282,26 +281,18 @@ function Save-WindowScreenshot {
         throw "Refusing screenshot '$Name' because window is $width x $height instead of canonical $WindowWidth x $WindowHeight."
     }
 
-    $path = Join-Path $OutputDirectory $Name
-    Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
-    $handleValue = $Handle.ToInt64()
-
-    # WinApp CLI's default screenshot path targets the HWND's DWM-composited surface
-    # using Windows.Graphics.Capture, with PrintWindow fallback. Unlike CopyFromScreen,
-    # this can capture portions of a 1280x800 window that extend beyond the runner desktop.
-    & winapp ui screenshot -w $handleValue --output $path
-    if ($LASTEXITCODE -ne 0) {
-        throw "WinApp CLI failed to capture screenshot '$Name' for HWND $handleValue."
-    }
-    if (-not (Test-Path -LiteralPath $path)) {
-        throw "WinApp CLI reported success but did not create screenshot '$path'."
-    }
-
-    $image = [System.Drawing.Image]::FromFile($path)
+    $bitmap = New-Object System.Drawing.Bitmap($width, $height)
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
     try {
-        Write-Host "Captured $path ($($image.Width)x$($image.Height))"
+        [ScreenshotNativeMethods]::SetForegroundWindow($Handle) | Out-Null
+        Start-Sleep -Milliseconds 250
+        $graphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, $bitmap.Size)
+        $path = Join-Path $OutputDirectory $Name
+        $bitmap.Save($path, [System.Drawing.Imaging.ImageFormat]::Png)
+        Write-Host "Captured $path"
     } finally {
-        $image.Dispose()
+        $graphics.Dispose()
+        $bitmap.Dispose()
     }
 }
 
@@ -426,7 +417,6 @@ debug: true
         primaryScreen = [ordered]@{ width = $screen.Bounds.Width; height = $screen.Bounds.Height }
         workingArea = [ordered]@{ width = $screen.WorkingArea.Width; height = $screen.WorkingArea.Height }
         dpi = [ScreenshotNativeMethods]::GetDpiForWindow($windowHandle)
-        capture = "winapp-window-surface"
         theme = "runner-default-light"
         catalog = "realistic-open-source-fixture"
     } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $OutputDirectory "manifest.json")

--- a/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
+++ b/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
@@ -122,6 +122,7 @@ function Set-RegistryFixture {
     New-Item -Path $Path -Force | Out-Null
     Set-ItemProperty -Path $Path -Name DisplayName -Value $DisplayName
     Set-ItemProperty -Path $Path -Name DisplayVersion -Value $DisplayVersion
+    Set-ItemProperty -Path $Path -Name UninstallString -Value "C:\Windows\System32\cmd.exe /c exit 0"
 }
 
 function Wait-FixtureServer {
@@ -395,6 +396,8 @@ try {
         Remove-Item -Path $path -Recurse -Force -ErrorAction SilentlyContinue
     }
 
+    # Seed realistic observed states. Gorilla's registry scanner requires
+    # DisplayName, DisplayVersion, and UninstallString for a valid entry.
     Set-RegistryFixture -Path $seededRegistryPaths[0] -DisplayName "Gorilla Screenshot 7-Zip" -DisplayVersion "23.01"
     Set-RegistryFixture -Path $seededRegistryPaths[1] -DisplayName "Gorilla Screenshot Audacity" -DisplayVersion "3.7.3"
     Set-RegistryFixture -Path $seededRegistryPaths[2] -DisplayName "Gorilla Screenshot Git" -DisplayVersion "2.50.1"

--- a/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
+++ b/integration/windows/app-catalog-screenshots/capture-app-catalog.ps1
@@ -157,12 +157,13 @@ function Set-CanonicalWindow {
 
     [ScreenshotNativeMethods]::ShowWindow($Handle, [ScreenshotNativeMethods]::SW_RESTORE) | Out-Null
     $workingArea = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
-    if ($WindowWidth -gt $workingArea.Width -or $WindowHeight -gt $workingArea.Height) {
-        throw "Requested $WindowWidth x $WindowHeight window does not fit in runner working area $($workingArea.Width) x $($workingArea.Height)"
-    }
 
-    $x = $workingArea.Left + [Math]::Floor(($workingArea.Width - $WindowWidth) / 2)
-    $y = $workingArea.Top + [Math]::Floor(($workingArea.Height - $WindowHeight) / 2)
+    # GitHub-hosted Windows sessions currently expose a smaller interactive desktop than
+    # our canonical documentation window. Keep the top-left of Gorilla visible for UIA
+    # interactions and allow the right/bottom edges to extend beyond the physical desktop.
+    # Screenshots are captured from the DWM window surface, not from the screen DC.
+    $x = $workingArea.Left
+    $y = $workingArea.Top
     $flags = [ScreenshotNativeMethods]::SWP_NOZORDER -bor [ScreenshotNativeMethods]::SWP_NOACTIVATE
     if (-not [ScreenshotNativeMethods]::SetWindowPos($Handle, [IntPtr]::Zero, $x, $y, $WindowWidth, $WindowHeight, $flags)) {
         throw "Unable to size Gorilla UI window"
@@ -281,18 +282,26 @@ function Save-WindowScreenshot {
         throw "Refusing screenshot '$Name' because window is $width x $height instead of canonical $WindowWidth x $WindowHeight."
     }
 
-    $bitmap = New-Object System.Drawing.Bitmap($width, $height)
-    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    $path = Join-Path $OutputDirectory $Name
+    Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+    $handleValue = $Handle.ToInt64()
+
+    # WinApp CLI's default screenshot path targets the HWND's DWM-composited surface
+    # using Windows.Graphics.Capture, with PrintWindow fallback. Unlike CopyFromScreen,
+    # this can capture portions of a 1280x800 window that extend beyond the runner desktop.
+    & winapp ui screenshot -w $handleValue --output $path
+    if ($LASTEXITCODE -ne 0) {
+        throw "WinApp CLI failed to capture screenshot '$Name' for HWND $handleValue."
+    }
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "WinApp CLI reported success but did not create screenshot '$path'."
+    }
+
+    $image = [System.Drawing.Image]::FromFile($path)
     try {
-        [ScreenshotNativeMethods]::SetForegroundWindow($Handle) | Out-Null
-        Start-Sleep -Milliseconds 250
-        $graphics.CopyFromScreen($rect.Left, $rect.Top, 0, 0, $bitmap.Size)
-        $path = Join-Path $OutputDirectory $Name
-        $bitmap.Save($path, [System.Drawing.Imaging.ImageFormat]::Png)
-        Write-Host "Captured $path"
+        Write-Host "Captured $path ($($image.Width)x$($image.Height))"
     } finally {
-        $graphics.Dispose()
-        $bitmap.Dispose()
+        $image.Dispose()
     }
 }
 
@@ -417,6 +426,7 @@ debug: true
         primaryScreen = [ordered]@{ width = $screen.Bounds.Width; height = $screen.Bounds.Height }
         workingArea = [ordered]@{ width = $screen.WorkingArea.Width; height = $screen.WorkingArea.Height }
         dpi = [ScreenshotNativeMethods]::GetDpiForWindow($windowHandle)
+        capture = "winapp-window-surface"
         theme = "runner-default-light"
         catalog = "realistic-open-source-fixture"
     } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $OutputDirectory "manifest.json")


### PR DESCRIPTION
## Summary

Fixes the manual App Catalog screenshot workflow so it can reliably capture the branch-matched WinUI catalog on GitHub-hosted Windows runners.

- configures the hosted Windows runner to `1920×1080` using the supported Server Core `Set-DisplayResolution` cmdlet
- verifies the resulting screen and working area before capture
- keeps the existing normal centered `1280×800` Gorilla window and `CopyFromScreen` capture path
- serves the screenshot fixture repository over `http://127.0.0.1:<port>/`, matching Gorilla's existing Windows release/UI integration-test pattern
- probes `manifests/screenshots.yaml` before starting Gorilla so fixture-serving failures are reported directly
- records fixture-server stdout/stderr in the artifact and stops the server during cleanup
- uses `if-no-files-found: warn` so an early setup failure does not create a second unrelated artifact-upload failure

## Failure history

### Run #1 — `34715851322`

The original custom Win32 display path failed because `EnumDisplaySettings(..., ENUM_CURRENT_SETTINGS, ...)` returned `false` in the hosted runner session.

### Run #2 — `34716302277`

WinForms reported the default hosted session as `1024×768` with a `1024×720` working area, too small for the canonical `1280×800` window.

### Run #3 — `34716778829`

An off-screen/window-surface experiment reached app launch, but Windows constrained the requested top-level window to `1044×788`.

### Run #4 — `34717396900`

`Set-DisplayResolution` successfully changed the runner to `1920×1080` with a `1920×1032` working area. Builds, service installation/start, and app launch succeeded. The remaining failure was fixture retrieval: the screenshot-only `file:///D:/...` URL returned a 404 through Gorilla's current file transport, so the catalog never populated.

The screenshot harness now uses the same localhost HTTP fixture-serving pattern already established by `run-release-integration.ps1` and `run-ui-e2e.ps1` rather than relying on `file://`.

## Scope

The production Gorilla UI/service behavior is unchanged. The PR only adjusts the manual screenshot workflow and its dedicated capture harness.