### PR TITLE
Add App Catalog refresh and freshness UX

### DIFF
--- a/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml
@@ -19,8 +19,7 @@
                 x:Name="CatalogFreshnessStatus"
                 VerticalAlignment="Center"
                 Opacity="0.72"
-                AutomationProperties.AutomationId="CatalogFreshnessStatus"
-                AutomationProperties.Name="Catalog freshness status" />
+                AutomationProperties.AutomationId="CatalogFreshnessStatus" />
             <ProgressRing
                 x:Name="CatalogRefreshProgress"
                 Grid.Column="1"

--- a/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml
@@ -13,7 +13,53 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Frame
-        x:Name="RootFrame"
-        AutomationProperties.AutomationId="NavigationFrame" />
+    <Grid RowDefinitions="Auto,Auto,*">
+        <Grid Padding="20,12,20,8" ColumnDefinitions="*,Auto,Auto">
+            <TextBlock
+                x:Name="CatalogFreshnessStatus"
+                VerticalAlignment="Center"
+                Opacity="0.72"
+                AutomationProperties.AutomationId="CatalogFreshnessStatus"
+                AutomationProperties.Name="Catalog freshness status" />
+            <ProgressRing
+                x:Name="CatalogRefreshProgress"
+                Grid.Column="1"
+                Width="18"
+                Height="18"
+                Margin="10,0,8,0"
+                VerticalAlignment="Center"
+                IsActive="False"
+                Visibility="Collapsed"
+                AutomationProperties.AutomationId="CatalogRefreshProgress"
+                AutomationProperties.Name="Refreshing App Catalog" />
+            <Button
+                x:Name="RefreshButton"
+                Grid.Column="2"
+                Content="Refresh"
+                Click="RefreshButton_Click"
+                AutomationProperties.AutomationId="CatalogRefreshButton"
+                AutomationProperties.Name="Refresh App Catalog" />
+        </Grid>
+
+        <Border
+            x:Name="CatalogDegradedBanner"
+            Grid.Row="1"
+            Margin="20,0,20,4"
+            Padding="10,8"
+            CornerRadius="6"
+            Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+            Visibility="Collapsed"
+            AutomationProperties.AutomationId="CatalogDegradedWarning"
+            AutomationProperties.LiveSetting="Polite">
+            <TextBlock
+                x:Name="CatalogDegradedText"
+                TextWrapping="Wrap"
+                AutomationProperties.AutomationId="CatalogDegradedWarningText" />
+        </Border>
+
+        <Frame
+            x:Name="RootFrame"
+            Grid.Row="2"
+            AutomationProperties.AutomationId="NavigationFrame" />
+    </Grid>
 </Window>

--- a/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml
@@ -47,12 +47,13 @@
             Margin="20,0,20,4"
             Padding="10,8"
             CornerRadius="6"
-            Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
             Visibility="Collapsed"
             AutomationProperties.AutomationId="CatalogDegradedWarning"
             AutomationProperties.LiveSetting="Polite">
             <TextBlock
                 x:Name="CatalogDegradedText"
+                Foreground="DarkOrange"
                 TextWrapping="Wrap"
                 AutomationProperties.AutomationId="CatalogDegradedWarningText" />
         </Border>

--- a/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml.cs
@@ -1,14 +1,134 @@
+using System;
+using System.ComponentModel;
+using Gorilla.UI.App.Services;
 using Gorilla.UI.App.Views;
+using Gorilla.UI.Core.Models;
+using Gorilla.UI.Core.ViewModels;
 using Microsoft.UI.Xaml;
 
 namespace Gorilla.UI.App
 {
     public sealed partial class MainWindow : Window
     {
+        private readonly AppCatalogSession _session;
+        private readonly HomeViewModel _viewModel;
+
         public MainWindow()
         {
             InitializeComponent();
+            _session = App.CurrentSession;
+            _viewModel = _session.ViewModel;
+            _viewModel.PropertyChanged += ViewModel_PropertyChanged;
+            Closed += MainWindow_Closed;
+            UpdateCatalogFreshnessPresentation();
             RootFrame.Navigate(typeof(HomePage));
+        }
+
+        private async void RefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await _viewModel.RefreshCatalogAsync(_session.LifetimeToken);
+            }
+            catch (OperationCanceledException) when (_session.LifetimeToken.IsCancellationRequested)
+            {
+            }
+            catch
+            {
+                // CatalogDataState owns the user-facing failure state and retains
+                // the underlying exception for the later troubleshooting surface.
+            }
+        }
+
+        private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(HomeViewModel.CatalogState))
+            {
+                UpdateCatalogFreshnessPresentation();
+            }
+        }
+
+        private void UpdateCatalogFreshnessPresentation()
+        {
+            var state = _viewModel.CatalogState;
+            RefreshButton.IsEnabled = !state.IsRefreshing;
+            CatalogRefreshProgress.IsActive = state.IsRefreshing;
+            CatalogRefreshProgress.Visibility = state.IsRefreshing
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+            CatalogFreshnessStatus.Text = BuildFreshnessText(state);
+
+            var warning = BuildDegradedWarning(state);
+            CatalogDegradedText.Text = warning;
+            CatalogDegradedBanner.Visibility = string.IsNullOrWhiteSpace(warning)
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+        }
+
+        private static string BuildFreshnessText(CatalogDataState state)
+        {
+            string text;
+            if (state.IsInitialLoading && !state.HasUsableData)
+            {
+                text = "Loading App Catalog…";
+            }
+            else if (state.IsCached)
+            {
+                text = state.CachedAtUtc is DateTimeOffset cachedAt
+                    ? $"Showing saved data from {FormatLocalTime(cachedAt)}"
+                    : "Showing saved data";
+            }
+            else if (state.IsLive && state.LastSuccessfulRefreshUtc is DateTimeOffset refreshedAt)
+            {
+                text = $"Updated {FormatLocalTime(refreshedAt)}";
+            }
+            else if (state.HasLoadFailure)
+            {
+                text = "App Catalog unavailable";
+            }
+            else
+            {
+                text = "App Catalog";
+            }
+
+            if (state.IsRefreshing && state.HasUsableData)
+            {
+                text += " · Refreshing…";
+            }
+
+            return text;
+        }
+
+        private static string BuildDegradedWarning(CatalogDataState state)
+        {
+            if (state.HasRefreshFailure && state.IsCached)
+            {
+                return "Showing saved data. Gorilla couldn't refresh the catalog.";
+            }
+
+            if (state.HasRefreshFailure && state.IsLive)
+            {
+                return state.LastSuccessfulRefreshUtc is DateTimeOffset refreshedAt
+                    ? $"Couldn't refresh. Showing data from {FormatLocalTime(refreshedAt)}."
+                    : "Couldn't refresh. Showing previously loaded data.";
+            }
+
+            if (state.HasCacheWriteFailure)
+            {
+                return "Gorilla couldn't save the latest catalog for fallback use.";
+            }
+
+            return string.Empty;
+        }
+
+        private static string FormatLocalTime(DateTimeOffset timestamp)
+            => timestamp.ToLocalTime().ToString("t");
+
+        private void MainWindow_Closed(object sender, WindowEventArgs args)
+        {
+            _viewModel.PropertyChanged -= ViewModel_PropertyChanged;
+            Closed -= MainWindow_Closed;
         }
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using Gorilla.UI.App.Services;
 using Gorilla.UI.App.Views;
 using Gorilla.UI.Core.Models;
@@ -123,7 +124,7 @@ namespace Gorilla.UI.App
         }
 
         private static string FormatLocalTime(DateTimeOffset timestamp)
-            => timestamp.ToLocalTime().ToString("t");
+            => timestamp.ToLocalTime().ToString("t", CultureInfo.CurrentCulture);
 
         private void MainWindow_Closed(object sender, WindowEventArgs args)
         {

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -199,6 +199,7 @@
                 HorizontalAlignment="Left"
                 Spacing="10"
                 AutomationProperties.AutomationId="CatalogInitialLoading"
+                AutomationProperties.AccessibilityView="Content"
                 AutomationProperties.LiveSetting="Polite">
                 <ProgressRing Width="28" Height="28" IsActive="True" />
                 <TextBlock Text="Loading App Catalog…" FontSize="18" />
@@ -210,6 +211,7 @@
                 HorizontalAlignment="Left"
                 Spacing="6"
                 AutomationProperties.AutomationId="CatalogLoadFailed"
+                AutomationProperties.AccessibilityView="Content"
                 AutomationProperties.LiveSetting="Polite">
                 <TextBlock Text="Couldn't load the App Catalog." FontSize="18" FontWeight="SemiBold" />
                 <TextBlock Text="Use Refresh to try again." TextWrapping="Wrap" />

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -197,23 +197,26 @@
                 x:Name="InitialLoadingState"
                 Visibility="Collapsed"
                 HorizontalAlignment="Left"
-                Spacing="10"
-                AutomationProperties.AutomationId="CatalogInitialLoading"
-                AutomationProperties.AccessibilityView="Content"
-                AutomationProperties.LiveSetting="Polite">
+                Spacing="10">
                 <ProgressRing Width="28" Height="28" IsActive="True" />
-                <TextBlock Text="Loading App Catalog…" FontSize="18" />
+                <TextBlock
+                    Text="Loading App Catalog…"
+                    FontSize="18"
+                    AutomationProperties.AutomationId="CatalogInitialLoading"
+                    AutomationProperties.LiveSetting="Polite" />
             </StackPanel>
 
             <StackPanel
                 x:Name="LoadFailedState"
                 Visibility="Collapsed"
                 HorizontalAlignment="Left"
-                Spacing="6"
-                AutomationProperties.AutomationId="CatalogLoadFailed"
-                AutomationProperties.AccessibilityView="Content"
-                AutomationProperties.LiveSetting="Polite">
-                <TextBlock Text="Couldn't load the App Catalog." FontSize="18" FontWeight="SemiBold" />
+                Spacing="6">
+                <TextBlock
+                    Text="Couldn't load the App Catalog."
+                    FontSize="18"
+                    FontWeight="SemiBold"
+                    AutomationProperties.AutomationId="CatalogLoadFailed"
+                    AutomationProperties.LiveSetting="Polite" />
                 <TextBlock Text="Use Refresh to try again." TextWrapping="Wrap" />
             </StackPanel>
 

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml
@@ -193,6 +193,28 @@
                 </GridView.ItemTemplate>
             </GridView>
 
+            <StackPanel
+                x:Name="InitialLoadingState"
+                Visibility="Collapsed"
+                HorizontalAlignment="Left"
+                Spacing="10"
+                AutomationProperties.AutomationId="CatalogInitialLoading"
+                AutomationProperties.LiveSetting="Polite">
+                <ProgressRing Width="28" Height="28" IsActive="True" />
+                <TextBlock Text="Loading App Catalog…" FontSize="18" />
+            </StackPanel>
+
+            <StackPanel
+                x:Name="LoadFailedState"
+                Visibility="Collapsed"
+                HorizontalAlignment="Left"
+                Spacing="6"
+                AutomationProperties.AutomationId="CatalogLoadFailed"
+                AutomationProperties.LiveSetting="Polite">
+                <TextBlock Text="Couldn't load the App Catalog." FontSize="18" FontWeight="SemiBold" />
+                <TextBlock Text="Use Refresh to try again." TextWrapping="Wrap" />
+            </StackPanel>
+
             <TextBlock
                 x:Name="SearchNoResults"
                 Visibility="Collapsed"
@@ -204,10 +226,11 @@
             <TextBlock
                 x:Name="CatalogEmpty"
                 Visibility="Collapsed"
-                Text="No software is currently available."
+                Text="No optional software available"
                 FontSize="18"
                 TextWrapping="Wrap"
-                AutomationProperties.AutomationId="CatalogEmpty" />
+                AutomationProperties.AutomationId="CatalogEmpty"
+                AutomationProperties.LiveSetting="Polite" />
         </Grid>
     </Grid>
 </Page>

--- a/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
+++ b/gorilla-ui/src/Gorilla.UI.App/Views/HomePage.xaml.cs
@@ -16,7 +16,6 @@ public sealed partial class HomePage : Page
 {
     private readonly AppCatalogSession _session;
     private long _serviceWarningTextChangedToken;
-    private bool _hasInitialized;
     private bool _isObservingPageState;
 
     public HomeViewModel ViewModel { get; }
@@ -36,7 +35,6 @@ public sealed partial class HomePage : Page
     {
         StartObservingPageState();
         await RunSafelyAsync(_session.EnsureInitializedAsync);
-        _hasInitialized = true;
         UpdateEmptyStates();
         UpdateCardWidths(CatalogItems.ActualWidth);
     }
@@ -84,7 +82,8 @@ public sealed partial class HomePage : Page
 
     private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(HomeViewModel.SearchQuery))
+        if (e.PropertyName == nameof(HomeViewModel.SearchQuery) ||
+            e.PropertyName == nameof(HomeViewModel.CatalogState))
         {
             UpdateEmptyStates();
         }
@@ -97,23 +96,36 @@ public sealed partial class HomePage : Page
 
     private void UpdateEmptyStates()
     {
-        if (!_hasInitialized)
-        {
-            SearchNoResults.Visibility = Visibility.Collapsed;
-            CatalogEmpty.Visibility = Visibility.Collapsed;
-            return;
-        }
-
+        var state = ViewModel.CatalogState;
+        var initialLoading = state.IsInitialLoading && !state.HasUsableData;
+        var loadFailed = state.HasLoadFailure;
+        var successfulEmpty = state.IsSuccessfulEmpty;
         var query = ViewModel.SearchQuery;
         var noVisibleItems = ViewModel.Items.Count == 0;
         var hasSearch = !string.IsNullOrWhiteSpace(query);
 
-        SearchNoResults.Visibility = hasSearch && noVisibleItems
+        InitialLoadingState.Visibility = initialLoading
             ? Visibility.Visible
             : Visibility.Collapsed;
+        LoadFailedState.Visibility = loadFailed
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
+        SearchNoResults.Visibility = !initialLoading &&
+            !loadFailed &&
+            state.HasUsableData &&
+            !successfulEmpty &&
+            hasSearch &&
+            noVisibleItems
+                ? Visibility.Visible
+                : Visibility.Collapsed;
         SearchNoResults.Text = hasSearch ? $"No apps match \"{query}\"." : string.Empty;
 
-        CatalogEmpty.Visibility = !hasSearch && noVisibleItems
+        CatalogEmpty.Visibility = successfulEmpty
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
+        CatalogItems.Visibility = state.HasUsableData && !successfulEmpty
             ? Visibility.Visible
             : Visibility.Collapsed;
     }

--- a/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogDataState.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/Models/CatalogDataState.cs
@@ -1,0 +1,45 @@
+namespace Gorilla.UI.Core.Models;
+
+public enum CatalogDataSource
+{
+    None,
+    Live,
+    Cached,
+}
+
+public sealed record CatalogDataState(
+    bool HasUsableData,
+    CatalogDataSource DataSource,
+    bool IsInitialLoading,
+    bool IsRefreshing,
+    bool IsSuccessfulEmpty,
+    DateTimeOffset? LastSuccessfulRefreshUtc,
+    DateTimeOffset? CachedAtUtc,
+    Exception? RefreshFailure,
+    Exception? LoadFailure,
+    Exception? CacheWriteFailure
+)
+{
+    public static CatalogDataState InitialLoading { get; } = new(
+        HasUsableData: false,
+        DataSource: CatalogDataSource.None,
+        IsInitialLoading: true,
+        IsRefreshing: true,
+        IsSuccessfulEmpty: false,
+        LastSuccessfulRefreshUtc: null,
+        CachedAtUtc: null,
+        RefreshFailure: null,
+        LoadFailure: null,
+        CacheWriteFailure: null
+    );
+
+    public bool IsLive => HasUsableData && DataSource == CatalogDataSource.Live;
+
+    public bool IsCached => HasUsableData && DataSource == CatalogDataSource.Cached;
+
+    public bool HasRefreshFailure => HasUsableData && RefreshFailure is not null;
+
+    public bool HasLoadFailure => !HasUsableData && LoadFailure is not null;
+
+    public bool HasCacheWriteFailure => CacheWriteFailure is not null;
+}

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
@@ -89,8 +89,9 @@ public sealed class OptionalInstallsCacheCoordinator
     private readonly IGorillaServiceClient _client;
     private readonly IOptionalInstallsCacheStore _cacheStore;
     private readonly object _refreshLock = new();
-    private readonly SemaphoreSlim _cacheWriteLock = new(1, 1);
+    private readonly object _cacheWriteLock = new();
     private Task<OptionalInstallsRefreshResult>? _refreshTask;
+    private Task _cacheWriteTail = Task.CompletedTask;
     private CatalogDataState _state = CatalogDataState.InitialLoading;
 
     public OptionalInstallsCacheCoordinator(IGorillaServiceClient client, IOptionalInstallsCacheStore cacheStore)
@@ -177,7 +178,7 @@ public sealed class OptionalInstallsCacheCoordinator
                 CacheWriteFailure: null
             ));
 
-            _ = PersistCacheAsync(document);
+            QueueCachePersistence(document);
 
             return new OptionalInstallsRefreshResult(
                 refreshedAtUtc,
@@ -234,38 +235,42 @@ public sealed class OptionalInstallsCacheCoordinator
         }
     }
 
-    private async Task PersistCacheAsync(OptionalInstallsCacheDocument document)
+    private void QueueCachePersistence(OptionalInstallsCacheDocument document)
     {
-        await _cacheWriteLock.WaitAsync(CancellationToken.None);
+        lock (_cacheWriteLock)
+        {
+            _cacheWriteTail = PersistCacheAfterAsync(_cacheWriteTail, document);
+        }
+    }
+
+    private async Task PersistCacheAfterAsync(Task previousWrite, OptionalInstallsCacheDocument document)
+    {
+        // Each queued write handles its own failures, but await the predecessor so
+        // cache snapshots cannot be persisted out of live-refresh order.
+        await previousWrite.ConfigureAwait(false);
+
         try
         {
-            try
-            {
-                await _cacheStore.SaveAsync(document, CancellationToken.None);
+            await _cacheStore.SaveAsync(document, CancellationToken.None).ConfigureAwait(false);
 
-                var state = _state;
-                var cachedAtUtc = state.CachedAtUtc is DateTimeOffset currentCachedAt && currentCachedAt > document.CachedAtUtc
-                    ? currentCachedAt
-                    : document.CachedAtUtc;
-                var isCurrentLiveSnapshot = state.LastSuccessfulRefreshUtc == document.CachedAtUtc;
-                SetState(state with
-                {
-                    CachedAtUtc = cachedAtUtc,
-                    CacheWriteFailure = isCurrentLiveSnapshot ? null : state.CacheWriteFailure,
-                });
-            }
-            catch (Exception ex)
+            var state = _state;
+            var cachedAtUtc = state.CachedAtUtc is DateTimeOffset currentCachedAt && currentCachedAt > document.CachedAtUtc
+                ? currentCachedAt
+                : document.CachedAtUtc;
+            var isCurrentLiveSnapshot = state.LastSuccessfulRefreshUtc == document.CachedAtUtc;
+            SetState(state with
             {
-                var state = _state;
-                if (state.LastSuccessfulRefreshUtc == document.CachedAtUtc)
-                {
-                    SetState(state with { CacheWriteFailure = ex });
-                }
-            }
+                CachedAtUtc = cachedAtUtc,
+                CacheWriteFailure = isCurrentLiveSnapshot ? null : state.CacheWriteFailure,
+            });
         }
-        finally
+        catch (Exception ex)
         {
-            _cacheWriteLock.Release();
+            var state = _state;
+            if (state.LastSuccessfulRefreshUtc == document.CachedAtUtc)
+            {
+                SetState(state with { CacheWriteFailure = ex });
+            }
         }
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
@@ -8,6 +8,12 @@ public sealed record OptionalInstallsCacheDocument(
     IReadOnlyList<OptionalInstallItem> Items
 );
 
+public sealed record OptionalInstallsRefreshResult(
+    DateTimeOffset RefreshedAtUtc,
+    IReadOnlyList<OptionalInstallItem> Items,
+    Exception? CacheWriteFailure = null
+);
+
 public interface IOptionalInstallsCacheStore
 {
     Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken);
@@ -93,15 +99,32 @@ public sealed class OptionalInstallsCacheCoordinator
         return _cacheStore.LoadAsync(cancellationToken);
     }
 
-    public async Task<OptionalInstallsCacheDocument> RefreshAsync(CancellationToken cancellationToken)
+    public async Task<OptionalInstallsRefreshResult> RefreshAsync(CancellationToken cancellationToken)
     {
         var items = await _client.ListOptionalInstallsAsync(cancellationToken);
-        var document = new OptionalInstallsCacheDocument(
-            CachedAtUtc: DateTimeOffset.UtcNow,
-            Items: items
-        );
+        var refreshedAtUtc = DateTimeOffset.UtcNow;
+        var document = new OptionalInstallsCacheDocument(refreshedAtUtc, items);
 
-        await _cacheStore.SaveAsync(document, cancellationToken);
-        return document;
+        Exception? cacheWriteFailure = null;
+        try
+        {
+            await _cacheStore.SaveAsync(document, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Fresh service data remains authoritative and usable even when the
+            // fallback cache cannot be updated.
+            cacheWriteFailure = ex;
+        }
+
+        return new OptionalInstallsRefreshResult(
+            refreshedAtUtc,
+            items,
+            cacheWriteFailure
+        );
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Gorilla.UI.Client;
+using Gorilla.UI.Core.Models;
 
 namespace Gorilla.UI.Core;
 
@@ -87,6 +88,9 @@ public sealed class OptionalInstallsCacheCoordinator
 {
     private readonly IGorillaServiceClient _client;
     private readonly IOptionalInstallsCacheStore _cacheStore;
+    private readonly object _refreshLock = new();
+    private Task<OptionalInstallsRefreshResult>? _refreshTask;
+    private CatalogDataState _state = CatalogDataState.InitialLoading;
 
     public OptionalInstallsCacheCoordinator(IGorillaServiceClient client, IOptionalInstallsCacheStore cacheStore)
     {
@@ -94,21 +98,96 @@ public sealed class OptionalInstallsCacheCoordinator
         _cacheStore = cacheStore;
     }
 
-    public Task<OptionalInstallsCacheDocument?> LoadCachedAsync(CancellationToken cancellationToken)
+    public CatalogDataState State => _state;
+
+    public event EventHandler? StateChanged;
+
+    public async Task<OptionalInstallsCacheDocument?> LoadCachedAsync(CancellationToken cancellationToken)
     {
-        return _cacheStore.LoadAsync(cancellationToken);
+        var cached = await _cacheStore.LoadAsync(cancellationToken);
+        if (cached is not null)
+        {
+            SetState(new CatalogDataState(
+                HasUsableData: true,
+                DataSource: CatalogDataSource.Cached,
+                IsInitialLoading: false,
+                IsRefreshing: true,
+                IsSuccessfulEmpty: false,
+                LastSuccessfulRefreshUtc: _state.LastSuccessfulRefreshUtc,
+                CachedAtUtc: cached.CachedAtUtc,
+                RefreshFailure: null,
+                LoadFailure: null,
+                CacheWriteFailure: null
+            ));
+        }
+
+        return cached;
     }
 
-    public async Task<OptionalInstallsRefreshResult> RefreshAsync(CancellationToken cancellationToken)
+    public Task<OptionalInstallsRefreshResult> RefreshAsync(CancellationToken cancellationToken)
     {
-        var items = await _client.ListOptionalInstallsAsync(cancellationToken);
-        var refreshedAtUtc = DateTimeOffset.UtcNow;
-        var document = new OptionalInstallsCacheDocument(refreshedAtUtc, items);
+        lock (_refreshLock)
+        {
+            if (_refreshTask is not null)
+            {
+                return _refreshTask;
+            }
 
-        Exception? cacheWriteFailure = null;
+            _refreshTask = RefreshCoreAsync(cancellationToken);
+            return _refreshTask;
+        }
+    }
+
+    private async Task<OptionalInstallsRefreshResult> RefreshCoreAsync(CancellationToken cancellationToken)
+    {
+        SetState(_state with
+        {
+            IsRefreshing = true,
+            IsInitialLoading = !_state.HasUsableData && _state.LastSuccessfulRefreshUtc is null,
+            RefreshFailure = null,
+            LoadFailure = null,
+        });
+
         try
         {
-            await _cacheStore.SaveAsync(document, cancellationToken);
+            var items = await _client.ListOptionalInstallsAsync(cancellationToken);
+            var refreshedAtUtc = DateTimeOffset.UtcNow;
+            var document = new OptionalInstallsCacheDocument(refreshedAtUtc, items);
+
+            Exception? cacheWriteFailure = null;
+            try
+            {
+                await _cacheStore.SaveAsync(document, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Fresh service data remains authoritative and usable even when the
+                // fallback cache cannot be updated.
+                cacheWriteFailure = ex;
+            }
+
+            SetState(new CatalogDataState(
+                HasUsableData: true,
+                DataSource: CatalogDataSource.Live,
+                IsInitialLoading: false,
+                IsRefreshing: false,
+                IsSuccessfulEmpty: items.Count == 0,
+                LastSuccessfulRefreshUtc: refreshedAtUtc,
+                CachedAtUtc: cacheWriteFailure is null ? refreshedAtUtc : _state.CachedAtUtc,
+                RefreshFailure: null,
+                LoadFailure: null,
+                CacheWriteFailure: cacheWriteFailure
+            ));
+
+            return new OptionalInstallsRefreshResult(
+                refreshedAtUtc,
+                items,
+                cacheWriteFailure
+            );
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -116,15 +195,52 @@ public sealed class OptionalInstallsCacheCoordinator
         }
         catch (Exception ex)
         {
-            // Fresh service data remains authoritative and usable even when the
-            // fallback cache cannot be updated.
-            cacheWriteFailure = ex;
+            if (_state.HasUsableData)
+            {
+                SetState(_state with
+                {
+                    IsInitialLoading = false,
+                    IsRefreshing = false,
+                    RefreshFailure = ex,
+                    LoadFailure = null,
+                    CacheWriteFailure = null,
+                });
+            }
+            else
+            {
+                SetState(new CatalogDataState(
+                    HasUsableData: false,
+                    DataSource: CatalogDataSource.None,
+                    IsInitialLoading: false,
+                    IsRefreshing: false,
+                    IsSuccessfulEmpty: false,
+                    LastSuccessfulRefreshUtc: _state.LastSuccessfulRefreshUtc,
+                    CachedAtUtc: null,
+                    RefreshFailure: null,
+                    LoadFailure: ex,
+                    CacheWriteFailure: null
+                ));
+            }
+
+            throw;
+        }
+        finally
+        {
+            lock (_refreshLock)
+            {
+                _refreshTask = null;
+            }
+        }
+    }
+
+    private void SetState(CatalogDataState state)
+    {
+        if (Equals(_state, state))
+        {
+            return;
         }
 
-        return new OptionalInstallsRefreshResult(
-            refreshedAtUtc,
-            items,
-            cacheWriteFailure
-        );
+        _state = state;
+        StateChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
@@ -90,9 +90,11 @@ public sealed class OptionalInstallsCacheCoordinator
     private readonly IOptionalInstallsCacheStore _cacheStore;
     private readonly object _refreshLock = new();
     private readonly object _cacheWriteLock = new();
+    private readonly object _stateNotificationLock = new();
     private Task<OptionalInstallsRefreshResult>? _refreshTask;
     private Task _cacheWriteTail = Task.CompletedTask;
     private CatalogDataState _state = CatalogDataState.InitialLoading;
+    private SynchronizationContext? _stateNotificationContext;
 
     public OptionalInstallsCacheCoordinator(IGorillaServiceClient client, IOptionalInstallsCacheStore cacheStore)
     {
@@ -106,6 +108,8 @@ public sealed class OptionalInstallsCacheCoordinator
 
     public async Task<OptionalInstallsCacheDocument?> LoadCachedAsync(CancellationToken cancellationToken)
     {
+        CaptureStateNotificationContext();
+
         var cached = await _cacheStore.LoadAsync(cancellationToken);
         if (cached is not null)
         {
@@ -128,6 +132,8 @@ public sealed class OptionalInstallsCacheCoordinator
 
     public Task<OptionalInstallsRefreshResult> RefreshAsync(CancellationToken cancellationToken)
     {
+        CaptureStateNotificationContext();
+
         lock (_refreshLock)
         {
             if (_refreshTask is not null)
@@ -245,9 +251,15 @@ public sealed class OptionalInstallsCacheCoordinator
 
     private async Task PersistCacheAfterAsync(Task previousWrite, OptionalInstallsCacheDocument document)
     {
-        // Each queued write handles its own failures, but await the predecessor so
-        // cache snapshots cannot be persisted out of live-refresh order.
-        await previousWrite.ConfigureAwait(false);
+        // Preserve write ordering, but never let an unexpected failure in an older
+        // best-effort persistence task prevent a newer live snapshot from being saved.
+        try
+        {
+            await previousWrite.ConfigureAwait(false);
+        }
+        catch
+        {
+        }
 
         try
         {
@@ -274,6 +286,20 @@ public sealed class OptionalInstallsCacheCoordinator
         }
     }
 
+    private void CaptureStateNotificationContext()
+    {
+        var current = SynchronizationContext.Current;
+        if (current is null)
+        {
+            return;
+        }
+
+        lock (_stateNotificationLock)
+        {
+            _stateNotificationContext ??= current;
+        }
+    }
+
     private void SetState(CatalogDataState state)
     {
         if (Equals(_state, state))
@@ -282,6 +308,32 @@ public sealed class OptionalInstallsCacheCoordinator
         }
 
         _state = state;
-        StateChanged?.Invoke(this, EventArgs.Empty);
+
+        var handler = StateChanged;
+        if (handler is null)
+        {
+            return;
+        }
+
+        SynchronizationContext? notificationContext;
+        lock (_stateNotificationLock)
+        {
+            notificationContext = _stateNotificationContext;
+        }
+
+        if (notificationContext is not null && !ReferenceEquals(SynchronizationContext.Current, notificationContext))
+        {
+            notificationContext.Post(
+                static payload =>
+                {
+                    var (owner, stateChanged) = ((OptionalInstallsCacheCoordinator Owner, EventHandler StateChanged))payload!;
+                    stateChanged(owner, EventArgs.Empty);
+                },
+                (this, handler)
+            );
+            return;
+        }
+
+        handler(this, EventArgs.Empty);
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
@@ -89,6 +89,7 @@ public sealed class OptionalInstallsCacheCoordinator
     private readonly IGorillaServiceClient _client;
     private readonly IOptionalInstallsCacheStore _cacheStore;
     private readonly object _refreshLock = new();
+    private readonly SemaphoreSlim _cacheWriteLock = new(1, 1);
     private Task<OptionalInstallsRefreshResult>? _refreshTask;
     private CatalogDataState _state = CatalogDataState.InitialLoading;
 
@@ -160,22 +161,9 @@ public sealed class OptionalInstallsCacheCoordinator
             var refreshedAtUtc = DateTimeOffset.UtcNow;
             var document = new OptionalInstallsCacheDocument(refreshedAtUtc, items);
 
-            Exception? cacheWriteFailure = null;
-            try
-            {
-                await _cacheStore.SaveAsync(document, cancellationToken);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                // Fresh service data remains authoritative and usable even when the
-                // fallback cache cannot be updated.
-                cacheWriteFailure = ex;
-            }
-
+            // A successful live response is immediately authoritative. Cache
+            // persistence is secondary durability work and must never delay fresh data
+            // becoming usable or keep the Refresh UI spinning.
             SetState(new CatalogDataState(
                 HasUsableData: true,
                 DataSource: CatalogDataSource.Live,
@@ -183,16 +171,18 @@ public sealed class OptionalInstallsCacheCoordinator
                 IsRefreshing: false,
                 IsSuccessfulEmpty: items.Count == 0,
                 LastSuccessfulRefreshUtc: refreshedAtUtc,
-                CachedAtUtc: cacheWriteFailure is null ? refreshedAtUtc : _state.CachedAtUtc,
+                CachedAtUtc: _state.CachedAtUtc,
                 RefreshFailure: null,
                 LoadFailure: null,
-                CacheWriteFailure: cacheWriteFailure
+                CacheWriteFailure: null
             ));
+
+            _ = PersistCacheAsync(document);
 
             return new OptionalInstallsRefreshResult(
                 refreshedAtUtc,
                 items,
-                cacheWriteFailure
+                CacheWriteFailure: null
             );
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -241,6 +231,41 @@ public sealed class OptionalInstallsCacheCoordinator
             {
                 _refreshTask = null;
             }
+        }
+    }
+
+    private async Task PersistCacheAsync(OptionalInstallsCacheDocument document)
+    {
+        await _cacheWriteLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            try
+            {
+                await _cacheStore.SaveAsync(document, CancellationToken.None);
+
+                var state = _state;
+                var cachedAtUtc = state.CachedAtUtc is DateTimeOffset currentCachedAt && currentCachedAt > document.CachedAtUtc
+                    ? currentCachedAt
+                    : document.CachedAtUtc;
+                var isCurrentLiveSnapshot = state.LastSuccessfulRefreshUtc == document.CachedAtUtc;
+                SetState(state with
+                {
+                    CachedAtUtc = cachedAtUtc,
+                    CacheWriteFailure = isCurrentLiveSnapshot ? null : state.CacheWriteFailure,
+                });
+            }
+            catch (Exception ex)
+            {
+                var state = _state;
+                if (state.LastSuccessfulRefreshUtc == document.CachedAtUtc)
+                {
+                    SetState(state with { CacheWriteFailure = ex });
+                }
+            }
+        }
+        finally
+        {
+            _cacheWriteLock.Release();
         }
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsCache.cs
@@ -140,6 +140,12 @@ public sealed class OptionalInstallsCacheCoordinator
 
     private async Task<OptionalInstallsRefreshResult> RefreshCoreAsync(CancellationToken cancellationToken)
     {
+        // Do not raise StateChanged synchronously while RefreshAsync still owns the
+        // coordination lock and has not yet published _refreshTask. A subscriber may
+        // legitimately observe refresh state and request Refresh again; yielding first
+        // guarantees that request joins the already-published task instead of racing it.
+        await Task.Yield();
+
         SetState(_state with
         {
             IsRefreshing = true,
@@ -191,6 +197,11 @@ public sealed class OptionalInstallsCacheCoordinator
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            SetState(_state with
+            {
+                IsInitialLoading = false,
+                IsRefreshing = false,
+            });
             throw;
         }
         catch (Exception ex)

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsStartupLoader.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsStartupLoader.cs
@@ -27,11 +27,18 @@ public sealed class OptionalInstallsStartupLoader
         {
             var refreshed = await _cacheCoordinator.RefreshAsync(cancellationToken);
             applyRefreshedItems(refreshed.Items);
-            return string.Empty;
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            return $"Showing cached data. Refresh failed: {ex.Message}";
+            throw;
         }
+        catch
+        {
+            // Catalog load/refresh failures are represented by the coordinator's
+            // explicit CatalogDataState. WarningBanner remains reserved for other
+            // service/operation infrastructure warnings.
+        }
+
+        return string.Empty;
     }
 }

--- a/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsStartupLoader.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/OptionalInstallsStartupLoader.cs
@@ -17,7 +17,22 @@ public sealed class OptionalInstallsStartupLoader
         CancellationToken cancellationToken
     )
     {
-        var cached = await _cacheCoordinator.LoadCachedAsync(cancellationToken);
+        OptionalInstallsCacheDocument? cached = null;
+        try
+        {
+            cached = await _cacheCoordinator.LoadCachedAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // An unreadable or invalid fallback cache is not authoritative. Treat it
+            // as absent and continue to the live service instead of aborting session
+            // initialization before a live catalog request can be attempted.
+        }
+
         if (cached is not null)
         {
             applyCachedItems(cached.Items);

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.CatalogRefresh.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.CatalogRefresh.cs
@@ -1,0 +1,40 @@
+using Gorilla.UI.Core.Models;
+
+namespace Gorilla.UI.Core.ViewModels;
+
+public sealed partial class HomeViewModel
+{
+    private bool _catalogStateSubscribed;
+
+    public CatalogDataState CatalogState
+    {
+        get
+        {
+            EnsureCatalogStateSubscription();
+            return _cacheCoordinator.State;
+        }
+    }
+
+    public async Task RefreshCatalogAsync(CancellationToken cancellationToken)
+    {
+        EnsureCatalogStateSubscription();
+        var refreshed = await _cacheCoordinator.RefreshAsync(cancellationToken);
+        ApplyItems(refreshed.Items);
+    }
+
+    private void EnsureCatalogStateSubscription()
+    {
+        if (_catalogStateSubscribed)
+        {
+            return;
+        }
+
+        _cacheCoordinator.StateChanged += CacheCoordinator_StateChanged;
+        _catalogStateSubscribed = true;
+    }
+
+    private void CacheCoordinator_StateChanged(object? sender, EventArgs e)
+    {
+        OnPropertyChanged(nameof(CatalogState));
+    }
+}

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -408,16 +408,12 @@ public sealed partial class HomeViewModel : INotifyPropertyChanged
         {
             throw;
         }
-        catch (Exception ex)
+        catch
         {
-            if (!preserveExistingWarning && string.IsNullOrWhiteSpace(WarningBanner))
-            {
-                WarningBanner = $"Operation completed, but optional installs refresh failed: {ex.Message}";
-            }
-            else if (preserveExistingWarning)
-            {
-                WarningBanner = $"{WarningBanner} Refresh also failed: {ex.Message}";
-            }
+            // Ordinary catalog-refresh failures are fully represented by
+            // CatalogDataState. WarningBanner is reserved for independent operation-
+            // tracking uncertainty and must not duplicate or retain raw refresh errors.
+            _ = preserveExistingWarning;
         }
     }
 

--- a/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
+++ b/gorilla-ui/src/Gorilla.UI.Core/ViewModels/HomeViewModel.cs
@@ -10,7 +10,7 @@ using AppCatalog = Gorilla.UI.Client.AppCatalog;
 
 namespace Gorilla.UI.Core.ViewModels;
 
-public sealed class HomeViewModel : INotifyPropertyChanged
+public sealed partial class HomeViewModel : INotifyPropertyChanged
 {
     private static readonly TimeSpan RecoveryRetryDelay = TimeSpan.FromSeconds(1);
     private readonly IGorillaServiceClient _client;

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -62,19 +62,23 @@ public sealed class ActivityTests
             Assert.False(string.IsNullOrWhiteSpace(operationId));
 
             shell.Refresh();
-            Assert.Equal(operationId, home.OperationId(SlowFixtureItemName));
-            shell.WaitForRefreshComplete(TimeSpan.FromSeconds(30));
-            home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
+            shell.WaitForRefreshStarted(TimeSpan.FromSeconds(30));
             Assert.Equal(operationId, home.OperationId(SlowFixtureItemName));
 
             var activity = ActivityPageDriver.OpenFromCatalog(session);
-            _ = activity.WaitForOperation(operationId, TimeSpan.FromSeconds(30));
+            activity.WaitForOperationState(operationId, "Installing", TimeSpan.FromSeconds(30));
             Assert.Equal(1, activity.CountEntries(operationId));
             Assert.Equal("Install", activity.ActionText(operationId));
-            session.CaptureCheckpoint("activity-after-catalog-refresh", includeAutomationTree: true);
+            session.CaptureCheckpoint("activity-during-catalog-refresh", includeAutomationTree: true);
 
             session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
             activity.WaitForOperationState(operationId, "Succeeded", TimeSpan.FromSeconds(30));
+            Assert.Equal(1, activity.CountEntries(operationId));
+
+            shell.WaitForRefreshComplete(TimeSpan.FromSeconds(30));
+            Assert.Equal(1, activity.CountEntries(operationId));
+            Assert.Equal("Succeeded", activity.StateText(operationId));
+            session.CaptureCheckpoint("activity-after-catalog-refresh", includeAutomationTree: true);
         });
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/ActivityTests.cs
@@ -47,6 +47,39 @@ public sealed class ActivityTests
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
+    public void CatalogRefreshPreservesActiveOperationAndActivityIdentity()
+    {
+        RunWithDiagnostics(nameof(CatalogRefreshPreservesActiveOperationAndActivityIdentity), session =>
+        {
+            var slowMarkerPath = RequiredPath("GORILLA_UI_E2E_SLOW_MARKER_PATH");
+            var home = new HomePageDriver(session);
+            var shell = new CatalogShellDriver(session);
+            EnsureSlowFixtureAbsent(session, home, slowMarkerPath);
+
+            home.PrimaryActionButton(SlowFixtureItemName).Invoke();
+            home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
+            var operationId = home.OperationId(SlowFixtureItemName);
+            Assert.False(string.IsNullOrWhiteSpace(operationId));
+
+            shell.Refresh();
+            Assert.Equal(operationId, home.OperationId(SlowFixtureItemName));
+            shell.WaitForRefreshComplete(TimeSpan.FromSeconds(30));
+            home.WaitForOperationContaining(SlowFixtureItemName, "Installing", TimeSpan.FromSeconds(30));
+            Assert.Equal(operationId, home.OperationId(SlowFixtureItemName));
+
+            var activity = ActivityPageDriver.OpenFromCatalog(session);
+            _ = activity.WaitForOperation(operationId, TimeSpan.FromSeconds(30));
+            Assert.Equal(1, activity.CountEntries(operationId));
+            Assert.Equal("Install", activity.ActionText(operationId));
+            session.CaptureCheckpoint("activity-after-catalog-refresh", includeAutomationTree: true);
+
+            session.WaitUntil(() => File.Exists(slowMarkerPath), TimeSpan.FromSeconds(30));
+            activity.WaitForOperationState(operationId, "Succeeded", TimeSpan.FromSeconds(30));
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
     public void RetainedFailureStaysLocalAndShowsStructuredDetail()
     {
         RunWithDiagnostics(nameof(RetainedFailureStaysLocalAndShowsStructuredDetail), session =>

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogShellDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogShellDriver.cs
@@ -49,6 +49,14 @@ internal sealed class CatalogShellDriver
         );
     }
 
+    public void WaitForRefreshStarted(TimeSpan? timeout = null)
+    {
+        _session.WaitUntil(
+            () => IsRefreshing && FreshnessText.Contains("Refreshing", StringComparison.OrdinalIgnoreCase),
+            timeout
+        );
+    }
+
     public void WaitForRefreshComplete(TimeSpan? timeout = null)
     {
         _session.WaitUntil(

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogShellDriver.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CatalogShellDriver.cs
@@ -1,0 +1,80 @@
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Exceptions;
+
+namespace Gorilla.UI.App.WindowsUiTests;
+
+internal sealed class CatalogShellDriver
+{
+    private readonly GorillaAppSession _session;
+
+    public CatalogShellDriver(GorillaAppSession session)
+    {
+        _session = session;
+    }
+
+    public Button RefreshButton => _session.WaitFor(
+        () => ById("CatalogRefreshButton")?.AsButton()
+    );
+
+    public string FreshnessText => SafeName(
+        _session.WaitFor(() => ById("CatalogFreshnessStatus"))
+    );
+
+    public string DegradedWarningText
+    {
+        get
+        {
+            var warning = ById("CatalogDegradedWarningText");
+            return warning is null ? string.Empty : SafeName(warning);
+        }
+    }
+
+    public bool IsRefreshing => ById("CatalogRefreshProgress") is not null && !RefreshButton.IsEnabled;
+
+    public void Refresh() => RefreshButton.Invoke();
+
+    public void WaitForFreshnessContaining(string expected, TimeSpan? timeout = null)
+    {
+        _session.WaitUntil(
+            () => FreshnessText.Contains(expected, StringComparison.OrdinalIgnoreCase),
+            timeout
+        );
+    }
+
+    public void WaitForDegradedWarningContaining(string expected, TimeSpan? timeout = null)
+    {
+        _session.WaitUntil(
+            () => DegradedWarningText.Contains(expected, StringComparison.OrdinalIgnoreCase),
+            timeout
+        );
+    }
+
+    public void WaitForRefreshComplete(TimeSpan? timeout = null)
+    {
+        _session.WaitUntil(
+            () => RefreshButton.IsEnabled && !FreshnessText.Contains("Refreshing", StringComparison.OrdinalIgnoreCase),
+            timeout
+        );
+    }
+
+    public bool HasInitialLoadingState() => ById("CatalogInitialLoading") is not null;
+
+    public bool HasLoadFailedState() => ById("CatalogLoadFailed") is not null;
+
+    public bool HasSuccessfulEmptyState() => ById("CatalogEmpty") is not null;
+
+    private AutomationElement? ById(string automationId)
+        => _session.MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(automationId));
+
+    private static string SafeName(AutomationElement element)
+    {
+        try
+        {
+            return element.Name;
+        }
+        catch (PropertyNotSupportedException)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
@@ -51,6 +51,30 @@ public sealed class CriticalPathTests
 
     [Fact]
     [Trait("E2EPhase", "Healthy")]
+    public void ManualRefreshPreservesSearchAndReturnsToFreshState()
+    {
+        RunWithDiagnostics(nameof(ManualRefreshPreservesSearchAndReturnsToFreshState), session =>
+        {
+            var home = new HomePageDriver(session);
+            var shell = new CatalogShellDriver(session);
+            _ = home.WaitForItem(FixtureItemName);
+            shell.WaitForFreshnessContaining("Updated", TimeSpan.FromSeconds(30));
+
+            home.Search(FixtureItemName);
+            session.WaitUntil(() => home.HasItem(FixtureItemName));
+            shell.Refresh();
+            shell.WaitForRefreshComplete(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(FixtureItemName, home.SearchBox.Text);
+            Assert.True(home.HasItem(FixtureItemName));
+            Assert.Contains("Updated", shell.FreshnessText, StringComparison.OrdinalIgnoreCase);
+            Assert.True(string.IsNullOrWhiteSpace(shell.DegradedWarningText));
+            session.CaptureCheckpoint("manual-refresh", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
     public void InstalledAndRemovedStateSurvivesAppRelaunch()
     {
         var markerPath = RequiredPath("GORILLA_UI_E2E_MARKER_PATH");
@@ -125,7 +149,7 @@ public sealed class CriticalPathTests
 
             home.InstallButton(FailureFixtureItemName).Invoke();
 
-            home.WaitForTerminalFeedbackContaining(FailureFixtureItemName, "Failed:", TimeSpan.FromSeconds(60));
+            home.WaitForTerminalFeedbackContaining(FailureFixtureItemName, "Installation error: exit status 7", TimeSpan.FromSeconds(60));
             Assert.Contains(
                 "Installation error: exit status 7",
                 home.TerminalFeedbackText(FailureFixtureItemName),
@@ -149,11 +173,30 @@ public sealed class CriticalPathTests
         RunWithDiagnostics(nameof(ServiceUnavailableStartupKeepsCachedItemsVisible), session =>
         {
             var home = new HomePageDriver(session);
+            var shell = new CatalogShellDriver(session);
             Assert.Equal("Available Software", home.Heading.Name);
             _ = home.WaitForItem(FixtureItemName);
-            home.WaitForWarningContaining("Showing cached data. Refresh failed", TimeSpan.FromSeconds(15));
+            shell.WaitForFreshnessContaining("Showing saved data", TimeSpan.FromSeconds(15));
+            shell.WaitForDegradedWarningContaining("couldn't refresh the catalog", TimeSpan.FromSeconds(15));
+            Assert.DoesNotContain("Updated", shell.FreshnessText, StringComparison.OrdinalIgnoreCase);
             home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("cached-service-unavailable", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "ServiceUnavailableNoCache")]
+    public void ServiceUnavailableWithoutCacheShowsLoadFailedInsteadOfEmpty()
+    {
+        RunWithDiagnostics(nameof(ServiceUnavailableWithoutCacheShowsLoadFailedInsteadOfEmpty), session =>
+        {
+            var shell = new CatalogShellDriver(session);
+            session.WaitUntil(() => shell.HasLoadFailedState(), TimeSpan.FromSeconds(15));
+
+            Assert.False(shell.HasSuccessfulEmptyState());
+            Assert.True(shell.RefreshButton.IsEnabled);
+            Assert.Contains("unavailable", shell.FreshnessText, StringComparison.OrdinalIgnoreCase);
+            session.CaptureCheckpoint("service-unavailable-no-cache", includeAutomationTree: true);
         });
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.App.WindowsUiTests/CriticalPathTests.cs
@@ -63,6 +63,7 @@ public sealed class CriticalPathTests
             home.Search(FixtureItemName);
             session.WaitUntil(() => home.HasItem(FixtureItemName));
             shell.Refresh();
+            Assert.True(home.HasItem(FixtureItemName));
             shell.WaitForRefreshComplete(TimeSpan.FromSeconds(30));
 
             Assert.Equal(FixtureItemName, home.SearchBox.Text);
@@ -70,6 +71,43 @@ public sealed class CriticalPathTests
             Assert.Contains("Updated", shell.FreshnessText, StringComparison.OrdinalIgnoreCase);
             Assert.True(string.IsNullOrWhiteSpace(shell.DegradedWarningText));
             session.CaptureCheckpoint("manual-refresh", includeAutomationTree: true);
+        });
+    }
+
+    [Fact]
+    [Trait("E2EPhase", "Healthy")]
+    public void CacheWriteFailureKeepsFreshCatalogVisibleAndActionable()
+    {
+        var cachePath = RequiredPath("GORILLA_UI_E2E_CACHE_PATH");
+        RunWithDiagnostics(nameof(CacheWriteFailureKeepsFreshCatalogVisibleAndActionable), session =>
+        {
+            var home = new HomePageDriver(session);
+            var shell = new CatalogShellDriver(session);
+            _ = home.WaitForItem(FixtureItemName);
+            shell.WaitForFreshnessContaining("Updated", TimeSpan.FromSeconds(30));
+            Assert.True(File.Exists(cachePath), $"Expected startup cache at {cachePath}.");
+
+            var originalAttributes = File.GetAttributes(cachePath);
+            try
+            {
+                File.SetAttributes(cachePath, originalAttributes | FileAttributes.ReadOnly);
+                shell.Refresh();
+                shell.WaitForRefreshComplete(TimeSpan.FromSeconds(30));
+                shell.WaitForDegradedWarningContaining("couldn't save the latest catalog", TimeSpan.FromSeconds(15));
+
+                Assert.True(home.HasItem(FixtureItemName));
+                Assert.True(home.PrimaryActionButton(FixtureItemName).IsEnabled);
+                Assert.Contains("Updated", shell.FreshnessText, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("couldn't refresh", shell.DegradedWarningText, StringComparison.OrdinalIgnoreCase);
+                session.CaptureCheckpoint("cache-write-degraded", includeAutomationTree: true);
+            }
+            finally
+            {
+                if (File.Exists(cachePath))
+                {
+                    File.SetAttributes(cachePath, originalAttributes);
+                }
+            }
         });
     }
 
@@ -168,9 +206,11 @@ public sealed class CriticalPathTests
 
     [Fact]
     [Trait("E2EPhase", "ServiceUnavailable")]
-    public void ServiceUnavailableStartupKeepsCachedItemsVisible()
+    public void ServiceUnavailableShowsCachedThenNoCacheFailureStatesTruthfully()
     {
-        RunWithDiagnostics(nameof(ServiceUnavailableStartupKeepsCachedItemsVisible), session =>
+        var cachePath = RequiredPath("GORILLA_UI_E2E_CACHE_PATH");
+
+        RunWithDiagnostics(nameof(ServiceUnavailableShowsCachedThenNoCacheFailureStatesTruthfully) + "-cached", session =>
         {
             var home = new HomePageDriver(session);
             var shell = new CatalogShellDriver(session);
@@ -182,13 +222,10 @@ public sealed class CriticalPathTests
             home.EnsureItemVisible(FixtureItemName);
             session.CaptureCheckpoint("cached-service-unavailable", includeAutomationTree: true);
         });
-    }
 
-    [Fact]
-    [Trait("E2EPhase", "ServiceUnavailableNoCache")]
-    public void ServiceUnavailableWithoutCacheShowsLoadFailedInsteadOfEmpty()
-    {
-        RunWithDiagnostics(nameof(ServiceUnavailableWithoutCacheShowsLoadFailedInsteadOfEmpty), session =>
+        File.Delete(cachePath);
+
+        RunWithDiagnostics(nameof(ServiceUnavailableShowsCachedThenNoCacheFailureStatesTruthfully) + "-no-cache", session =>
         {
             var shell = new CatalogShellDriver(session);
             session.WaitUntil(() => shell.HasLoadFailedState(), TimeSpan.FromSeconds(15));

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
@@ -150,6 +150,7 @@ public sealed class CatalogRefreshStateTests
     [Fact]
     public async Task BlockedCacheSave_DoesNotDelayFreshLiveSnapshot()
     {
+        OptionalInstallsCacheDocument? persistedDocument = null;
         var saveStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseSave = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var store = new TestCacheStore
@@ -158,10 +159,9 @@ public sealed class CatalogRefreshStateTests
             {
                 saveStarted.TrySetResult(true);
                 await releaseSave.Task;
-                storeDocument = document;
+                persistedDocument = document;
             },
         };
-        OptionalInstallsCacheDocument? storeDocument = null;
         var client = new FakeClient
         {
             ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([Item("live", "Live")]),
@@ -176,12 +176,12 @@ public sealed class CatalogRefreshStateTests
         Assert.True(coordinator.State.HasUsableData);
         Assert.False(coordinator.State.IsRefreshing);
         Assert.NotNull(coordinator.State.LastSuccessfulRefreshUtc);
-        Assert.Null(storeDocument);
+        Assert.Null(persistedDocument);
         Assert.False(releaseSave.Task.IsCompleted);
 
         releaseSave.TrySetResult(true);
-        await WaitUntilAsync(() => storeDocument is not null);
-        Assert.Equal(result.RefreshedAtUtc, storeDocument!.CachedAtUtc);
+        await WaitUntilAsync(() => persistedDocument is not null);
+        Assert.Equal(result.RefreshedAtUtc, persistedDocument!.CachedAtUtc);
     }
 
     [Fact]

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
@@ -1,0 +1,346 @@
+using Gorilla.UI.Client;
+using Gorilla.UI.Client.AppCatalog;
+using Gorilla.UI.Core.Models;
+using Gorilla.UI.Core.Services;
+using Gorilla.UI.Core.ViewModels;
+using Xunit;
+using CatalogAction = Gorilla.UI.Client.AppCatalog.Action;
+
+namespace Gorilla.UI.Core.Tests;
+
+public sealed class CatalogRefreshStateTests
+{
+    [Fact]
+    public async Task NoCache_LivePending_RemainsInitialLoadingUntilLiveSucceeds()
+    {
+        var pending = new TaskCompletionSource<IReadOnlyList<OptionalInstallItem>>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var client = new FakeClient { ListAsync = _ => pending.Task };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new TestCacheStore());
+
+        Assert.Null(await coordinator.LoadCachedAsync(CancellationToken.None));
+        var refresh = coordinator.RefreshAsync(CancellationToken.None);
+        await Task.Yield();
+
+        Assert.True(coordinator.State.IsInitialLoading);
+        Assert.True(coordinator.State.IsRefreshing);
+        Assert.False(coordinator.State.HasUsableData);
+
+        pending.SetResult([Item("one", "One")]);
+        await refresh;
+
+        Assert.True(coordinator.State.IsLive);
+        Assert.False(coordinator.State.IsInitialLoading);
+        Assert.False(coordinator.State.IsRefreshing);
+        Assert.NotNull(coordinator.State.LastSuccessfulRefreshUtc);
+    }
+
+    [Fact]
+    public async Task NoCache_LiveEmpty_IsSuccessfulEmpty_NotLoadFailure()
+    {
+        var client = new FakeClient { ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([]) };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new TestCacheStore());
+
+        await coordinator.RefreshAsync(CancellationToken.None);
+
+        Assert.True(coordinator.State.IsLive);
+        Assert.True(coordinator.State.IsSuccessfulEmpty);
+        Assert.False(coordinator.State.HasLoadFailure);
+    }
+
+    [Fact]
+    public async Task NoCache_LiveFailure_IsLoadFailureWithoutUsableData()
+    {
+        var failure = new IOException("pipe unavailable");
+        var client = new FakeClient { ListAsync = _ => Task.FromException<IReadOnlyList<OptionalInstallItem>>(failure) };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new TestCacheStore());
+
+        await Assert.ThrowsAsync<IOException>(() => coordinator.RefreshAsync(CancellationToken.None));
+
+        Assert.False(coordinator.State.HasUsableData);
+        Assert.True(coordinator.State.HasLoadFailure);
+        Assert.Same(failure, coordinator.State.LoadFailure);
+        Assert.Null(coordinator.State.LastSuccessfulRefreshUtc);
+    }
+
+    [Fact]
+    public async Task CacheFirst_CacheIsExplicitUntilLiveSucceeds()
+    {
+        var cachedAt = DateTimeOffset.Parse("2026-09-12T18:00:00Z");
+        var liveReady = new TaskCompletionSource<IReadOnlyList<OptionalInstallItem>>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var store = new TestCacheStore
+        {
+            Document = new OptionalInstallsCacheDocument(cachedAt, [Item("cached", "Cached")]),
+        };
+        var client = new FakeClient { ListAsync = _ => liveReady.Task };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, store);
+        IReadOnlyList<OptionalInstallItem>? appliedCache = null;
+        IReadOnlyList<OptionalInstallItem>? appliedLive = null;
+        var loader = new OptionalInstallsStartupLoader(coordinator);
+
+        var initialize = loader.InitializeAsync(
+            items => appliedCache = items,
+            items => appliedLive = items,
+            CancellationToken.None
+        );
+        await Task.Yield();
+
+        Assert.NotNull(appliedCache);
+        Assert.Null(appliedLive);
+        Assert.True(coordinator.State.IsCached);
+        Assert.Equal(cachedAt, coordinator.State.CachedAtUtc);
+        Assert.Null(coordinator.State.LastSuccessfulRefreshUtc);
+
+        liveReady.SetResult([Item("live", "Live")]);
+        await initialize;
+
+        Assert.NotNull(appliedLive);
+        Assert.True(coordinator.State.IsLive);
+        Assert.NotNull(coordinator.State.LastSuccessfulRefreshUtc);
+        Assert.Null(coordinator.State.RefreshFailure);
+    }
+
+    [Fact]
+    public async Task CacheFirst_LiveFailure_PreservesCachedStateAndTimestamp()
+    {
+        var cachedAt = DateTimeOffset.Parse("2026-09-12T18:00:00Z");
+        var store = new TestCacheStore
+        {
+            Document = new OptionalInstallsCacheDocument(cachedAt, [Item("cached", "Cached")]),
+        };
+        var failure = new TimeoutException("timed out");
+        var client = new FakeClient { ListAsync = _ => Task.FromException<IReadOnlyList<OptionalInstallItem>>(failure) };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, store);
+
+        await coordinator.LoadCachedAsync(CancellationToken.None);
+        await Assert.ThrowsAsync<TimeoutException>(() => coordinator.RefreshAsync(CancellationToken.None));
+
+        Assert.True(coordinator.State.IsCached);
+        Assert.True(coordinator.State.HasUsableData);
+        Assert.Same(failure, coordinator.State.RefreshFailure);
+        Assert.Equal(cachedAt, coordinator.State.CachedAtUtc);
+        Assert.Null(coordinator.State.LastSuccessfulRefreshUtc);
+    }
+
+    [Fact]
+    public async Task CacheSaveFailure_DoesNotInvalidateSuccessfulLiveRefresh()
+    {
+        var store = new TestCacheStore { SaveFailure = new IOException("disk full") };
+        var client = new FakeClient
+        {
+            ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([Item("live", "Live")]),
+        };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, store);
+
+        var result = await coordinator.RefreshAsync(CancellationToken.None);
+
+        Assert.Single(result.Items);
+        Assert.NotNull(result.CacheWriteFailure);
+        Assert.True(coordinator.State.IsLive);
+        Assert.True(coordinator.State.HasUsableData);
+        Assert.True(coordinator.State.HasCacheWriteFailure);
+        Assert.False(coordinator.State.HasRefreshFailure);
+        Assert.NotNull(coordinator.State.LastSuccessfulRefreshUtc);
+    }
+
+    [Fact]
+    public async Task ConcurrentRefreshes_ShareOneLiveRequest()
+    {
+        var pending = new TaskCompletionSource<IReadOnlyList<OptionalInstallItem>>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var client = new FakeClient { ListAsync = _ => pending.Task };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new TestCacheStore());
+
+        var first = coordinator.RefreshAsync(CancellationToken.None);
+        var second = coordinator.RefreshAsync(CancellationToken.None);
+        await Task.Yield();
+
+        Assert.Equal(1, client.ListCalls);
+        pending.SetResult([Item("one", "One")]);
+        await Task.WhenAll(first, second);
+        Assert.Equal(1, client.ListCalls);
+    }
+
+    [Fact]
+    public async Task HomeViewModel_RefreshPreservesSearchSelectionIdentityAndActivity()
+    {
+        var firstItem = Item("one", "One", "1.0");
+        var operation = new OperationStatusEvent(
+            "operation-1",
+            OperationState.Completed,
+            100,
+            "done",
+            DateTimeOffset.Parse("2026-09-12T18:00:00Z"),
+            "one",
+            CatalogAction.Install,
+            new Result(ResultOutcome.Succeeded, "ok", "Installed")
+        );
+        var responses = new Queue<IReadOnlyList<OptionalInstallItem>>();
+        responses.Enqueue([firstItem]);
+        responses.Enqueue([Item("one", "One updated", "2.0"), Item("two", "Two")]);
+        var client = new FakeClient
+        {
+            ListAsync = _ => Task.FromResult(responses.Dequeue()),
+            Operations = [operation],
+        };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new TestCacheStore());
+        var tracker = new OperationTracker(client);
+        var viewModel = new HomeViewModel(client, coordinator, tracker);
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+        viewModel.SearchQuery = "One";
+        Assert.True(viewModel.SelectItem("one"));
+        var canonical = viewModel.SelectedItem;
+        Assert.NotNull(canonical);
+        Assert.Single(viewModel.ActivityItems);
+
+        await viewModel.RefreshCatalogAsync(CancellationToken.None);
+
+        Assert.Equal("One", viewModel.SearchQuery);
+        Assert.Equal("one", viewModel.SelectedItemName);
+        Assert.Same(canonical, viewModel.SelectedItem);
+        Assert.Equal("One updated", viewModel.SelectedItem!.DisplayName);
+        Assert.Single(viewModel.ActivityItems);
+        Assert.Equal("operation-1", viewModel.ActivityItems[0].OperationId);
+    }
+
+    [Fact]
+    public async Task HomeViewModel_RefreshFailureKeepsExistingCatalogAndSuccessfulRetryClearsFailure()
+    {
+        var attempt = 0;
+        var client = new FakeClient
+        {
+            ListAsync = _ => ++attempt switch
+            {
+                1 => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([Item("one", "One")]),
+                2 => Task.FromException<IReadOnlyList<OptionalInstallItem>>(new IOException("service unavailable")),
+                _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([Item("one", "One refreshed")]),
+            },
+        };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new TestCacheStore());
+        var viewModel = new HomeViewModel(client, coordinator, new OperationTracker(client));
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+        var canonical = viewModel.FindItem("one");
+        var firstTimestamp = viewModel.CatalogState.LastSuccessfulRefreshUtc;
+
+        await Assert.ThrowsAsync<IOException>(() => viewModel.RefreshCatalogAsync(CancellationToken.None));
+        Assert.Same(canonical, viewModel.FindItem("one"));
+        Assert.True(viewModel.CatalogState.HasRefreshFailure);
+        Assert.Equal(firstTimestamp, viewModel.CatalogState.LastSuccessfulRefreshUtc);
+
+        await viewModel.RefreshCatalogAsync(CancellationToken.None);
+        Assert.Same(canonical, viewModel.FindItem("one"));
+        Assert.Equal("One refreshed", viewModel.FindItem("one")!.DisplayName);
+        Assert.False(viewModel.CatalogState.HasRefreshFailure);
+        Assert.True(viewModel.CatalogState.IsLive);
+        Assert.True(viewModel.CatalogState.LastSuccessfulRefreshUtc >= firstTimestamp);
+    }
+
+    [Fact]
+    public async Task HomeViewModel_RemovedSelectedItemBecomesUnavailable()
+    {
+        var responses = new Queue<IReadOnlyList<OptionalInstallItem>>();
+        responses.Enqueue([Item("one", "One")]);
+        responses.Enqueue([Item("two", "Two")]);
+        var client = new FakeClient { ListAsync = _ => Task.FromResult(responses.Dequeue()) };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new TestCacheStore());
+        var viewModel = new HomeViewModel(client, coordinator, new OperationTracker(client));
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+        Assert.True(viewModel.SelectItem("one"));
+
+        await viewModel.RefreshCatalogAsync(CancellationToken.None);
+
+        Assert.Null(viewModel.SelectedItemName);
+        Assert.Null(viewModel.SelectedItem);
+    }
+
+    private static OptionalInstallItem Item(string itemName, string displayName, string version = "1.0")
+    {
+        var now = DateTimeOffset.Parse("2026-09-12T18:00:00Z");
+        return new OptionalInstallItem(
+            ItemName: itemName,
+            DisplayName: displayName,
+            Version: version,
+            Catalog: "test",
+            InstallerType: "ps1",
+            InstallerPackageId: itemName,
+            InstallerLocation: $"{itemName}.ps1",
+            IsManaged: true,
+            IsInstalled: false,
+            Status: OptionalInstallStatus.NotInstalled,
+            StatusUpdatedAtUtc: now,
+            LastOperationId: null,
+            TargetVersion: version,
+            Observation: new Observation(
+                ObservedState.Absent,
+                InstalledVersion: null,
+                CheckedAtUtc: now,
+                DetailCode: string.Empty,
+                InstallRequirement: RequirementState.Unknown
+            ),
+            Policy: null,
+            Actions: new Actions(
+                new ActionDecision(true, string.Empty),
+                new ActionDecision(false, "Not installed")
+            ),
+            Description: "Test app"
+        );
+    }
+
+    private sealed class TestCacheStore : IOptionalInstallsCacheStore
+    {
+        public OptionalInstallsCacheDocument? Document { get; set; }
+        public Exception? SaveFailure { get; set; }
+
+        public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken)
+            => Task.FromResult(Document);
+
+        public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
+        {
+            if (SaveFailure is not null)
+            {
+                return Task.FromException(SaveFailure);
+            }
+
+            Document = document;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeClient : IGorillaServiceClient
+    {
+        public required Func<CancellationToken, Task<IReadOnlyList<OptionalInstallItem>>> ListAsync { get; init; }
+        public IReadOnlyList<OperationStatusEvent> Operations { get; init; } = [];
+        public int ListCalls { get; private set; }
+
+        public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
+        {
+            ListCalls++;
+            return ListAsync(cancellationToken);
+        }
+
+        public Task<IReadOnlyList<OperationStatusEvent>> ListOperationsAsync(CancellationToken cancellationToken)
+            => Task.FromResult(Operations);
+
+        public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<OperationAccepted> RemoveItemAsync(string itemName, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public async IAsyncEnumerable<OperationStatusEvent> StreamOperationStatusAsync(
+            string operationId,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken
+        )
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+}

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
@@ -136,14 +136,52 @@ public sealed class CatalogRefreshStateTests
         var coordinator = new OptionalInstallsCacheCoordinator(client, store);
 
         var result = await coordinator.RefreshAsync(CancellationToken.None);
+        await WaitUntilAsync(() => coordinator.State.HasCacheWriteFailure);
 
         Assert.Single(result.Items);
-        Assert.NotNull(result.CacheWriteFailure);
+        Assert.Null(result.CacheWriteFailure);
         Assert.True(coordinator.State.IsLive);
         Assert.True(coordinator.State.HasUsableData);
         Assert.True(coordinator.State.HasCacheWriteFailure);
         Assert.False(coordinator.State.HasRefreshFailure);
         Assert.NotNull(coordinator.State.LastSuccessfulRefreshUtc);
+    }
+
+    [Fact]
+    public async Task BlockedCacheSave_DoesNotDelayFreshLiveSnapshot()
+    {
+        var saveStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSave = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new TestCacheStore
+        {
+            SaveAsyncOverride = async (document, _) =>
+            {
+                saveStarted.TrySetResult(true);
+                await releaseSave.Task;
+                storeDocument = document;
+            },
+        };
+        OptionalInstallsCacheDocument? storeDocument = null;
+        var client = new FakeClient
+        {
+            ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([Item("live", "Live")]),
+        };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, store);
+
+        var result = await coordinator.RefreshAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
+        await saveStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Single(result.Items);
+        Assert.True(coordinator.State.IsLive);
+        Assert.True(coordinator.State.HasUsableData);
+        Assert.False(coordinator.State.IsRefreshing);
+        Assert.NotNull(coordinator.State.LastSuccessfulRefreshUtc);
+        Assert.Null(storeDocument);
+        Assert.False(releaseSave.Task.IsCompleted);
+
+        releaseSave.TrySetResult(true);
+        await WaitUntilAsync(() => storeDocument is not null);
+        Assert.Equal(result.RefreshedAtUtc, storeDocument!.CachedAtUtc);
     }
 
     [Fact]
@@ -260,6 +298,15 @@ public sealed class CatalogRefreshStateTests
         Assert.Null(viewModel.SelectedItem);
     }
 
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        while (!condition())
+        {
+            await Task.Delay(10, timeout.Token);
+        }
+    }
+
     private static OptionalInstallItem Item(string itemName, string displayName, string version = "1.0")
     {
         var now = DateTimeOffset.Parse("2026-09-12T18:00:00Z");
@@ -297,12 +344,18 @@ public sealed class CatalogRefreshStateTests
     {
         public OptionalInstallsCacheDocument? Document { get; set; }
         public Exception? SaveFailure { get; set; }
+        public Func<OptionalInstallsCacheDocument, CancellationToken, Task>? SaveAsyncOverride { get; set; }
 
         public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken)
             => Task.FromResult(Document);
 
         public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
         {
+            if (SaveAsyncOverride is not null)
+            {
+                return SaveAsyncOverride(document, cancellationToken);
+            }
+
             if (SaveFailure is not null)
             {
                 return Task.FromException(SaveFailure);

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/CatalogRefreshStateTests.cs
@@ -177,7 +177,7 @@ public sealed class CatalogRefreshStateTests
             DateTimeOffset.Parse("2026-09-12T18:00:00Z"),
             "one",
             CatalogAction.Install,
-            new Result(ResultOutcome.Succeeded, "ok", "Installed")
+            new Result(Outcome.Succeeded, "ok", Message: "Installed")
         );
         var responses = new Queue<IReadOnlyList<OptionalInstallItem>>();
         responses.Enqueue([firstItem]);

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelMutationTests.cs
@@ -176,7 +176,7 @@ public class HomeViewModelMutationTests
     }
 
     [Fact]
-    public async Task InstallAsync_RefreshFailureAfterOperationFailure_ShowsRefreshWarningAndKeepsItemFailureLocal()
+    public async Task InstallAsync_RefreshFailureAfterOperationFailure_UsesCatalogStateAndKeepsItemFailureLocal()
     {
         var client = new FakeClient
         {
@@ -188,8 +188,9 @@ public class HomeViewModelMutationTests
         var item = MakeUiItem("VLC");
         await viewModel.InstallAsync(item, CancellationToken.None);
         Assert.Equal("Failed: exit code 1", item.CardPresentation.TerminalFeedbackText);
-        Assert.Contains("Operation completed, but optional installs refresh failed", viewModel.WarningBanner);
-        Assert.Contains("refresh unavailable", viewModel.WarningBanner);
+        Assert.Empty(viewModel.WarningBanner);
+        Assert.True(viewModel.CatalogState.HasLoadFailure);
+        Assert.Contains("refresh unavailable", viewModel.CatalogState.LoadFailure!.Message);
         Assert.Equal(1, client.ListCalls);
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelRecoveryTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelRecoveryTests.cs
@@ -66,6 +66,39 @@ public class HomeViewModelRecoveryTests
         Assert.Equal(1, client.ListOperationsCalls);
     }
 
+    [Fact]
+    public async Task PostOperationRefreshFailure_UsesCatalogStateAndManualRecoveryClearsIt()
+    {
+        var listAttempt = 0;
+        var client = new FakeClient
+        {
+            ListAsync = _ => ++listAttempt switch
+            {
+                1 => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([CatalogItem()]),
+                2 => Task.FromException<IReadOnlyList<OptionalInstallItem>>(new IOException("catalog refresh failed")),
+                _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([CatalogItem()]),
+            },
+            StreamAsync = (_, _) => CompletedStream(),
+        };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, new InMemoryCacheStore());
+        var viewModel = new HomeViewModel(client, coordinator, new OperationTracker(client));
+
+        await viewModel.InitializeAsync(CancellationToken.None);
+        var item = Assert.Single(viewModel.Items);
+
+        await viewModel.InstallAsync(item, CancellationToken.None);
+
+        Assert.Equal(string.Empty, viewModel.WarningBanner);
+        Assert.True(viewModel.CatalogState.HasRefreshFailure);
+        Assert.Contains("catalog refresh failed", viewModel.CatalogState.RefreshFailure!.Message);
+
+        await viewModel.RefreshCatalogAsync(CancellationToken.None);
+
+        Assert.Equal(string.Empty, viewModel.WarningBanner);
+        Assert.False(viewModel.CatalogState.HasRefreshFailure);
+        Assert.True(viewModel.CatalogState.IsLive);
+    }
+
     private static UiOptionalInstallItem MakeUiItem() => new()
     {
         ItemName = "VLC",
@@ -76,6 +109,25 @@ public class HomeViewModelRecoveryTests
         InstallAllowed = true,
         RemoveAllowed = false,
     };
+
+    private static OptionalInstallItem CatalogItem() => new(
+        "VLC",
+        "VLC",
+        "1.0.0",
+        "testcatalog",
+        "ps1",
+        "VLC",
+        "VLC.ps1",
+        true,
+        false,
+        OptionalInstallStatus.NotInstalled,
+        Now,
+        null,
+        Actions: new Actions(
+            new ActionDecision(true, "allowed"),
+            new ActionDecision(false, "not_installed")
+        )
+    );
 
     private static OperationStatusEvent ActiveOperation() => new(
         "op-1",
@@ -135,32 +187,14 @@ public class HomeViewModelRecoveryTests
         public IReadOnlyList<OperationStatusEvent> Operations { get; init; } = [];
         public Func<string, CancellationToken, IAsyncEnumerable<OperationStatusEvent>> StreamAsync { get; set; }
             = (_, _) => EmptyStream();
+        public Func<CancellationToken, Task<IReadOnlyList<OptionalInstallItem>>> ListAsync { get; init; }
+            = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([CatalogItem()]);
 
         public int StreamCalls { get; private set; }
         public int ListOperationsCalls { get; private set; }
 
         public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
-            => Task.FromResult<IReadOnlyList<OptionalInstallItem>>
-            ([
-                new OptionalInstallItem(
-                    "VLC",
-                    "VLC",
-                    "1.0.0",
-                    "testcatalog",
-                    "ps1",
-                    "VLC",
-                    "VLC.ps1",
-                    true,
-                    false,
-                    OptionalInstallStatus.NotInstalled,
-                    Now,
-                    null,
-                    Actions: new Actions(
-                        new ActionDecision(true, "allowed"),
-                        new ActionDecision(false, "not_installed")
-                    )
-                ),
-            ]);
+            => ListAsync(cancellationToken);
 
         public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken)
             => Task.FromResult(new OperationAccepted("op-1", true, Now));

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/HomeViewModelTests.cs
@@ -136,7 +136,7 @@ public class HomeViewModelTests
     }
 
     [Fact]
-    public async Task InstallAsync_RefreshFailureAfterSuccess_SetsRefreshWarning()
+    public async Task InstallAsync_RefreshFailureAfterSuccess_RecordsCatalogFailureWithoutWarningBanner()
     {
         var client = new FakeClient
         {
@@ -153,8 +153,9 @@ public class HomeViewModelTests
         await viewModel.InstallAsync(item, CancellationToken.None);
 
         Assert.Equal(1, client.ListCalls);
-        Assert.Contains("Operation completed, but optional installs refresh failed:", viewModel.WarningBanner);
-        Assert.Contains("refresh unavailable", viewModel.WarningBanner);
+        Assert.Empty(viewModel.WarningBanner);
+        Assert.True(viewModel.CatalogState.HasLoadFailure);
+        Assert.Contains("refresh unavailable", viewModel.CatalogState.LoadFailure!.Message);
         Assert.False(item.IsBusy);
     }
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsCacheTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsCacheTests.cs
@@ -74,7 +74,7 @@ public class OptionalInstallsCacheTests
     }
 
     [Fact]
-    public async Task Coordinator_RefreshSavesAndReturnsFreshData()
+    public async Task Coordinator_RefreshReturnsFreshDataBeforeSecondaryCachePersistenceCompletes()
     {
         var now = DateTimeOffset.Parse("2026-02-14T18:10:00Z");
         var store = new InMemoryCacheStore();
@@ -82,14 +82,19 @@ public class OptionalInstallsCacheTests
         var coordinator = new OptionalInstallsCacheCoordinator(client, store);
 
         var refreshed = await coordinator.RefreshAsync(CancellationToken.None);
-        var cached = await coordinator.LoadCachedAsync(CancellationToken.None);
 
         Assert.Single(refreshed.Items);
         Assert.Equal("VLC", refreshed.Items[0].ItemName);
+        Assert.Null(refreshed.CacheWriteFailure);
+        Assert.True(coordinator.State.IsLive);
+        Assert.False(coordinator.State.IsRefreshing);
+
+        await store.Saved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var cached = await coordinator.LoadCachedAsync(CancellationToken.None);
+
         Assert.NotNull(cached);
         Assert.Equal(refreshed.RefreshedAtUtc, cached!.CachedAtUtc);
         Assert.Equal(refreshed.Items, cached.Items);
-        Assert.Null(refreshed.CacheWriteFailure);
     }
 
     private static string MakeTempDirectory()
@@ -122,11 +127,14 @@ public class OptionalInstallsCacheTests
     {
         private OptionalInstallsCacheDocument? _document;
 
+        public TaskCompletionSource<bool> Saved { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken) => Task.FromResult(_document);
 
         public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
         {
             _document = document;
+            Saved.TrySetResult(true);
             return Task.CompletedTask;
         }
     }

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsCacheTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsCacheTests.cs
@@ -87,7 +87,9 @@ public class OptionalInstallsCacheTests
         Assert.Single(refreshed.Items);
         Assert.Equal("VLC", refreshed.Items[0].ItemName);
         Assert.NotNull(cached);
-        Assert.Equal(refreshed, cached);
+        Assert.Equal(refreshed.RefreshedAtUtc, cached!.CachedAtUtc);
+        Assert.Equal(refreshed.Items, cached.Items);
+        Assert.Null(refreshed.CacheWriteFailure);
     }
 
     private static string MakeTempDirectory()

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsStartupLoaderTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsStartupLoaderTests.cs
@@ -80,6 +80,37 @@ public class OptionalInstallsStartupLoaderTests
         Assert.Contains("service unavailable", coordinator.State.RefreshFailure!.Message);
     }
 
+    [Fact]
+    public async Task InitializeAsync_InvalidCacheStillLoadsSuccessfulLiveCatalog()
+    {
+        var now = DateTimeOffset.Parse("2026-02-19T18:11:00Z");
+        var cacheStore = new InMemoryCacheStore(null)
+        {
+            LoadFailure = new InvalidDataException("cached protocol data is invalid"),
+        };
+        var client = new FakeClient
+        {
+            ListAsync = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([MakeItem("FreshChrome", now)]),
+        };
+        var coordinator = new OptionalInstallsCacheCoordinator(client, cacheStore);
+        var loader = new OptionalInstallsStartupLoader(coordinator);
+        var cachedCalled = false;
+        IReadOnlyList<OptionalInstallItem>? refreshedItems = null;
+
+        var warning = await loader.InitializeAsync(
+            _ => cachedCalled = true,
+            items => refreshedItems = items,
+            CancellationToken.None
+        );
+
+        Assert.Equal(string.Empty, warning);
+        Assert.False(cachedCalled);
+        Assert.Equal("FreshChrome", Assert.Single(refreshedItems!).ItemName);
+        Assert.Equal(1, client.ListCalls);
+        Assert.True(coordinator.State.IsLive);
+        Assert.False(coordinator.State.HasLoadFailure);
+    }
+
     private static OptionalInstallItem MakeItem(string itemName, DateTimeOffset now) => new(
         itemName,
         itemName,
@@ -101,7 +132,17 @@ public class OptionalInstallsStartupLoaderTests
 
         public InMemoryCacheStore(OptionalInstallsCacheDocument? document) => _document = document;
 
-        public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken) => Task.FromResult(_document);
+        public Exception? LoadFailure { get; init; }
+
+        public Task<OptionalInstallsCacheDocument?> LoadAsync(CancellationToken cancellationToken)
+        {
+            if (LoadFailure is not null)
+            {
+                return Task.FromException<OptionalInstallsCacheDocument?>(LoadFailure);
+            }
+
+            return Task.FromResult(_document);
+        }
 
         public Task SaveAsync(OptionalInstallsCacheDocument document, CancellationToken cancellationToken)
         {
@@ -113,8 +154,14 @@ public class OptionalInstallsStartupLoaderTests
     private sealed class FakeClient : IGorillaServiceClient
     {
         public Func<CancellationToken, Task<IReadOnlyList<OptionalInstallItem>>> ListAsync { get; init; } = _ => Task.FromResult<IReadOnlyList<OptionalInstallItem>>([]);
+        public int ListCalls { get; private set; }
 
-        public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken) => ListAsync(cancellationToken);
+        public Task<IReadOnlyList<OptionalInstallItem>> ListOptionalInstallsAsync(CancellationToken cancellationToken)
+        {
+            ListCalls++;
+            return ListAsync(cancellationToken);
+        }
+
         public Task<OperationAccepted> InstallItemAsync(string itemName, CancellationToken cancellationToken) => throw new NotSupportedException();
         public Task<OperationAccepted> RemoveItemAsync(string itemName, CancellationToken cancellationToken) => throw new NotSupportedException();
 

--- a/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsStartupLoaderTests.cs
+++ b/gorilla-ui/tests/Gorilla.UI.Core.Tests/OptionalInstallsStartupLoaderTests.cs
@@ -14,7 +14,8 @@ public class OptionalInstallsStartupLoaderTests
         var cacheStore = new InMemoryCacheStore(new OptionalInstallsCacheDocument(cachedNow, [MakeItem("CachedVLC", cachedNow)]));
         var refreshReady = new TaskCompletionSource<IReadOnlyList<OptionalInstallItem>>(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new FakeClient { ListAsync = _ => refreshReady.Task };
-        var loader = new OptionalInstallsStartupLoader(new OptionalInstallsCacheCoordinator(client, cacheStore));
+        var coordinator = new OptionalInstallsCacheCoordinator(client, cacheStore);
+        var loader = new OptionalInstallsStartupLoader(coordinator);
 
         var applyOrder = new ConcurrentQueue<string>();
         var cachedApplied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -38,6 +39,7 @@ public class OptionalInstallsStartupLoaderTests
 
         await cachedApplied.Task.WaitAsync(TimeSpan.FromSeconds(2));
         Assert.Null(refreshedItems);
+        Assert.True(coordinator.State.IsCached);
 
         var refreshNow = DateTimeOffset.Parse("2026-02-19T18:11:00Z");
         refreshReady.SetResult([MakeItem("FreshChrome", refreshNow)]);
@@ -46,6 +48,7 @@ public class OptionalInstallsStartupLoaderTests
         Assert.Equal(string.Empty, warning);
         Assert.Equal("CachedVLC", Assert.Single(cachedItems!).ItemName);
         Assert.Equal("FreshChrome", Assert.Single(refreshedItems!).ItemName);
+        Assert.True(coordinator.State.IsLive);
         Assert.True(applyOrder.TryDequeue(out var first));
         Assert.Equal("cached", first);
         Assert.True(applyOrder.TryDequeue(out var second));
@@ -53,12 +56,13 @@ public class OptionalInstallsStartupLoaderTests
     }
 
     [Fact]
-    public async Task InitializeAsync_RefreshFailureKeepsCachedAndReturnsWarning()
+    public async Task InitializeAsync_RefreshFailureKeepsCachedAndRecordsDegradedState()
     {
         var now = DateTimeOffset.Parse("2026-02-19T18:10:00Z");
         var cacheStore = new InMemoryCacheStore(new OptionalInstallsCacheDocument(now, [MakeItem("CachedVLC", now)]));
         var client = new FakeClient { ListAsync = _ => Task.FromException<IReadOnlyList<OptionalInstallItem>>(new InvalidOperationException("service unavailable")) };
-        var loader = new OptionalInstallsStartupLoader(new OptionalInstallsCacheCoordinator(client, cacheStore));
+        var coordinator = new OptionalInstallsCacheCoordinator(client, cacheStore);
+        var loader = new OptionalInstallsStartupLoader(coordinator);
 
         IReadOnlyList<OptionalInstallItem>? cachedItems = null;
         var refreshedCalled = false;
@@ -70,8 +74,10 @@ public class OptionalInstallsStartupLoaderTests
 
         Assert.Equal("CachedVLC", Assert.Single(cachedItems!).ItemName);
         Assert.False(refreshedCalled);
-        Assert.Contains("Showing cached data. Refresh failed:", warning);
-        Assert.Contains("service unavailable", warning);
+        Assert.Equal(string.Empty, warning);
+        Assert.True(coordinator.State.IsCached);
+        Assert.True(coordinator.State.HasRefreshFailure);
+        Assert.Contains("service unavailable", coordinator.State.RefreshFailure!.Message);
     }
 
     private static OptionalInstallItem MakeItem(string itemName, DateTimeOffset now) => new(


### PR DESCRIPTION
## Summary

Implements PR F of Stage 6: explicit App Catalog refresh, freshness/provenance, degraded-state handling, and cache-write degradation.

- adds a Core-owned `CatalogDataState` separating provenance from refresh activity
- tracks live vs cached data, initial loading, successful empty, refresh failure with retained data, load failure without data, and cache-write degradation
- records `LastSuccessfulRefreshUtc` only after a successful live `ListOptionalInstalls` response
- keeps cache reads from masquerading as live freshness
- makes cache persistence secondary: a cache-save failure no longer prevents fresh service data from reaching the UI
- serializes concurrent catalog refreshes through the existing cache/live coordinator
- adds shared shell-level Refresh/freshness UX that remains visible across Catalog, Details, and Activity
- preserves the canonical `HomeViewModel`, search, selection, Details identity, Activity, and operation tracking during refresh
- adds dedicated initial-loading, successful-empty, search-no-results, and no-usable-data load-failed states
- adds focused portable coverage for state transitions, retry recovery, cache persistence failure, canonical identity, and Activity continuity

## Stage boundary

No operation Retry, historical mutation replay, new action policy, service/protocol changes, client-side version comparison, scheduled/background refresh, or broad troubleshooting UI is added. Underlying exceptions remain retained in Core state for PR G.

## Validation

Draft while Windows/FlaUI boundary coverage and repository CI validation are completed.